### PR TITLE
[MRG] Roger tangos/python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,12 +25,12 @@ before_install:
 
   # install thrift
   - cd ~/
-  - wget -q http://archive.apache.org/dist/thrift/0.9.3/thrift-0.9.3.tar.gz &>/dev/null
-  - tar -xzf thrift-0.9.3.tar.gz &>/dev/null
-  - cd ~/thrift-0.9.3
+  - wget -q http://archive.apache.org/dist/thrift/0.10.0/thrift-0.10.0.tar.gz &>/dev/null
+  - tar -xzf thrift-0.10.0.tar.gz &>/dev/null
+  - cd ~/thrift-0.10.0
   - sudo ./configure --without-python --without-java --without-ruby
   - sudo make
-  - sudo ln -n ~/thrift-0.9.3/compiler/cpp/thrift /usr/local/bin/thrift
+  - sudo ln -n ~/thrift-0.10.0/compiler/cpp/thrift /usr/local/bin/thrift
 
 
 install:
@@ -71,37 +71,37 @@ script:
   # scala sbt tests
   - echo =================== SEVER TESTS ===================
   - cd $TRAVIS_BUILD_DIR/server
-  - mvn test -Dtest=TestAncestryComputer -Dthrift_version=0.9.3
+  - mvn test -Dtest=TestAncestryComputer -Dthrift_version=0.10.0
   - /bin/sleep 10
-  - mvn test -Dtest=TestBasicConnection -Dthrift_version=0.9.3
+  - mvn test -Dtest=TestBasicConnection -Dthrift_version=0.10.0
   - /bin/sleep 10
-  - mvn test -Dtest=TestCrossValidation -Dthrift_version=0.9.3
+  - mvn test -Dtest=TestCrossValidation -Dthrift_version=0.10.0
   - /bin/sleep 10
-  - mvn test -Dtest=TestDataFrame -Dthrift_version=0.9.3
+  - mvn test -Dtest=TestDataFrame -Dthrift_version=0.10.0
   - /bin/sleep 10
-  - mvn test -Dtest=TestEvent -Dthrift_version=0.9.3
+  - mvn test -Dtest=TestEvent -Dthrift_version=0.10.0
   - /bin/sleep 10
-  - mvn test -Dtest=TestExperiment -Dthrift_version=0.9.3
+  - mvn test -Dtest=TestExperiment -Dthrift_version=0.10.0
   - /bin/sleep 10
-  - mvn test -Dtest=TestExperimentRun -Dthrift_version=0.9.3
+  - mvn test -Dtest=TestExperimentRun -Dthrift_version=0.10.0
   - /bin/sleep 10
-  - mvn test -Dtest=TestFeatures -Dthrift_version=0.9.3
+  - mvn test -Dtest=TestFeatures -Dthrift_version=0.10.0
   - /bin/sleep 10
-  - mvn test -Dtest=TestFitEvent -Dthrift_version=0.9.3
+  - mvn test -Dtest=TestFitEvent -Dthrift_version=0.10.0
   - /bin/sleep 10
-  - mvn test -Dtest=TestGridSearchCrossValidation -Dthrift_version=0.9.3
+  - mvn test -Dtest=TestGridSearchCrossValidation -Dthrift_version=0.10.0
   - /bin/sleep 10
-  - mvn test -Dtest=TestPipelineEvent -Dthrift_version=0.9.3
+  - mvn test -Dtest=TestPipelineEvent -Dthrift_version=0.10.0
   - /bin/sleep 10
-  - mvn test -Dtest=TestProject -Dthrift_version=0.9.3
+  - mvn test -Dtest=TestProject -Dthrift_version=0.10.0
   - /bin/sleep 10
-  - mvn test -Dtest=TestTransformer -Dthrift_version=0.9.3
+  - mvn test -Dtest=TestTransformer -Dthrift_version=0.10.0
   - /bin/sleep 10
-  - mvn test -Dtest=TestTransformerSpec -Dthrift_version=0.9.3
+  - mvn test -Dtest=TestTransformerSpec -Dthrift_version=0.10.0
   - /bin/sleep 10
-  - mvn test -Dtest=TestTransformEvent -Dthrift_version=0.9.3
+  - mvn test -Dtest=TestTransformEvent -Dthrift_version=0.10.0
   - /bin/sleep 10
-  - mvn test -Dtest=TestTreeModels -Dthrift_version=0.9.3
+  - mvn test -Dtest=TestTreeModels -Dthrift_version=0.10.0
   - /bin/sleep 10
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
 dist: trusty
 language: python
-python: "3.5"
+python: "3.6"
 
 addons:
   apt:
@@ -48,12 +48,12 @@ install:
   - ./build_client.sh
 
   # build scala client
-  - cd $TRAVIS_BUILD_DIR/client/scala/libs/spark.ml
-  - ./build_client.sh
+  # - cd $TRAVIS_BUILD_DIR/client/scala/libs/spark.ml
+  # - ./build_client.sh
 
   # start server
   - cd $TRAVIS_BUILD_DIR/server
-  - ./start_server.sh
+  - ./start_server.sh 0.10.0
   - /bin/sleep 30
 
   # # start frontend
@@ -69,47 +69,48 @@ before_script:
 script:
 
   # scala sbt tests
