### PR TITLE
Add API call to get runs in a given experiment

### DIFF
--- a/server/codegen/sqlite/createDb.sql
+++ b/server/codegen/sqlite/createDb.sql
@@ -25,6 +25,7 @@ DROP TABLE IF EXISTS ExperimentRun;
 CREATE TABLE ExperimentRun (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   experiment INTEGER REFERENCES Experiment NOT NULL,
+  description TEXT, -- Can be empty.
   created TIMESTAMP NOT NULL
 );
 

--- a/server/src/main/java/edu/mit/csail/db/ml/client/SampleClient.java
+++ b/server/src/main/java/edu/mit/csail/db/ml/client/SampleClient.java
@@ -49,6 +49,7 @@ public class SampleClient {
     testModelsWithFeatures(client);
     testDescendentModels(client);
     testReadInfo(client);
+    testReadRunsInExperiment(client);
   }
 
   private static void testTransformEvent(ModelDBService.Client client) throws Exception {
@@ -401,6 +402,10 @@ public class SampleClient {
 
     // Get all the info for the model.
     System.out.println(client.getModel(model.getId()));
+  }
+
+  private static void testReadRunsInExperiment(ModelDBService.Client client) throws Exception {
+    System.out.println(client.getRunsInExperiment(1));
   }
 
   /**

--- a/server/src/main/java/edu/mit/csail/db/ml/server/ModelDbServer.java
+++ b/server/src/main/java/edu/mit/csail/db/ml/server/ModelDbServer.java
@@ -192,4 +192,8 @@ public class ModelDbServer implements ModelDBService.Iface {
   public ModelResponse getModel(int modelId) throws TException {
     return run(() -> TransformerDao.readInfo(modelId, ctx));
   }
+
+  public List<ExperimentRun> getRunsInExperiment(int experimentId) throws TException {
+    return run(() -> ExperimentRunDao.readExperimentRunsInExperiment(experimentId, ctx));
+  }
 }

--- a/server/src/main/java/edu/mit/csail/db/ml/server/storage/ExperimentRunDao.java
+++ b/server/src/main/java/edu/mit/csail/db/ml/server/storage/ExperimentRunDao.java
@@ -13,6 +13,7 @@ import org.jooq.Record2;
 
 import java.sql.Timestamp;
 import java.util.Date;
+import java.util.List;
 
 public class ExperimentRunDao {
     // TODO: should we do a check here if experiment run exists?
@@ -21,6 +22,7 @@ public class ExperimentRunDao {
     ExperimentrunRecord erRec = ctx.newRecord(Tables.EXPERIMENTRUN);
     erRec.setId(er.id < 0 ? null : er.id);
     erRec.setExperiment(er.experimentId);
+    erRec.setDescription(er.description);
     erRec.setCreated(new Timestamp((new Date()).getTime()));
     erRec.store();
     return new ExperimentRunEventResponse(erRec.getId());
@@ -48,5 +50,20 @@ public class ExperimentRunDao {
         id
       ));
     }
+  }
+
+  public static List<ExperimentRun> readExperimentRunsInExperiment(int experimentId, DSLContext ctx) {
+    List<Integer> experimentRunIds = ctx
+      .select(Tables.EXPERIMENT_RUN_VIEW.EXPERIMENTRUNID)
+      .from(Tables.EXPERIMENT_RUN_VIEW)
+      .where(Tables.EXPERIMENT_RUN_VIEW.EXPERIMENTID.eq(experimentId))
+      .fetch()
+      .map(Record1::value1);
+
+    return ctx
+      .selectFrom(Tables.EXPERIMENTRUN)
+      .where(Tables.EXPERIMENTRUN.EXPERIMENT.in(experimentRunIds))
+      .fetch()
+      .map(r -> new ExperimentRun(r.getId(), r.getExperiment(), r.getDescription()));
   }
 }

--- a/thrift/ModelDB.thrift
+++ b/thrift/ModelDB.thrift
@@ -510,4 +510,6 @@ service ModelDBService {
     throws (1: ResourceNotFoundException rnfEx, 2: ServerLogicException svEx)
 
   ModelResponse getModel(1: i32 modelId) throws (1: ResourceNotFoundException rnfEx, 2: ServerLogicException svEx),
+
+  list<ExperimentRun> getRunsInExperiment(1: i32 experimentId) throws (1: ServerLogicException svEx)
 }


### PR DESCRIPTION
Add a thrift call so that we can get all the `ExperimentRun`s associated with a given `Experiment` ID.
