### PR TITLE
jessie-backports no longer maintained

### DIFF
--- a/dockerbuild/Dockerfile-backend
+++ b/dockerbuild/Dockerfile-backend
@@ -4,12 +4,12 @@ EXPOSE 6543
  
 # Maven installs openjdk-7 as the default Java. update-alternatives points java back to 8.
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 0C49F3730359A14518585931BC711F9BA15703C6 && \
-    echo 'deb http://httpredir.debian.org/debian jessie-backports main' > \
+    echo 'deb http://archive.debian.org/debian jessie-backports main' > \
     /etc/apt/sources.list.d/backports.list && \
-    apt-get update && apt-get -y dist-upgrade && \
+    apt-get -o Acquire::Check-Valid-Until=false update && apt-get -y -o Acquire::Check-Valid-Until=false dist-upgrade && \
     echo "deb [ arch=amd64,arm64 ] http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.4 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-3.4.list && \
-    apt-get update && \
-    apt-get install -y \
+    apt-get -o Acquire::Check-Valid-Until=false update && \
+    apt-get -o Acquire::Check-Valid-Until=false install -y \
         maven \
         sqlite \
         g++ \


### PR DESCRIPTION
1. Point jessie-backports to archive.debian.org
2. Update apt-get commands to include "-o Acquire::Check-Valid-Until=false " to avoid expiration errors.