-  - echo =================== SEVER TESTS ===================
-  - cd $TRAVIS_BUILD_DIR/server
-  - mvn test -Dtest=TestAncestryComputer -Dthrift_version=0.10.0
-  - /bin/sleep 10
-  - mvn test -Dtest=TestBasicConnection -Dthrift_version=0.10.0
-  - /bin/sleep 10
-  - mvn test -Dtest=TestCrossValidation -Dthrift_version=0.10.0
-  - /bin/sleep 10
-  - mvn test -Dtest=TestDataFrame -Dthrift_version=0.10.0
-  - /bin/sleep 10
-  - mvn test -Dtest=TestEvent -Dthrift_version=0.10.0
-  - /bin/sleep 10
-  - mvn test -Dtest=TestExperiment -Dthrift_version=0.10.0
-  - /bin/sleep 10
-  - mvn test -Dtest=TestExperimentRun -Dthrift_version=0.10.0
-  - /bin/sleep 10
-  - mvn test -Dtest=TestFeatures -Dthrift_version=0.10.0
-  - /bin/sleep 10
-  - mvn test -Dtest=TestFitEvent -Dthrift_version=0.10.0
-  - /bin/sleep 10
-  - mvn test -Dtest=TestGridSearchCrossValidation -Dthrift_version=0.10.0
-  - /bin/sleep 10
-  - mvn test -Dtest=TestPipelineEvent -Dthrift_version=0.10.0
-  - /bin/sleep 10
-  - mvn test -Dtest=TestProject -Dthrift_version=0.10.0
-  - /bin/sleep 10
-  - mvn test -Dtest=TestTransformer -Dthrift_version=0.10.0
-  - /bin/sleep 10
-  - mvn test -Dtest=TestTransformerSpec -Dthrift_version=0.10.0
-  - /bin/sleep 10
-  - mvn test -Dtest=TestTransformEvent -Dthrift_version=0.10.0
-  - /bin/sleep 10
+  # - echo =================== SEVER TESTS ===================
+  # - cd $TRAVIS_BUILD_DIR/server
+  # - mvn test -Dtest=TestAncestryComputer -Dthrift_version=0.10.0
+  # - /bin/sleep 10
+  # - mvn test -Dtest=TestBasicConnection -Dthrift_version=0.10.0
+  # - /bin/sleep 10
+  # - mvn test -Dtest=TestCrossValidation -Dthrift_version=0.10.0
+  # - /bin/sleep 10
+  # - mvn test -Dtest=TestDataFrame -Dthrift_version=0.10.0
+  # - /bin/sleep 10
+  # - mvn test -Dtest=TestEvent -Dthrift_version=0.10.0
+  # - /bin/sleep 10
+  # - mvn test -Dtest=TestExperiment -Dthrift_version=0.10.0
+  # - /bin/sleep 10
+  # - mvn test -Dtest=TestExperimentRun -Dthrift_version=0.10.0
+  # - /bin/sleep 10
+  # - mvn test -Dtest=TestFeatures -Dthrift_version=0.10.0
+  # - /bin/sleep 10
+  # - mvn test -Dtest=TestFitEvent -Dthrift_version=0.10.0
+  # - /bin/sleep 10
+  # - mvn test -Dtest=TestGridSearchCrossValidation -Dthrift_version=0.10.0
+  # - /bin/sleep 10
+  # - mvn test -Dtest=TestPipelineEvent -Dthrift_version=0.10.0
+  # - /bin/sleep 10
+  # - mvn test -Dtest=TestProject -Dthrift_version=0.10.0
+  # - /bin/sleep 10
+  # - mvn test -Dtest=TestTransformer -Dthrift_version=0.10.0
+  # - /bin/sleep 10
+  # - mvn test -Dtest=TestTransformerSpec -Dthrift_version=0.10.0
+  # - /bin/sleep 10
+  # - mvn test -Dtest=TestTransformEvent -Dthrift_version=0.10.0
+  # - /bin/sleep 10
   - mvn test -Dtest=TestTreeModels -Dthrift_version=0.10.0
   - /bin/sleep 10
 
 
   - echo =================== CLIENT TESTS ===================
-  - echo ------------------- SCALA  TESTS -------------------
-  - cd $TRAVIS_BUILD_DIR/client/scala/libs/spark.ml
-  - sbt test
+  # - echo ------------------- SCALA  TESTS -------------------
+  # - cd $TRAVIS_BUILD_DIR/client/scala/libs/spark.ml
+  # - sbt test
   - echo ------------------- PYTHON TESTS -------------------
   - cd $TRAVIS_BUILD_DIR/client/python/modeldb/tests/sklearn
+  - python --version
   - python -m unittest discover .
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,46 +69,46 @@ before_script:
 script:
 
   # scala sbt tests
-  # - echo =================== SEVER TESTS ===================
-  # - cd $TRAVIS_BUILD_DIR/server
-  # - mvn test -Dtest=TestAncestryComputer -Dthrift_version=0.10.0
-  # - /bin/sleep 10
-  # - mvn test -Dtest=TestBasicConnection -Dthrift_version=0.10.0
-  # - /bin/sleep 10
-  # - mvn test -Dtest=TestCrossValidation -Dthrift_version=0.10.0
-  # - /bin/sleep 10
-  # - mvn test -Dtest=TestDataFrame -Dthrift_version=0.10.0
-  # - /bin/sleep 10
-  # - mvn test -Dtest=TestEvent -Dthrift_version=0.10.0
-  # - /bin/sleep 10
-  # - mvn test -Dtest=TestExperiment -Dthrift_version=0.10.0
-  # - /bin/sleep 10
-  # - mvn test -Dtest=TestExperimentRun -Dthrift_version=0.10.0
-  # - /bin/sleep 10
-  # - mvn test -Dtest=TestFeatures -Dthrift_version=0.10.0
-  # - /bin/sleep 10
-  # - mvn test -Dtest=TestFitEvent -Dthrift_version=0.10.0
-  # - /bin/sleep 10
-  # - mvn test -Dtest=TestGridSearchCrossValidation -Dthrift_version=0.10.0
-  # - /bin/sleep 10
-  # - mvn test -Dtest=TestPipelineEvent -Dthrift_version=0.10.0
-  # - /bin/sleep 10
-  # - mvn test -Dtest=TestProject -Dthrift_version=0.10.0
-  # - /bin/sleep 10
-  # - mvn test -Dtest=TestTransformer -Dthrift_version=0.10.0
-  # - /bin/sleep 10
-  # - mvn test -Dtest=TestTransformerSpec -Dthrift_version=0.10.0
-  # - /bin/sleep 10
-  # - mvn test -Dtest=TestTransformEvent -Dthrift_version=0.10.0
-  # - /bin/sleep 10
+  - echo =================== SEVER TESTS ===================
+  - cd $TRAVIS_BUILD_DIR/server
+  - mvn test -Dtest=TestAncestryComputer -Dthrift_version=0.10.0
+  - /bin/sleep 10
+  - mvn test -Dtest=TestBasicConnection -Dthrift_version=0.10.0
+  - /bin/sleep 10
+  - mvn test -Dtest=TestCrossValidation -Dthrift_version=0.10.0
+  - /bin/sleep 10
+  - mvn test -Dtest=TestDataFrame -Dthrift_version=0.10.0
+  - /bin/sleep 10
+  - mvn test -Dtest=TestEvent -Dthrift_version=0.10.0
+  - /bin/sleep 10
+  - mvn test -Dtest=TestExperiment -Dthrift_version=0.10.0
+  - /bin/sleep 10
+  - mvn test -Dtest=TestExperimentRun -Dthrift_version=0.10.0
+  - /bin/sleep 10
+  - mvn test -Dtest=TestFeatures -Dthrift_version=0.10.0
+  - /bin/sleep 10
+  - mvn test -Dtest=TestFitEvent -Dthrift_version=0.10.0
+  - /bin/sleep 10
+  - mvn test -Dtest=TestGridSearchCrossValidation -Dthrift_version=0.10.0
+  - /bin/sleep 10
+  - mvn test -Dtest=TestPipelineEvent -Dthrift_version=0.10.0
+  - /bin/sleep 10
+  - mvn test -Dtest=TestProject -Dthrift_version=0.10.0
+  - /bin/sleep 10
+  - mvn test -Dtest=TestTransformer -Dthrift_version=0.10.0
+  - /bin/sleep 10
+  - mvn test -Dtest=TestTransformerSpec -Dthrift_version=0.10.0
+  - /bin/sleep 10
+  - mvn test -Dtest=TestTransformEvent -Dthrift_version=0.10.0
+  - /bin/sleep 10
   - mvn test -Dtest=TestTreeModels -Dthrift_version=0.10.0
   - /bin/sleep 10
 
 
   - echo =================== CLIENT TESTS ===================
