### PR TITLE
Generate timestamped names

### DIFF
--- a/client/verta/tests/test_entities.py
+++ b/client/verta/tests/test_entities.py
@@ -10,6 +10,7 @@ import pytest
 from . import utils
 
 import verta
+import verta._internal_utils._utils
 import json
 
 
@@ -90,9 +91,9 @@ class TestClient:
 
     @pytest.mark.skipif('VERTA_EMAIL' not in os.environ or 'VERTA_DEV_KEY' not in os.environ, reason="insufficient Verta credentials")
     def test_config_file(self):
-        PROJECT_NAME = "test_project"
-        DATASET_NAME = "test_dataset"
-        EXPERIMENT_NAME = "test_experiment"
+        PROJECT_NAME = verta._internal_utils._utils.generate_default_name()
+        DATASET_NAME = verta._internal_utils._utils.generate_default_name()
+        EXPERIMENT_NAME = verta._internal_utils._utils.generate_default_name()
         CONFIG_FILENAME = "verta_config.json"
 
         HOST = "app.verta.ai"


### PR DESCRIPTION
This test has a race condition if multiple suites are running it in parallel. Because the ModelDB entity names are hard-coded, one test might delete it while another is about to retrieve it.

Now the names will be generated from the current timestamp + process ID.

This test had failed:
https://vertaai.slack.com/archives/CR0PEMHB9/p1584772178000200