### PR TITLE
Add back ports so docker-compose up succeeds

### DIFF
--- a/dockerbuild/Dockerfile-backend
+++ b/dockerbuild/Dockerfile-backend
@@ -2,13 +2,15 @@ FROM openjdk:8
 
 EXPOSE 6543
 
-RUN echo 'deb http://httpredir.debian.org/debian jessie-backports main' > \
-    /etc/apt/sources.list.d/backports.list && \
- apt-get update && apt-get -y dist-upgrade
+RUN  \
+ 
  
 # Maven installs openjdk-7 as the default Java. update-alternatives points java back to 8.
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 0C49F3730359A14518585931BC711F9BA15703C6 && \
-    echo "deb [ arch=amd64 ] http://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.4 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-3.4.list && \
+    echo 'deb http://httpredir.debian.org/debian jessie-backports main' > \
+    /etc/apt/sources.list.d/backports.list &&
+    apt-get update && apt-get -y dist-upgrade &&
+    echo "deb [ arch=amd64,arm64 ] http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.4 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-3.4.list && \
     apt-get update && \
     apt-get install -y \
         maven \

--- a/dockerbuild/Dockerfile-backend
+++ b/dockerbuild/Dockerfile-backend
@@ -2,6 +2,10 @@ FROM openjdk:8
 
 EXPOSE 6543
 
+RUN echo 'deb http://httpredir.debian.org/debian jessie-backports main' > \
+    /etc/apt/sources.list.d/backports.list && \
+ apt-get update && apt-get -y dist-upgrade
+ 
 # Maven installs openjdk-7 as the default Java. update-alternatives points java back to 8.
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 0C49F3730359A14518585931BC711F9BA15703C6 && \
     echo "deb [ arch=amd64 ] http://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.4 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-3.4.list && \

--- a/dockerbuild/Dockerfile-backend
+++ b/dockerbuild/Dockerfile-backend
@@ -1,9 +1,6 @@
 FROM openjdk:8
 
 EXPOSE 6543
-
-RUN  \
- 
  
 # Maven installs openjdk-7 as the default Java. update-alternatives points java back to 8.
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 0C49F3730359A14518585931BC711F9BA15703C6 && \

--- a/dockerbuild/Dockerfile-backend
+++ b/dockerbuild/Dockerfile-backend
@@ -5,8 +5,8 @@ EXPOSE 6543
 # Maven installs openjdk-7 as the default Java. update-alternatives points java back to 8.
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 0C49F3730359A14518585931BC711F9BA15703C6 && \
     echo 'deb http://httpredir.debian.org/debian jessie-backports main' > \
-    /etc/apt/sources.list.d/backports.list &&
-    apt-get update && apt-get -y dist-upgrade &&
+    /etc/apt/sources.list.d/backports.list && \
+    apt-get update && apt-get -y dist-upgrade && \
     echo "deb [ arch=amd64,arm64 ] http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.4 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-3.4.list && \
     apt-get update && \
     apt-get install -y \


### PR DESCRIPTION
If you don't add jessie back ports mongodb-org-shell will not install due to the fact its looking for libssl1.0 which isn't installable.