### PR TITLE
[MRG] Fix ModelDbSyncerBase imports, so python tests run

### DIFF
--- a/client/python/modeldb/basic/ModelDbSyncerBase.py
+++ b/client/python/modeldb/basic/ModelDbSyncerBase.py
@@ -9,10 +9,11 @@ from thrift.protocol import TBinaryProtocol
 from ..events import (
     Event, ExperimentEvent, ExperimentRunEvent, FitEvent, GridSearchCVEvent,
     MetricEvent, PipelineEvent, ProjectEvent, RandomSplitEvent, TransformEvent)
+
 from Structs import (NewOrExistingProject, ExistingProject,
     NewOrExistingExperiment, ExistingExperiment, DefaultExperiment,
-     NewExperimentRun, ExistingExperimentRun, Dataset, ModelConfig, Model,
-     ModelMetrics)
+     NewExperimentRun, ExistingExperimentRun, ThriftConfig, VersioningConfig,
+     Dataset, ModelConfig, Model, ModelMetrics)
 
 from ..thrift.modeldb import ModelDBService
 from ..thrift.modeldb import ttypes as modeldb_types


### PR DESCRIPTION
When resolving a conflict with one of the last PR's, I accidentally deleted two imports. This re-imports them. This fixes that.