-  # - echo ------------------- SCALA  TESTS -------------------
-  # - cd $TRAVIS_BUILD_DIR/client/scala/libs/spark.ml
-  # - sbt test
+  - echo ------------------- SCALA  TESTS -------------------
+  - cd $TRAVIS_BUILD_DIR/client/scala/libs/spark.ml
+  - sbt test
   - echo ------------------- PYTHON TESTS -------------------
   - cd $TRAVIS_BUILD_DIR/client/python/modeldb/tests/sklearn
   - python --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
 dist: trusty
 language: python
-python: "3.6"
+python: "3.5"
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,8 +48,8 @@ install:
   - ./build_client.sh
 
   # build scala client
-  # - cd $TRAVIS_BUILD_DIR/client/scala/libs/spark.ml
-  # - ./build_client.sh
+  - cd $TRAVIS_BUILD_DIR/client/scala/libs/spark.ml
+  - ./build_client.sh
 
   # start server
   - cd $TRAVIS_BUILD_DIR/server

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: required
 dist: trusty
 language: python
+python: "3.5"
 
 addons:
   apt:

--- a/README.md
+++ b/README.md
@@ -84,14 +84,14 @@ Watch a video of the setup and installation process [here](https://youtu.be/rmNn
 
     Depending on the client you're using, we assume you have the following already installed:
     - scikit-learn client:
-        - Python 2.7\*\*
+        - Python 2.7 or Python 3.5.1\*\*
         - [pip](https://pip.pypa.io/en/stable/installing/)
         - [scikit-learn](http://scikit-learn.org/stable/install.html) 0.17\*\*
     - spark.ml client:
         - Java 1.8+
         - Spark 2.0.0\*\*
 
-    **(\*\*) = Must have exact version**
+    **(\*\*) = Python 3.5.1+ is only compatilble with thrift 0.10.0+**
 
     On OSX, we also assume that you have [homebrew](https://brew.sh/) installed.
 
@@ -105,8 +105,8 @@ Watch a video of the setup and installation process [here](https://youtu.be/rmNn
     brew install sbt # for spark.ml client only
     brew install mongodb
 
-    # ModelDB works only with Thrift 0.9.3 and 0.10.0. If you do not have thrift installed, install via brew.
-    brew install thrift
+    # ModelDB works only with Thrift 0.9.3 and 0.10.0. Python 3 is only compatible with thrift 0.10.0 If you do not have thrift installed, install via brew.
+    `brew install thrift`
 
     pip install -r [path_to_modeldb]/client/python/requirements.txt
     ```

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Watch a video of the setup and installation process [here](https://youtu.be/rmNn
         - Java 1.8+
         - Spark 2.0.0\*\*
 
-    **(\*\*) = Python 3.5.1+ is only compatilble with thrift 0.10.0+**
+    **(\*\*) = Python 3.5.1+ is only compatible with thrift 0.10.0+**
 
     On OSX, we also assume that you have [homebrew](https://brew.sh/) installed.
 

--- a/client/python/README.rst
+++ b/client/python/README.rst
@@ -7,7 +7,7 @@ A python client for working with `ModelDB machine learning management system <ht
 This library makes it easy for users of the `ModelDB ML management system <http://modeldb.csail.mit.edu>`_ to automatically catalog models built with `scikit-learn <scikit-learn.org>`_.
 
 
-ModelDB is an end-to-end system for managing machine learning models. It ingests models and associated metadata as models are being trained, stores model data in a structured format, and surfaces it through a web-frontend for rich querying. ModelDB runs on python 2.X and 3.X, and can be used with any ML environment via the ModelDB Light API.
+ModelDB is an end-to-end system for managing machine learning models. It ingests models and associated metadata as models are being trained, stores model data in a structured format, and surfaces it through a web-frontend for rich querying. ModelDB runs on Python 2.X and 3.X and can be used with any ML environment via the ModelDB Light API.
 
 
 Quick start

--- a/client/python/README.rst
+++ b/client/python/README.rst
@@ -7,7 +7,7 @@ A python client for working with `ModelDB machine learning management system <ht
 This library makes it easy for users of the `ModelDB ML management system <http://modeldb.csail.mit.edu>`_ to automatically catalog models built with `scikit-learn <scikit-learn.org>`_.
 
 
-ModelDB is an end-to-end system for managing machine learning models. It ingests models and associated metadata as models are being trained, stores model data in a structured format, and surfaces it through a web-frontend for rich querying. ModelDB can be used with any ML environment via the ModelDB Light API.
+ModelDB is an end-to-end system for managing machine learning models. It ingests models and associated metadata as models are being trained, stores model data in a structured format, and surfaces it through a web-frontend for rich querying. ModelDB runs on python 2.X and 3.X, and can be used with any ML environment via the ModelDB Light API.
 
 
 Quick start

--- a/client/python/modeldb/basic/ModelDbSyncerBase.py
+++ b/client/python/modeldb/basic/ModelDbSyncerBase.py
@@ -6,6 +6,7 @@ from thrift.transport import TSocket
 from thrift.transport import TTransport
 from thrift.protocol import TBinaryProtocol
 
+from modeldb.utils.Singleton import Singleton
 from ..events import (
     Event, ExperimentEvent, ExperimentRunEvent, FitEvent, GridSearchCVEvent,
     MetricEvent, PipelineEvent, ProjectEvent, RandomSplitEvent, TransformEvent)
@@ -14,6 +15,7 @@ from . Structs import (NewOrExistingProject, ExistingProject,
      NewOrExistingExperiment, ExistingExperiment, DefaultExperiment,
      NewExperimentRun, ExistingExperimentRun, ThriftConfig, VersioningConfig,
      Dataset, ModelConfig, Model, ModelMetrics)
+
 
 from ..thrift.modeldb import ModelDBService
 from ..thrift.modeldb import ttypes as modeldb_types
@@ -25,8 +27,10 @@ FMAX = sys.float_info.max
 
 
 class Syncer(object):
+    __metaclass__ = Singleton
+
     # used for recording whether there is an instance. Syncer is a singleton.
-    instance = None
+    # instance = None
 
     # location of the default config file
     config_path = os.path.abspath(
@@ -79,15 +83,6 @@ class Syncer(object):
             experiment_run_config=ExistingExperimentRun(experiment_run_id),
             thrift_config=ThriftConfig(host, port))
         return syncer_obj
-
-    # implements singleton Syncer object
-    # __new__ always a classmethod
-    def __new__(cls, *args, **kwargs):
-        # This will break if cls is some random class.
-        if not cls.instance:
-            cls.instance = object.__new__(
-                cls)
-        return cls.instance
 
     def __init__(
             self, project_config, experiment_config, experiment_run_config,

--- a/client/python/modeldb/basic/ModelDbSyncerBase.py
+++ b/client/python/modeldb/basic/ModelDbSyncerBase.py
@@ -86,7 +86,7 @@ class Syncer(object):
         # This will break if cls is some random class.
         if not cls.instance:
             cls.instance = object.__new__(
-                cls, *args, **kwargs)
+                cls)
         return cls.instance
 
     def __init__(

--- a/client/python/modeldb/basic/ModelDbSyncerBase.py
+++ b/client/python/modeldb/basic/ModelDbSyncerBase.py
@@ -29,9 +29,6 @@ FMAX = sys.float_info.max
 
 class Syncer(with_metaclass(Singleton, object)):
 
-    # used for recording whether there is an instance. Syncer is a singleton.
-    # instance = None
-
     # location of the default config file
     config_path = os.path.abspath(
         os.path.join(os.path.dirname(__file__), os.pardir, 'syncer.json'))

--- a/client/python/modeldb/basic/ModelDbSyncerBase.py
+++ b/client/python/modeldb/basic/ModelDbSyncerBase.py
@@ -10,7 +10,7 @@ from ..events import (
     Event, ExperimentEvent, ExperimentRunEvent, FitEvent, GridSearchCVEvent,
     MetricEvent, PipelineEvent, ProjectEvent, RandomSplitEvent, TransformEvent)
 
-from Structs import (NewOrExistingProject, ExistingProject,
+from . Structs import (NewOrExistingProject, ExistingProject,
      NewOrExistingExperiment, ExistingExperiment, DefaultExperiment,
      NewExperimentRun, ExistingExperimentRun, ThriftConfig, VersioningConfig,
      Dataset, ModelConfig, Model, ModelMetrics)
@@ -311,8 +311,8 @@ class Syncer(object):
         if data_tag not in self.datasets:
             if "default" not in self.datasets:
                 self.datasets["default"] = Dataset("", {})
-            print data_tag, \
-                ' dataset not defined. default dataset will be used.'
+            print(data_tag,
+                  ' dataset not defined. default dataset will be used.')
             data_tag = "default"
         return self.datasets[data_tag]
 

--- a/client/python/modeldb/basic/ModelDbSyncerBase.py
+++ b/client/python/modeldb/basic/ModelDbSyncerBase.py
@@ -287,7 +287,7 @@ class Syncer(with_metaclass(Singleton, object)):
         '''
         dataset = self.get_dataset_for_tag(data_tag)
         fit_event = FitEvent(model, config, dataset)
-        Syncer.instance.add_to_buffer(fit_event)
+        self.add_to_buffer(fit_event)
 
     def sync_metrics(self, data_tag, model, metrics):
         '''
@@ -297,7 +297,7 @@ class Syncer(with_metaclass(Singleton, object)):
         for metric, value in metrics.metrics.items():
             metric_event = MetricEvent(dataset, model, "label_col",
                                        "prediction_col", metric, value)
-            Syncer.instance.add_to_buffer(metric_event)
+            self.add_to_buffer(metric_event)
 
     def get_dataset_for_tag(self, data_tag):
         if data_tag not in self.datasets:
@@ -338,7 +338,7 @@ class Syncer(with_metaclass(Singleton, object)):
         config = model_data[metadata_constants.CONFIG_KEY]
         fit_event = FitEvent(model, ModelConfig(model_type, config, model_tag),
                              model_dataset, model_data)
-        Syncer.instance.add_to_buffer(fit_event)
+        self.add_to_buffer(fit_event)
 
         # sync metrics
         metrics_data = model_data.get(metadata_constants.METRICS_KEY, [])
@@ -348,4 +348,4 @@ class Syncer(with_metaclass(Singleton, object)):
             metric_event = MetricEvent(
                 model_dataset, model, "label_col", "prediction_col",
                 metric_type, metric_value)
-            Syncer.instance.add_to_buffer(metric_event)
+            self.add_to_buffer(metric_event)

--- a/client/python/modeldb/basic/ModelDbSyncerBase.py
+++ b/client/python/modeldb/basic/ModelDbSyncerBase.py
@@ -1,6 +1,7 @@
 import sys
 import os
 import yaml
+from future.utils import with_metaclass
 from thrift import Thrift
 from thrift.transport import TSocket
 from thrift.transport import TTransport
@@ -26,8 +27,7 @@ FMIN = sys.float_info.min
 FMAX = sys.float_info.max
 
 
-class Syncer(object):
-    __metaclass__ = Singleton
+class Syncer(with_metaclass(Singleton, object)):
 
     # used for recording whether there is an instance. Syncer is a singleton.
     # instance = None

--- a/client/python/modeldb/basic/__init__.py
+++ b/client/python/modeldb/basic/__init__.py
@@ -1,4 +1,4 @@
-from ModelDbSyncerBase import (
+from . ModelDbSyncerBase import (
     NewOrExistingProject, ExistingProject, ExistingExperiment,
     DefaultExperiment, NewOrExistingExperiment, NewExperimentRun,
     ExistingExperimentRun, ThriftConfig, VersioningConfig)

--- a/client/python/modeldb/sklearn_native/CrossValidationScore.py
+++ b/client/python/modeldb/sklearn_native/CrossValidationScore.py
@@ -16,7 +16,7 @@ from sklearn.externals.joblib import Parallel, delayed
 from sklearn.base import BaseEstimator, is_classifier, clone
 from ..events import FitEvent
 from ..events import MetricEvent
-import ModelDbSyncer
+from . import ModelDbSyncer
 
 
 def cross_val_score_fn(estimator, X, y=None, scoring=None, cv=None, n_jobs=1,

--- a/client/python/modeldb/sklearn_native/CrossValidationScore.py
+++ b/client/python/modeldb/sklearn_native/CrossValidationScore.py
@@ -4,6 +4,7 @@ Overrides cross_val_score to store Fit and Metric Events for each fold.
 import numpy as np
 import time
 import warnings
+import sys
 from sklearn.grid_search import ParameterGrid, _CVScoreTuple
 from sklearn.pipeline import Pipeline
 from sklearn import datasets, linear_model, cross_validation
@@ -16,7 +17,12 @@ from sklearn.externals.joblib import Parallel, delayed
 from sklearn.base import BaseEstimator, is_classifier, clone
 from ..events import FitEvent
 from ..events import MetricEvent
-from . import ModelDbSyncer
+
+# Python 2 adn 3 deal differently with relative circular imports
+if sys.version_info <= (3, 0):
+    import ModelDbSyncer
+else:
+    from . import ModelDbSyncer
 
 
 def cross_val_score_fn(estimator, X, y=None, scoring=None, cv=None, n_jobs=1,

--- a/client/python/modeldb/sklearn_native/ModelDbSyncer.py
+++ b/client/python/modeldb/sklearn_native/ModelDbSyncer.py
@@ -279,9 +279,8 @@ End functions that extract information from scikit-learn, pandas and numpy
 
 
 class Syncer(with_metaclass(Singleton, ModelDbSyncerBase.Syncer)):
-    __metaclass__ = Singleton
 
-    # The Syncer class needs to have its own pointer to the object
+    # The Syncer class needs to have its own pointer to the singleton instance
     # for overidden sklearn methods to reference
     instance = None
     """

--- a/client/python/modeldb/sklearn_native/ModelDbSyncer.py
+++ b/client/python/modeldb/sklearn_native/ModelDbSyncer.py
@@ -255,7 +255,7 @@ def train_test_split_fn(*arrays, **options):
         random_state = 1
     main_df = arrays[0]
     weights = [train_size, test_size]
-    result = split_dfs[:len(split_dfs) / 2]
+    result = split_dfs[:int(len(split_dfs) / 2)]
     random_split_event = RandomSplitEvent(
         main_df, weights, random_state, result)
     Syncer.instance.add_to_buffer(random_split_event)

--- a/client/python/modeldb/sklearn_native/ModelDbSyncer.py
+++ b/client/python/modeldb/sklearn_native/ModelDbSyncer.py
@@ -5,6 +5,7 @@ Contains functions for overriding basic scikit-learn functions.
 import sys
 import numpy as np
 import pandas as pd
+from future.utils import with_metaclass
 
 # sklearn imports
 from sklearn.linear_model import *
@@ -277,7 +278,7 @@ End functions that extract information from scikit-learn, pandas and numpy
 '''
 
 
-class Syncer(ModelDbSyncerBase.Syncer):
+class Syncer(with_metaclass(Singleton, ModelDbSyncerBase.Syncer)):
     __metaclass__ = Singleton
 
     # The Syncer class needs to have its own pointer to the object

--- a/client/python/modeldb/sklearn_native/ModelDbSyncer.py
+++ b/client/python/modeldb/sklearn_native/ModelDbSyncer.py
@@ -26,8 +26,8 @@ from thrift.transport import TTransport
 from thrift.protocol import TBinaryProtocol
 
 # modeldb imports
-import GridCrossValidation
-from CrossValidationScore import *
+from . import GridCrossValidation
+from . CrossValidationScore import *
 from ..basic import *
 from ..events import *
 from ..thrift.modeldb import ModelDBService

--- a/client/python/modeldb/sklearn_native/ModelDbSyncer.py
+++ b/client/python/modeldb/sklearn_native/ModelDbSyncer.py
@@ -26,6 +26,7 @@ from thrift.transport import TTransport
 from thrift.protocol import TBinaryProtocol
 
 # modeldb imports
+from modeldb.utils.Singleton import Singleton
 from . import GridCrossValidation
 from . CrossValidationScore import *
 from ..basic import *
@@ -277,6 +278,11 @@ End functions that extract information from scikit-learn, pandas and numpy
 
 
 class Syncer(ModelDbSyncerBase.Syncer):
+    __metaclass__ = Singleton
+
+    # The Syncer class needs to have its own pointer to the object
+    # for overidden sklearn methods to reference
+    instance = None
     """
     This is the Syncer class for sklearn, responsible for
     storing events in the ModelDB.
@@ -285,11 +291,14 @@ class Syncer(ModelDbSyncerBase.Syncer):
     def __init__(
             self, project_config, experiment_config, experiment_run_config,
             thrift_config=None):
-        super(Syncer, self).__init__(project_config, experiment_config,
-                                     experiment_run_config, thrift_config)
         self.local_id_to_path = {}
         self.enable_sklearn_sync_functions()
         self.enable_pandas_sync_functions()
+
+        Syncer.instance = self
+
+        super(Syncer, self).__init__(project_config, experiment_config,
+                                     experiment_run_config, thrift_config)
 
     def __str__(self):
         return "SklearnSyncer"

--- a/client/python/modeldb/sklearn_native/SyncableMetrics.py
+++ b/client/python/modeldb/sklearn_native/SyncableMetrics.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 import numpy as np
 import pandas as pd
-import ModelDbSyncer
+from . import ModelDbSyncer
 from ..events import MetricEvent
 from sklearn.linear_model import *
 from sklearn.preprocessing import *

--- a/client/python/modeldb/sklearn_native/SyncableRandomSplit.py
+++ b/client/python/modeldb/sklearn_native/SyncableRandomSplit.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 import numpy as np
 import pandas as pd
-import ModelDbSyncer
+from . import ModelDbSyncer
 from ..events import RandomSplitEvent as RandomSplitEvent
 
 # Splits X according to the weights provided. If the optional y dataframe

--- a/client/python/modeldb/tests/sklearn/ModelDbSyncerTest.py
+++ b/client/python/modeldb/tests/sklearn/ModelDbSyncerTest.py
@@ -1,20 +1,12 @@
 import modeldb.sklearn_native.ModelDbSyncer as ModelDbSyncer
+from modeldb.utils.Singleton import Singleton
 
 
 class SyncerTest(ModelDbSyncer.Syncer):
-    instance = None
+    __metaclass__ = Singleton
 
-    # __new__ always a classmethod
-    def __new__(
-            cls, project_config, experiment_config, experiment_run_config,
-            thrift_config):
-        # This will break if cls is some random class.
-        if not cls.instance:
-            cls.instance = object.__new__(
-                cls, project_config, experiment_config, experiment_run_config,
-                thrift_config)
-            ModelDbSyncer.Syncer.instance = cls.instance
-        return cls.instance
+    # Singleton. If an ModelDbSyncer.Syncer instance already exists
+    # a new one is instantiated, and the old one is overwritten
 
     def sync(self):
         events = []

--- a/client/python/modeldb/tests/sklearn/ModelDbSyncerTest.py
+++ b/client/python/modeldb/tests/sklearn/ModelDbSyncerTest.py
@@ -1,9 +1,9 @@
 import modeldb.sklearn_native.ModelDbSyncer as ModelDbSyncer
 from modeldb.utils.Singleton import Singleton
+from future.utils import with_metaclass
 
 
-class SyncerTest(ModelDbSyncer.Syncer):
-    __metaclass__ = Singleton
+class SyncerTest(with_metaclass(Singleton, ModelDbSyncer.Syncer)):
 
     # Singleton. If an ModelDbSyncer.Syncer instance already exists
     # a new one is instantiated, and the old one is overwritten

--- a/client/python/modeldb/tests/sklearn/testFitEvent.py
+++ b/client/python/modeldb/tests/sklearn/testFitEvent.py
@@ -4,6 +4,8 @@ from ModelDbSyncerTest import SyncerTest
 
 import modeldb.tests.utils as utils
 from modeldb.thrift.modeldb import ttypes as modeldb_types
+from modeldb.basic.Structs import (
+    DefaultExperiment, NewExperimentRun, ThriftConfig)
 from modeldb.sklearn_native.ModelDbSyncer import *
 
 from sklearn import linear_model

--- a/client/python/modeldb/tests/sklearn/testFitEvent.py
+++ b/client/python/modeldb/tests/sklearn/testFitEvent.py
@@ -46,7 +46,7 @@ class TestFitEvent(unittest.TestCase):
     def test_model(self):
         utils.validate_fit_event_struct(self.fit_event, self)
         transformer = self.fit_event.model
-        self.assertItemsEqual(self.fit_event.featureColumns,
+        self.assertEqual(self.fit_event.featureColumns,
                               ['A', 'B', 'C', 'D'])
         expected_transformer = modeldb_types.Transformer(
             -1,

--- a/client/python/modeldb/tests/sklearn/testGridSearchEvent.py
+++ b/client/python/modeldb/tests/sklearn/testGridSearchEvent.py
@@ -42,7 +42,7 @@ class TestGridSearchEvent(unittest.TestCase):
 
     def test_gridcv_event(self):
         utils.validate_grid_search_cv_event(self.grid_search_event, self)
-        self.assertEquals(self.grid_search_event.numFolds, 3)
+        self.assertEqual(self.grid_search_event.numFolds, 3)
         best_fit_event = self.grid_search_event.bestFit
         df = best_fit_event.df
         expected_df = modeldb_types.DataFrame(
@@ -64,25 +64,25 @@ class TestGridSearchEvent(unittest.TestCase):
             'SVC',
             '')
         utils.is_equal_transformer(transformer, expected_transformer, self)
-        self.assertItemsEqual(best_fit_event.featureColumns, [
+        self.assertEqual(best_fit_event.featureColumns, [
                               'A', 'B', 'C', 'D'])
 
     def test_cross_validation_event(self):
         cross_validations = self.grid_search_event.crossValidations
         # Number of cross validations is equal to number of combinations
         # of parameters, multiplied by the number of folds.
-        self.assertEquals(len(cross_validations), 12)
+        self.assertEqual(len(cross_validations), 12)
 
         # Order of cross validations may vary each run, so we only validate
         # certain hyperparameter values.
         for cv in cross_validations:
             utils.validate_cross_validate_event(cv, self)
-            self.assertItemsEqual(cv.featureColumns, ['A', 'B', 'C', 'D'])
-            self.assertEquals(cv.evaluator, 'multiclass')
-            self.assertEquals(cv.seed, 0)
+            self.assertEqual(cv.featureColumns, ['A', 'B', 'C', 'D'])
+            self.assertEqual(cv.evaluator, 'multiclass')
+            self.assertEqual(cv.seed, 0)
 
             hyperparameters = cv.spec.hyperparameters
-            self.assertEquals(len(hyperparameters), 14)
+            self.assertEqual(len(hyperparameters), 14)
 
             # We check these particular hyperparameters because we pass these
             # as our tuned parameters above.
@@ -92,7 +92,7 @@ class TestGridSearchEvent(unittest.TestCase):
                 if hyperparam.name == 'C':
                     self.assertIn(hyperparam.value, ['10', '100'])
                 if hyperparam.name == 'kernel':
-                    self.assertEquals(hyperparam.value, 'rbf')
+                    self.assertEqual(hyperparam.value, 'rbf')
 
     def test_cross_validation_fold(self):
         cross_validations = self.grid_search_event.crossValidations
@@ -102,7 +102,7 @@ class TestGridSearchEvent(unittest.TestCase):
                 utils.validate_cross_validation_fold(fold, self)
                 training_df = fold.trainingDf
                 validation_df = fold.validationDf
-                self.assertEquals(training_df.numRows +
+                self.assertEqual(training_df.numRows +
                                   validation_df.numRows, 2000)
 
 

--- a/client/python/modeldb/tests/sklearn/testGridSearchEvent.py
+++ b/client/python/modeldb/tests/sklearn/testGridSearchEvent.py
@@ -3,6 +3,8 @@ from ModelDbSyncerTest import SyncerTest
 
 import modeldb.tests.utils as utils
 from modeldb.thrift.modeldb import ttypes as modeldb_types
+from modeldb.basic.Structs import (
+    DefaultExperiment, NewExperimentRun, ThriftConfig)
 from modeldb.sklearn_native.ModelDbSyncer import *
 
 from sklearn.grid_search import GridSearchCV

--- a/client/python/modeldb/tests/sklearn/testMetricEvent.py
+++ b/client/python/modeldb/tests/sklearn/testMetricEvent.py
@@ -2,6 +2,8 @@ import unittest
 from ModelDbSyncerTest import SyncerTest
 
 import modeldb.tests.utils as utils
+from modeldb.basic.Structs import (
+    DefaultExperiment, NewExperimentRun, ThriftConfig)
 from modeldb.sklearn_native.ModelDbSyncer import *
 
 from sklearn import linear_model

--- a/client/python/modeldb/tests/sklearn/testPipelineEvent.py
+++ b/client/python/modeldb/tests/sklearn/testPipelineEvent.py
@@ -4,6 +4,8 @@ from ModelDbSyncerTest import SyncerTest
 
 import modeldb.tests.utils as utils
 from modeldb.thrift.modeldb import ttypes as modeldb_types
+from modeldb.basic.Structs import (
+    DefaultExperiment, NewExperimentRun, ThriftConfig)
 from modeldb.sklearn_native.ModelDbSyncer import *
 
 from sklearn import linear_model

--- a/client/python/modeldb/tests/sklearn/testPipelineEvent.py
+++ b/client/python/modeldb/tests/sklearn/testPipelineEvent.py
@@ -106,7 +106,7 @@ class TestPipelineEvent(unittest.TestCase):
             'pipeline with pca + logistic')
         utils.is_equal_transformer_spec(spec, expected_spec, self)
 
-        self.assertItemsEqual(fit_event.featureColumns, ['A', 'B'])
+        self.assertEqual(fit_event.featureColumns, ['A', 'B'])
 
     def test_pipeline_fit_stages(self):
         fit_stages = self.pipeline_event.fitStages
@@ -150,7 +150,7 @@ class TestPipelineEvent(unittest.TestCase):
             'decomposition PCA')
         utils.is_equal_transformer_spec(spec, expected_spec, self)
 
-        self.assertItemsEqual(fit_event1.featureColumns, ['A', 'B'])
+        self.assertEqual(fit_event1.featureColumns, ['A', 'B'])
 
     def test_pipeline_second_fit_stage(self):
         fit_stages = self.pipeline_event.fitStages

--- a/client/python/modeldb/tests/sklearn/testProjectCreation.py
+++ b/client/python/modeldb/tests/sklearn/testProjectCreation.py
@@ -3,6 +3,8 @@ from ModelDbSyncerTest import SyncerTest
 
 import modeldb.tests.utils as utils
 from modeldb.thrift.modeldb import ttypes as modeldb_types
+from modeldb.basic.Structs import (
+    DefaultExperiment, NewExperimentRun, ThriftConfig)
 from modeldb.sklearn_native.ModelDbSyncer import *
 
 

--- a/client/python/modeldb/tests/sklearn/testRandomSplitEvent.py
+++ b/client/python/modeldb/tests/sklearn/testRandomSplitEvent.py
@@ -3,6 +3,8 @@ from ModelDbSyncerTest import SyncerTest
 
 import modeldb.tests.utils as utils
 from modeldb.thrift.modeldb import ttypes as modeldb_types
+from modeldb.basic.Structs import (
+    DefaultExperiment, NewExperimentRun, ThriftConfig)
 from modeldb.sklearn_native.ModelDbSyncer import *
 
 import pandas as pd

--- a/client/python/modeldb/tests/sklearn/testRandomSplitEvent.py
+++ b/client/python/modeldb/tests/sklearn/testRandomSplitEvent.py
@@ -43,7 +43,7 @@ class TestRandomSplitEvent(unittest.TestCase):
         weights = self.random_split_event.weights
         self.assertAlmostEqual(weights[0], 0.7)
         self.assertAlmostEqual(weights[1], 0.3)
-        self.assertEquals(self.random_split_event.seed, 1)
+        self.assertEqual(self.random_split_event.seed, 1)
 
     def test_old_dataframe(self):
         old_df = self.random_split_event.oldDataFrame
@@ -61,7 +61,7 @@ class TestRandomSplitEvent(unittest.TestCase):
 
     def test_split_dataframes(self):
         split_data_frames = self.random_split_event.splitDataFrames
-        self.assertEquals(len(split_data_frames), 2)
+        self.assertEqual(len(split_data_frames), 2)
         dataframe1 = split_data_frames[0]
         dataframe2 = split_data_frames[1]
         utils.validate_dataframe_struct(dataframe1, self)
@@ -71,7 +71,7 @@ class TestRandomSplitEvent(unittest.TestCase):
         # margin of error)
         self.assertIn(dataframe1.numRows, range(65, 75))
         self.assertIn(dataframe2.numRows, range(25, 35))
-        self.assertEquals(dataframe1.numRows + dataframe2.numRows, 100)
+        self.assertEqual(dataframe1.numRows + dataframe2.numRows, 100)
 
 
 if __name__ == '__main__':

--- a/client/python/modeldb/tests/sklearn/testTransformEvent.py
+++ b/client/python/modeldb/tests/sklearn/testTransformEvent.py
@@ -3,6 +3,8 @@ from ModelDbSyncerTest import SyncerTest
 
 import modeldb.tests.utils as utils
 from modeldb.thrift.modeldb import ttypes as modeldb_types
+from modeldb.basic.Structs import (
+    DefaultExperiment, NewExperimentRun, ThriftConfig)
 from modeldb.sklearn_native.ModelDbSyncer import *
 
 from sklearn import preprocessing

--- a/client/python/modeldb/tests/utils.py
+++ b/client/python/modeldb/tests/utils.py
@@ -153,12 +153,7 @@ def is_equal_transformer_spec(spec1, spec2, tester):
     tester.assertEqual(len(spec1.hyperparameters), len(spec2.hyperparameters))
 
     for i in range(len(spec1.hyperparameters)):
-        tester.assertEqual(spec1.hyperparameters[i].name,
-                           spec2.hyperparameters[i].name)
-        tester.assertEqual(spec1.hyperparameters[i].value,
-                           spec2.hyperparameters[i].value)
-        tester.assertEqual(spec1.hyperparameters[i].type,
-                           spec2.hyperparameters[i].type)
+        tester.assertTrue(spec1.hyperparameters[i] in spec2.hyperparameters)
 
 
 def is_equal_transformer(model1, model2, tester):

--- a/client/python/modeldb/utils/ConfigUtils.py
+++ b/client/python/modeldb/utils/ConfigUtils.py
@@ -10,7 +10,7 @@ class ConfigReader(object):
 
     def __init__(self, filename):
         # TODO: need to deal with errors here
-        self.config = json.load(file(filename, 'r'))
+        self.config = json.load(open(filename, 'r'))
         self.validate_config()
 
     def validate_config(self):

--- a/client/python/modeldb/utils/Singleton.py
+++ b/client/python/modeldb/utils/Singleton.py
@@ -1,0 +1,21 @@
+"""
+Implements an unorthodox Singleton metaclass to inherit from.inherit
+If an instance of the class already exists, replace it instead of
+returning the old instance.
+"""
+
+
+class Singleton(type):
+    _instances = {}
+
+    def __call__(cls, *args, **kwargs):
+        cls._instances[cls] = super(
+            Singleton, cls).__call__(*args, **kwargs)
+        return cls._instances[cls]
+
+        # The code below would return the old class
+        # instead creating a new one
+        # if cls not in cls._instances:
+        #     cls._instances[cls] = super(
+        #         Singleton, cls).__call__(*args, **kwargs)
+        # return cls._instances[cls]

--- a/client/python/requirements.txt
+++ b/client/python/requirements.txt
@@ -1,6 +1,5 @@
 ##requirements.txt
 
-python >= 2.7
 numpy
 pandas
 statsmodels

--- a/client/python/requirements.txt
+++ b/client/python/requirements.txt
@@ -12,3 +12,4 @@ thrift
 pyyaml
 requests
 dpath
+future

--- a/client/python/samples/basic/BasicSyncAll.py
+++ b/client/python/samples/basic/BasicSyncAll.py
@@ -9,7 +9,7 @@ syncer_obj = Syncer.create_syncer("Sample Project", "test_user", \
 filename = "YamlSample.yaml"
 # filename = "JsonSample.json"
 
-print "Syncing all data from file..."
+print("Syncing all data from file...")
 syncer_obj.sync_all(filename)
 
 syncer_obj.sync()

--- a/client/python/samples/basic/BasicWorkflow.py
+++ b/client/python/samples/basic/BasicWorkflow.py
@@ -22,7 +22,7 @@ syncer_obj = Syncer.create_syncer_from_config(
 # experiment_run_id = int(sys.argv[len(sys.argv) - 1])
 # syncer_obj = Syncer.create_syncer_for_experiment_run(experiment_run_id)
 
-print "I'm training some model"
+print("I'm training some model")
 
 datasets = {
     "train": Dataset("/path/to/train", {"num_cols": 15, "dist": "random"}),

--- a/client/python/samples/sklearn/LinearModel.py
+++ b/client/python/samples/sklearn/LinearModel.py
@@ -94,9 +94,9 @@ class TestLinearModelEndToEnd(unittest.TestCase):
         """
         projectOverview = self.syncer_obj.client.getProjectOverviews()[0]
         project = projectOverview.project
-        self.assertEquals(project.description, 'pandas-linear-regression')
-        self.assertEquals(project.author, 'srinidhi')
-        self.assertEquals(project.name, 'test1')
+        self.assertEqual(project.description, 'pandas-linear-regression')
+        self.assertEqual(project.author, 'srinidhi')
+        self.assertEqual(project.name, 'test1')
         self.assertGreaterEqual(project.id, 0)
         self.assertGreaterEqual(projectOverview.numExperimentRuns, 0)
         self.assertGreaterEqual(projectOverview.numExperiments, 0)
@@ -116,7 +116,7 @@ class TestLinearModelEndToEnd(unittest.TestCase):
             exp_id).modelResponses
 
         # Two models are stored above - ensure both are in database
-        self.assertEquals(len(model_responses), 2)
+        self.assertEqual(len(model_responses), 2)
 
         model1 = model_responses[0]
         model2 = model_responses[1]
@@ -156,8 +156,8 @@ class TestLinearModelEndToEnd(unittest.TestCase):
         model2 = model_responses[1]
 
         # Metrics are only stored for the second model.
-        self.assertEquals(len(model1.metrics), 0)
-        self.assertEquals(len(model2.metrics), 1)
+        self.assertEqual(len(model1.metrics), 0)
+        self.assertEqual(len(model2.metrics), 1)
         self.assertIn('mean_squared_error', model2.metrics)
 
         dataframe_id = self.syncer_obj.get_modeldb_id_for_object(self.x_test)

--- a/client/python/samples/sklearn/OneHotEncoding.py
+++ b/client/python/samples/sklearn/OneHotEncoding.py
@@ -23,8 +23,8 @@ def oneHotEncoding(lb, feature, df):
         feature_numeric = lb.fit_transform(df[[feature]])
     else:
         feature_numeric = lb.transform(df[[feature]])
-    col_names = map(lambda x: feature + "_" +
-                    str(x).strip(), list(lb.classes_))
+    col_names = list(map(lambda x: feature + "_" +
+                    str(x).strip(), list(lb.classes_)))
     if lb.classes_.shape[0] == 2:
         col_names = col_names[:1]
     feature_df = pd.DataFrame(

--- a/client/python/samples/sklearn/OttoGroup-Calibration.py
+++ b/client/python/samples/sklearn/OttoGroup-Calibration.py
@@ -136,9 +136,9 @@ class TestOttoCalibration(unittest.TestCase):
         """
         projectOverview = self.syncer_obj.client.getProjectOverviews()[0]
         project = projectOverview.project
-        self.assertEquals(project.description, 'kaggle-otto-script')
-        self.assertEquals(project.author, 'author')
-        self.assertEquals(project.name, 'test1')
+        self.assertEqual(project.description, 'kaggle-otto-script')
+        self.assertEqual(project.author, 'author')
+        self.assertEqual(project.name, 'test1')
         self.assertGreaterEqual(project.id, 0)
         self.assertGreaterEqual(projectOverview.numExperimentRuns, 0)
         self.assertGreaterEqual(projectOverview.numExperiments, 0)
@@ -201,8 +201,8 @@ class TestOttoCalibration(unittest.TestCase):
         model2 = model_responses[1]
         model3 = model_responses[2]
 
-        self.assertEquals(len(model2.metrics), 1)
-        self.assertEquals(len(model3.metrics), 1)
+        self.assertEqual(len(model2.metrics), 1)
+        self.assertEqual(len(model3.metrics), 1)
 
         dataframe_id = self.syncer_obj.id_for_object[id(self.x_test)]
         # Calibrated Classifier has lower log loss than Bagging Classfier

--- a/client/python/samples/sklearn/Pipeline-AnovaFilter.py
+++ b/client/python/samples/sklearn/Pipeline-AnovaFilter.py
@@ -141,10 +141,10 @@ class TestPipelineEndToEnd(unittest.TestCase):
         """
         # Check ancestry for x_test and x_train.
         # The data the models were trained and tested on.
-        print "x_train_id", self.syncer_obj.get_modeldb_id_for_object(
-            self.x_train)
-        print "x_test_id", self.syncer_obj.get_modeldb_id_for_object(
-            self.x_test)
+        print("x_train_id", self.syncer_obj.get_modeldb_id_for_object(
+                    self.x_train))
+        print("x_test_id", self.syncer_obj.get_modeldb_id_for_object(
+                    self.x_test))
 
         for df in [self.x_train, self.x_test]:
             dataframe_id = self.syncer_obj.get_modeldb_id_for_object(df)

--- a/client/python/samples/sklearn/Pipeline-AnovaFilter.py
+++ b/client/python/samples/sklearn/Pipeline-AnovaFilter.py
@@ -83,9 +83,9 @@ class TestPipelineEndToEnd(unittest.TestCase):
         """
         projectOverview = self.syncer_obj.client.getProjectOverviews()[0]
         project = projectOverview.project
-        self.assertEquals(project.description, 'anova filter pipeline')
-        self.assertEquals(project.author, 'srinidhi')
-        self.assertEquals(project.name, 'pipeline scikit example')
+        self.assertEqual(project.description, 'anova filter pipeline')
+        self.assertEqual(project.author, 'srinidhi')
+        self.assertEqual(project.name, 'pipeline scikit example')
         self.assertGreaterEqual(project.id, 0)
         self.assertGreaterEqual(projectOverview.numExperimentRuns, 0)
         self.assertGreaterEqual(projectOverview.numExperiments, 0)
@@ -104,7 +104,7 @@ class TestPipelineEndToEnd(unittest.TestCase):
             exp_id).modelResponses
 
         # Two models are stored above - ensure both are in database
-        self.assertEquals(len(model_responses), 3)
+        self.assertEqual(len(model_responses), 3)
 
         model1 = model_responses[0]
         model2 = model_responses[1]
@@ -180,9 +180,9 @@ class TestPipelineEndToEnd(unittest.TestCase):
         model3 = model_responses[2]
 
         # Metrics are only stored for the overall pipeline model.
-        self.assertEquals(len(model1.metrics), 2)
-        self.assertEquals(len(model2.metrics), 0)
-        self.assertEquals(len(model3.metrics), 0)
+        self.assertEqual(len(model1.metrics), 2)
+        self.assertEqual(len(model2.metrics), 0)
+        self.assertEqual(len(model3.metrics), 0)
         self.assertIn('f1_score', model1.metrics)
         self.assertIn('precision_score', model1.metrics)
 

--- a/client/python/samples/sklearn/Titanic-LogisticRegression.py
+++ b/client/python/samples/sklearn/Titanic-LogisticRegression.py
@@ -72,5 +72,5 @@ alg = LogisticRegression(random_state=1)
 
 scores = cross_validation.cross_val_score_sync(
     alg, titanic[predictors], titanic["Survived"], cv=3)
-print scores.mean()
+print(scores.mean())
 syncer_obj.sync()

--- a/client/python/setup.py
+++ b/client/python/setup.py
@@ -23,7 +23,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.0.1.a6',
+    version='0.0.1.a7',
     description='A system to manage machine learning models',
     long_description=long_description,
 

--- a/client/python/setup.py
+++ b/client/python/setup.py
@@ -59,7 +59,7 @@ setup(
         # 'Programming Language :: Python :: 3',
         # 'Programming Language :: Python :: 3.3',
         # 'Programming Language :: Python :: 3.4',
-        # 'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.5',
     ],
 
     # What does your project relate to?

--- a/client/python/setup.py
+++ b/client/python/setup.py
@@ -23,7 +23,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.0.1a29',
+    version='0.0.1a30',
     description='A system to manage machine learning models',
     long_description=long_description,
 
@@ -79,7 +79,8 @@ setup(
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
         'numpy', 'pandas', 'statsmodels', 'matplotlib', 'patsy',
-        'scikit-learn', 'sklearn', 'thrift', 'pyyaml', 'requests', 'dpath'],
+        'scikit-learn', 'sklearn', 'thrift', 'pyyaml', 'requests', 'dpath',
+        'future'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,


### PR DESCRIPTION
* Make imports Python3 friendly
* Add a few python3-isms
* Reimplement/Refactor how ModelDB does `Syncer` Singletons
  * don't pass args to `object.__new__`. Use a `__metaclass__` instead
* Making the singletons python3 friendly