### PR TITLE
Open external links in new tab

### DIFF
--- a/client/verta/docs/examples/examples.rst
+++ b/client/verta/docs/examples/examples.rst
@@ -1,7 +1,7 @@
 Examples
 ========
 
-|GitHub repo| houses |Client workflows| for reference and exploration.
+|Verta's GitHub repository| houses |various example projects| for reference and exploration.
 
 Here are some of our most popular examples.
 
@@ -76,10 +76,10 @@ XGBoost
   <https://github.com/VertaAI/modeldb/blob/master/client/workflows/examples/xgboost-integration.ipynb>`__
 
 
-.. |GitHub repo| raw:: html
+.. |Verta's GitHub repository| raw:: html
 
   <a href="https://github.com/VertaAI/modeldb" target="_blank">Verta's GitHub repository</a>
 
-.. |Client workflows| raw:: html
+.. |various example projects| raw:: html
 
    <a href="https://github.com/VertaAI/modeldb/tree/master/client/workflows" target="_blank">various example projects</a>

--- a/client/verta/docs/examples/examples.rst
+++ b/client/verta/docs/examples/examples.rst
@@ -1,9 +1,7 @@
 Examples
 ========
 
-`Verta's GitHub repository <https://github.com/VertaAI/modeldb>`_ houses `various example
-projects <https://github.com/VertaAI/modeldb/tree/master/client/workflows>`_ for reference and
-exploration.
+|GitHub repo| houses |Client workflows| for reference and exploration.
 
 Here are some of our most popular examples.
 
@@ -76,3 +74,12 @@ XGBoost
   <https://github.com/VertaAI/modeldb/blob/master/client/workflows/examples/xgboost.ipynb>`__
 - `Client Integration
   <https://github.com/VertaAI/modeldb/blob/master/client/workflows/examples/xgboost-integration.ipynb>`__
+
+
+.. |GitHub repo| raw:: html
+
+  <a href="https://github.com/VertaAI/modeldb" target="_blank">Verta's GitHub repository</a>
+
+.. |Client workflows| raw:: html
+
+   <a href="https://github.com/VertaAI/modeldb/tree/master/client/workflows" target="_blank">various example projects</a>

--- a/client/verta/docs/examples/tutorials/dataset.rst
+++ b/client/verta/docs/examples/tutorials/dataset.rst
@@ -31,7 +31,7 @@ Setup
 
 This guide assumes a basic familiarity with Verta's client interface.
 
-Imagine we have some CSV files stored on `Amazon S3 <https://aws.amazon.com/s3/>`_ that we would
+Imagine we have some CSV files stored on |S3| that we would
 like to associate with our workflows. We'd like to keep track of which files we're accessing, and
 when they are accessed.
 
@@ -48,7 +48,7 @@ Don't worry—Verta doesn't download or store the actual S3 object; instead, we 
 information for you to later identify the snapshot of data that was used.
 
 After installation, make sure AWS credentials are set up in your local environment, following their
-`official instructions <https://pypi.org/project/boto3/>`_.
+|boto3|.
 
 
 Version Logging
@@ -102,3 +102,12 @@ Clicking on *training_data* will direct you to the DatasetVersion page:
 And there, you'll find information about your dataset version:
 
 .. image:: /_static/images/dataset-version-page.png
+
+
+.. |S3| raw:: html
+
+   <a href="https://aws.amazon.com/s3/" target="_blank">Amazon S3</a>
+
+.. |boto3| raw:: html
+
+   <a href="https://pypi.org/project/boto3/" target="_blank">official instructions</a>

--- a/client/verta/docs/examples/tutorials/dataset.rst
+++ b/client/verta/docs/examples/tutorials/dataset.rst
@@ -31,7 +31,7 @@ Setup
 
 This guide assumes a basic familiarity with Verta's client interface.
 
-Imagine we have some CSV files stored on |S3| that we would
+Imagine we have some CSV files stored on |Amazon S3| that we would
 like to associate with our workflows. We'd like to keep track of which files we're accessing, and
 when they are accessed.
 
@@ -48,7 +48,7 @@ Don't worry—Verta doesn't download or store the actual S3 object; instead, we 
 information for you to later identify the snapshot of data that was used.
 
 After installation, make sure AWS credentials are set up in your local environment, following their
-|boto3|.
+|official instructions|.
 
 
 Version Logging
@@ -104,10 +104,10 @@ And there, you'll find information about your dataset version:
 .. image:: /_static/images/dataset-version-page.png
 
 
-.. |S3| raw:: html
+.. |Amazon S3| raw:: html
 
    <a href="https://aws.amazon.com/s3/" target="_blank">Amazon S3</a>
 
-.. |boto3| raw:: html
+.. |official instructions| raw:: html
 
    <a href="https://pypi.org/project/boto3/" target="_blank">official instructions</a>

--- a/client/verta/docs/examples/tutorials/webapp.rst
+++ b/client/verta/docs/examples/tutorials/webapp.rst
@@ -3,7 +3,7 @@ Verta Web App
 
 Projects Page
 ^^^^^^^^^^^^^
-Navigate to the |web app| to see all your projects.
+Navigate to the |Web App| to see all your projects.
 
 .. image:: /_static/images/web-app-projects.png
    :width: 75%
@@ -36,6 +36,6 @@ Clicking on an individual Experiment Run allows you to see specific details and 
    :width: 75%
 
 
-.. |web app| raw:: html
+.. |Web App| raw:: html
 
    <a href="https://app.verta.ai" target="_blank">Web App</a>

--- a/client/verta/docs/examples/tutorials/webapp.rst
+++ b/client/verta/docs/examples/tutorials/webapp.rst
@@ -3,7 +3,7 @@ Verta Web App
 
 Projects Page
 ^^^^^^^^^^^^^
-Navigate to the `Web App <https://app.verta.ai>`__ to see all your projects.
+Navigate to the |web app| to see all your projects.
 
 .. image:: /_static/images/web-app-projects.png
    :width: 75%
@@ -34,3 +34,8 @@ Clicking on an individual Experiment Run allows you to see specific details and 
 
 .. image:: /_static/images/web-app-expt-run.png
    :width: 75%
+
+
+.. |web app| raw:: html
+
+   <a href="https://app.verta.ai" target="_blank">Web App</a>

--- a/client/verta/docs/faqs.rst
+++ b/client/verta/docs/faqs.rst
@@ -12,10 +12,10 @@ What parts of Verta are open-source?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 All the Verta modules related to model versioning and metadata are free and open-source under ModelDB.
-Find code and getting started information for ModelDB `here <https://github.com/VertaAI/modeldb>`__.
+Find code and getting started information for ModelDB |ModelDB repo|.
 
 In addition, we have open-source different deployment and packaging components that are available on the
-`Verta Git repository <https://github.com/VertaAI?q=&type=public>`_.
+|Verta public repos|.
 
 .. _how-is-modeldb-different:
 
@@ -50,3 +50,12 @@ Additional Questions?
 
 If your question is not covered above, please check out the `Support & Community <support.html>`_ page for more
 information about our support channels.
+
+
+.. |ModelDB repo| raw:: html
+
+   <a href="https://github.com/VertaAI/modeldb" target="_blank">here</a>
+
+.. |Verta public repos| raw:: html
+
+   <a href="https://github.com/VertaAI?q=&type=public" target="_blank">Verta Git repository</a>

--- a/client/verta/docs/faqs.rst
+++ b/client/verta/docs/faqs.rst
@@ -12,10 +12,10 @@ What parts of Verta are open-source?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 All the Verta modules related to model versioning and metadata are free and open-source under ModelDB.
-Find code and getting started information for ModelDB |ModelDB repo|.
+Find code and getting started information for ModelDB |here|.
 
 In addition, we have open-source different deployment and packaging components that are available on the
-|Verta public repos|.
+|Verta Git repository|.
 
 .. _how-is-modeldb-different:
 
@@ -52,10 +52,10 @@ If your question is not covered above, please check out the `Support & Community
 information about our support channels.
 
 
-.. |ModelDB repo| raw:: html
+.. |here| raw:: html
 
    <a href="https://github.com/VertaAI/modeldb" target="_blank">here</a>
 
-.. |Verta public repos| raw:: html
+.. |Verta Git repository| raw:: html
 
    <a href="https://github.com/VertaAI?q=&type=public" target="_blank">Verta Git repository</a>

--- a/client/verta/docs/learn.rst
+++ b/client/verta/docs/learn.rst
@@ -8,13 +8,13 @@ Let us know on `Slack <support.html>`_  if you'd like to see a particular learni
 News
 ====
 
-Check out information on upcoming releases, talks, and events `here <https://verta.ai/news>`_.
+Check out information on upcoming releases, talks, and events |news|.
 
 ===============================
 Verta and ModelDB Presentations
 ===============================
 
-* Check out the `Verta YouTube channel <https://www.youtube.com/channel/UClJKA9nhsFNpxK5ACRKjzbA/about>`_ for Product videos and tutorials.
+* Check out the |YouTube channel| for Product videos and tutorials.
 
 ..
     =================
@@ -25,3 +25,12 @@ Verta and ModelDB Presentations
     MLOps
     =====
 ..
+
+
+.. |news| raw:: html
+
+   <a href="https://verta.ai/news" target="_blank">here</a>
+
+.. |YouTube channel| raw:: html
+
+   <a href="https://www.youtube.com/channel/UClJKA9nhsFNpxK5ACRKjzbA/about" target="_blank">Verta YouTube channel</a>

--- a/client/verta/docs/learn.rst
+++ b/client/verta/docs/learn.rst
@@ -27,10 +27,10 @@ Verta and ModelDB Presentations
 ..
 
 
-.. |news| raw:: html
+.. |here| raw:: html
 
    <a href="https://verta.ai/news" target="_blank">here</a>
 
-.. |YouTube channel| raw:: html
+.. |Verta YouTube channel| raw:: html
 
    <a href="https://www.youtube.com/channel/UClJKA9nhsFNpxK5ACRKjzbA/about" target="_blank">Verta YouTube channel</a>

--- a/client/verta/docs/learn.rst
+++ b/client/verta/docs/learn.rst
@@ -8,13 +8,13 @@ Let us know on `Slack <support.html>`_  if you'd like to see a particular learni
 News
 ====
 
-Check out information on upcoming releases, talks, and events |news|.
+Check out information on upcoming releases, talks, and events |here|.
 
 ===============================
 Verta and ModelDB Presentations
 ===============================
 
-* Check out the |YouTube channel| for Product videos and tutorials.
+* Check out the |Verta YouTube channel| for Product videos and tutorials.
 
 ..
     =================

--- a/client/verta/docs/overview/deployment.rst
+++ b/client/verta/docs/overview/deployment.rst
@@ -1,13 +1,13 @@
 Deployment & Release
 ====================
 
-The most challenging and yet crucial operation in operationalization of models is model 
+The most challenging and yet crucial operation in operationalization of models is model
 deployment and release.
-Due to the diversity of ML frameworks and libraries, and the lack of common systems 
+Due to the diversity of ML frameworks and libraries, and the lack of common systems
 for ML development vs. software delivery systems, it takes many months to release models
 into products.
 
-One of Verta's key innovations is our open-core model deployment and release system that 
+One of Verta's key innovations is our open-core model deployment and release system that
 works seamlessly with models built in over a dozen frameworks and languages, and integrates
 with state-of-the-art DevOps and software delivery systems.
 
@@ -59,7 +59,7 @@ of three steps:
         )
         run.log_requirements(["annoy", "tensorflow"])
 
-That's it, this model can now be packaged and deployed on the Verta platform. 
+That's it, this model can now be packaged and deployed on the Verta platform.
 Refer to the :doc:`../api/deployment` API reference for details about the Deployment APIs.
 
 ================
@@ -84,6 +84,9 @@ Model Release
 =============
 
 Verta also provides integrations into popular tools such as Jenkins to automate the package and release
-of models.
-Check out `this <https://github.com/VertaAI/modeldb/tree/master/demos/03-20-mdb-jenkins-prom>`_ Jenkins pipeline to automate the model release process. 
+of models. Check out |jenkins| Jenkins pipeline to automate the model release process.
 
+
+.. |jenkins| raw:: html
+
+   <a href="https://github.com/VertaAI/modeldb/tree/master/demos/03-20-mdb-jenkins-prom" target="_blank">this</a>

--- a/client/verta/docs/overview/deployment.rst
+++ b/client/verta/docs/overview/deployment.rst
@@ -84,9 +84,9 @@ Model Release
 =============
 
 Verta also provides integrations into popular tools such as Jenkins to automate the package and release
-of models. Check out |jenkins| Jenkins pipeline to automate the model release process.
+of models. Check out |this| Jenkins pipeline to automate the model release process.
 
 
-.. |jenkins| raw:: html
+.. |this| raw:: html
 
    <a href="https://github.com/VertaAI/modeldb/tree/master/demos/03-20-mdb-jenkins-prom" target="_blank">this</a>

--- a/client/verta/docs/overview/modeldb.rst
+++ b/client/verta/docs/overview/modeldb.rst
@@ -17,11 +17,11 @@ Use Cases
 1. Make your ML models reproducible
 ------------------------------------
 
-ML models currently have a major problem with reproducibility that causes weeks to be spent on audit 
+ML models currently have a major problem with reproducibility that causes weeks to be spent on audit
 inquiries in regulated industries and challenges fixing production issues with models.
 ModelDB provides the ability to version every change to a model and make a model fully reproducible.
 
-By versioning the *constituent elements* required for the creation of a model, ModelDB can enable 
+By versioning the *constituent elements* required for the creation of a model, ModelDB can enable
 reproducibility of all models and drastically reduce the time required to answer production incidents as
 well as regulatory inquiries.
 
@@ -41,7 +41,7 @@ reporting, and model analysis functionality.
 
 As more models are built across a team or organization, there are productivity benefits to be obtained by sharing
 ML know-how and models across team members.
-Towards this, a central model repository such as one providee\d by ModelDB can enable model sharing, 
+Towards this, a central model repository such as one providee\d by ModelDB can enable model sharing,
 collaboration, and reuse.
 
 4. Managing the  Model Lifecycle
@@ -94,14 +94,31 @@ Technical Features
 Repository
 ==========
 
-The ModelDB repository is located `here <https://github.com/VertaAI/modeldb>`_. Please clone, star, and contribute!
+The ModelDB repository is located |repo|. Please clone, star, and contribute!
 
 .. _modeldb-history:
 
 History
 =======
 
-ModelDB 1.0 started in 2016 as a research project in the `Database Group <http://dsg.csail.mit.edu>`_ at `MIT CSAIL <http://csail.mit.edu>`_.
+ModelDB 1.0 started in 2016 as a research project in the |DSG| at |CSAIL|.
 At the time, ModelDB was focused on model metadata management and pioneered the approach that is now used in many research and commercial systems.
 Since then, ModelDB evovled to be the first model versioning system to provide model reproducibility and along with metadata management.
-ModelDB 2.0 is maintained by `Verta.ai <https://verta.ai>`_.
+ModelDB 2.0 is maintained by |Verta|.
+
+
+.. |repo| raw:: html
+
+    <a href="https://github.com/VertaAI/modeldb" target="_blank">here</a>
+
+.. |DSG| raw:: html
+
+   <a href="http://dsg.csail.mit.edu" target="_blank">Database Group</a>
+
+.. |CSAIL| raw:: html
+
+   <a href="http://csail.mit.edu" target="_blank">hMIT CSAILere</a>
+
+.. |Verta| raw:: html
+
+   <a href="https://verta.ai" target="_blank">Verta.ai</a>

--- a/client/verta/docs/overview/modeldb.rst
+++ b/client/verta/docs/overview/modeldb.rst
@@ -94,31 +94,31 @@ Technical Features
 Repository
 ==========
 
-The ModelDB repository is located |repo|. Please clone, star, and contribute!
+The ModelDB repository is located |here|. Please clone, star, and contribute!
 
 .. _modeldb-history:
 
 History
 =======
 
-ModelDB 1.0 started in 2016 as a research project in the |DSG| at |CSAIL|.
+ModelDB 1.0 started in 2016 as a research project in the |Database Group| at |MIT CSAIL|.
 At the time, ModelDB was focused on model metadata management and pioneered the approach that is now used in many research and commercial systems.
 Since then, ModelDB evovled to be the first model versioning system to provide model reproducibility and along with metadata management.
-ModelDB 2.0 is maintained by |Verta|.
+ModelDB 2.0 is maintained by |Verta.ai|.
 
 
-.. |repo| raw:: html
+.. |here| raw:: html
 
     <a href="https://github.com/VertaAI/modeldb" target="_blank">here</a>
 
-.. |DSG| raw:: html
+.. |Database Group| raw:: html
 
    <a href="http://dsg.csail.mit.edu" target="_blank">Database Group</a>
 
-.. |CSAIL| raw:: html
+.. |MIT CSAIL| raw:: html
 
    <a href="http://csail.mit.edu" target="_blank">hMIT CSAILere</a>
 
-.. |Verta| raw:: html
+.. |Verta.ai| raw:: html
 
    <a href="https://verta.ai" target="_blank">Verta.ai</a>

--- a/client/verta/docs/quickstart.rst
+++ b/client/verta/docs/quickstart.rst
@@ -9,7 +9,7 @@ Get started with Verta in 5 minutes.
 You have a few options here:
 
 * If you are on Verta Core or Verta Enterprise, you do not need to set up a Verta Server; please reach out to `Verta Support <mailto:support@verta.ai>`_ for instructions for your server information.
-* You are only looking to run open-source ModelDB, head over to the `ModelDB repo <https://github.com/VertaAI/modeldb>`_ for installation instructions.
+* You are only looking to run open-source ModelDB, head over to the |ModelDB repo| for installation instructions.
 
 
 2. Setup the Verta Client
@@ -31,7 +31,7 @@ The Verta client supports Python 2.7 & 3.5–3.7!
 3. Obtain your Verta Credentials
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* On Verta Core or Verta Enterprise, log into the Verta Web App (e.g., `https://app.verta.ai <https://app.verta.ai>`__) and visit the Profile page to find your developer key.
+* On Verta Core or Verta Enterprise, log into the Verta Web App (e.g., |web app|) and visit the Profile page to find your developer key.
 
     .. image:: /_static/images/web-app-profile.png
         :width: 50%
@@ -87,3 +87,12 @@ Now that you have versioned a few models, you can interact with them in a variet
 ..
     For more information, read the `workflow guide <workflow.html>`_ and the `API reference
     <../reference/api.html>`_.
+
+
+.. |ModelDB repo| raw:: html
+
+   <a href="https://github.com/VertaAI/modeldb" target="_blank">`ModelDB repo</a>
+
+.. |web app| raw:: html
+
+   <a href="https://app.verta.ai" target="_blank">https://app.verta.ai</a>

--- a/client/verta/docs/support.rst
+++ b/client/verta/docs/support.rst
@@ -1,10 +1,19 @@
 Support & Community
 ===================
 
-Verta is an open-core MLOps platform and we provide a variety of ways for our users to 
+Verta is an open-core MLOps platform and we provide a variety of ways for our users to
 engage with our team, provide feedback, and get help!
 
 * Check out our `Resources <learn.html>`_, `Tutorials &  Examples <examples.html>`_, and `FAQs <faqs.html>`_ sections for guides and answers to basic queestions.
-* Verta `Git repositories <https://github.com/VertaAI/>`_ all have an Issues track for users to ask questions, create support tickets, and submit feature requests.
-* Check out our `Verta Community Slack channel <http://bit.ly/modeldb-mlops>`_ for open-source and basic support.
+* Verta |GitHub| all have an Issues track for users to ask questions, create support tickets, and submit feature requests.
+* Check out our |Slack| for open-source and basic support.
 * If you are a Verta Enterprise customer, check with your Verta admin or email `support@verta.ai` for your organization-specific Slack information.
+
+
+.. |GitHub| raw:: html
+
+   <a href="https://github.com/VertaAI/" target="_blank">Git repositories</a>
+
+.. |Slack| raw:: html
+
+   <a href="http://bit.ly/modeldb-mlops" target="_blank">Verta Community Slack channel</a>

--- a/client/verta/docs/support.rst
+++ b/client/verta/docs/support.rst
@@ -5,15 +5,15 @@ Verta is an open-core MLOps platform and we provide a variety of ways for our us
 engage with our team, provide feedback, and get help!
 
 * Check out our `Resources <learn.html>`_, `Tutorials &  Examples <examples.html>`_, and `FAQs <faqs.html>`_ sections for guides and answers to basic queestions.
-* Verta |GitHub| all have an Issues track for users to ask questions, create support tickets, and submit feature requests.
-* Check out our |Slack| for open-source and basic support.
+* Verta |Git repositories| all have an Issues track for users to ask questions, create support tickets, and submit feature requests.
+* Check out our |Verta Community Slack channel| for open-source and basic support.
 * If you are a Verta Enterprise customer, check with your Verta admin or email `support@verta.ai` for your organization-specific Slack information.
 
 
-.. |GitHub| raw:: html
+.. |Git repositories| raw:: html
 
    <a href="https://github.com/VertaAI/" target="_blank">Git repositories</a>
 
-.. |Slack| raw:: html
+.. |Verta Community Slack channel| raw:: html
 
    <a href="http://bit.ly/modeldb-mlops" target="_blank">Verta Community Slack channel</a>

--- a/client/verta/docs/verta.rst
+++ b/client/verta/docs/verta.rst
@@ -24,7 +24,7 @@ monitoring, and maintenance.
 
 Verta is an open-core platform; i.e., the platform is based on core open-source technology
 developed by the Verta team that is freely available. Find more information about our
-open-source technology |open source| and in subsequent
+open-source technology |gere| and in subsequent
 sections.
 
 Verta provides MLOps functionality in three key areas: **model versioning and metadata**,
@@ -35,7 +35,7 @@ Model Versioning & Metadata
 ===========================
 
 The first step to enable operationalization of ML models is to make them reproducible and
-associate governance data with them. Verta's open-source |ModelDB repo|
+associate governance data with them. Verta's open-source |ModelDB|
 component is the only system to provide full model versioning and reproducibility along
 with a rich metadata system.
 
@@ -89,10 +89,10 @@ Ready to get started? We recommend the following:
     ModelDB <overview/modeldb>
 
 
-.. |open source| raw:: html
+.. |here| raw:: html
 
     <a href="https://verta.ai/open-source" target="_blank">here</a>
 
-.. |ModelDB repo| raw:: html
+.. |ModelDB| raw:: html
 
     <a href="https://github.com/VertaAI/modeldb" target="_blank">ModelDB</a>

--- a/client/verta/docs/verta.rst
+++ b/client/verta/docs/verta.rst
@@ -24,7 +24,7 @@ monitoring, and maintenance.
 
 Verta is an open-core platform; i.e., the platform is based on core open-source technology
 developed by the Verta team that is freely available. Find more information about our
-open-source technology |gere| and in subsequent
+open-source technology |here| and in subsequent
 sections.
 
 Verta provides MLOps functionality in three key areas: **model versioning and metadata**,

--- a/client/verta/docs/verta.rst
+++ b/client/verta/docs/verta.rst
@@ -4,16 +4,16 @@ Verta
 The Complete MLOps Platform
 ---------------------------
 
-Verta is a complete MLOps (ML Operations) platform focused on operationalization of ML 
-models, i.e., integrating ML development and delivery into regular software in a way 
-that allows data scientists to continue focus on machine learning and data science, 
+Verta is a complete MLOps (ML Operations) platform focused on operationalization of ML
+models, i.e., integrating ML development and delivery into regular software in a way
+that allows data scientists to continue focus on machine learning and data science,
 while providing ML and DevOps Engineers the means to safely and reliably integrate ML into the
 broader software ecosystem in any organization.
 
 
 As shown below, the full ML lifecycle consists of three components: the data preparation
 loop (including ETL, Data Cleaning), the model development loop (including training, feature pre-processing,
-model validation), and model operationalization (including packaging, release, monitoring and operations). 
+model validation), and model operationalization (including packaging, release, monitoring and operations).
 Verta comes in during model development and provides model versioning capabilities via ModelDB.
 ModelDB then serves as the connection between the development and operationalization phases.
 During the operationalization phase, Verta provides modular components for model deployment, release,
@@ -24,18 +24,18 @@ monitoring, and maintenance.
 
 Verta is an open-core platform; i.e., the platform is based on core open-source technology
 developed by the Verta team that is freely available. Find more information about our
-open-source technology `here <https://verta.ai/open-source>`_ and in subsequent
+open-source technology |open source| and in subsequent
 sections.
 
-Verta provides MLOps functionality in three key areas: **model versioning and metadata**, 
+Verta provides MLOps functionality in three key areas: **model versioning and metadata**,
 **model deployment and release**, and **real-time model monitoring**.
 
 ===========================
 Model Versioning & Metadata
 ===========================
 
-The first step to enable operationalization of ML models is to make them reproducible and 
-associate governance data with them. Verta's open-source `ModelDB <https://github.com/VertaAI/modeldb>`_ 
+The first step to enable operationalization of ML models is to make them reproducible and
+associate governance data with them. Verta's open-source |ModelDB repo|
 component is the only system to provide full model versioning and reproducibility along
 with a rich metadata system.
 
@@ -46,24 +46,24 @@ in your ML workflows.
 Model Deployment & Release
 ==========================
 
-The most challenging and yet crucial operation in operationalization of models is model 
+The most challenging and yet crucial operation in operationalization of models is model
 deployment and release.
-Due to the diversity of ML frameworks and libraries, along with the  disparate systems 
+Due to the diversity of ML frameworks and libraries, along with the  disparate systems
 for ML development vs. software delivery systems, it takes many months to release models
 into products.
 
-One of Verta's key innovations is our open-core model deployment and release system that 
+One of Verta's key innovations is our open-core model deployment and release system that
 works seamlessly with models built in over a dozen frameworks and languages, and integrates
 with state-of-the-art DevOps and software delivery systems.
 
-Head over to :doc:`overview/deployment` to deploy your models. 
+Head over to :doc:`overview/deployment` to deploy your models.
 
 ==========================
 Real-time Model Monitoring
 ==========================
 
 Once a model is deployed, close monitoring is required, both at the systems level  (e.g. CPU,
-memory, network) as well as the feature and data level to ensure that the model is performing 
+memory, network) as well as the feature and data level to ensure that the model is performing
 at the highest levels and rapidly remedy production incidents.
 
 Verta's model monitoring provides both system and data monitoring to ensure real-time model
@@ -87,3 +87,12 @@ Ready to get started? We recommend the following:
     Deployment & Release <overview/deployment>
     Model Monitoring <overview/monitoring>
     ModelDB <overview/modeldb>
+
+
+.. |open source| raw:: html
+
+    <a href="https://verta.ai/open-source" target="_blank">here</a>
+
+.. |ModelDB repo| raw:: html
+
+    <a href="https://github.com/VertaAI/modeldb" target="_blank">ModelDB</a>


### PR DESCRIPTION
The only links I didn't touch are the ones in [the changelog](https://docs.verta.ai/en/master/changelog.html) and [the examples](https://docs.verta.ai/en/master/examples/examples.html) because it negates our bullet-point-list styling (we made them nicely spaced, nicely sized) presumably because it's overriding Sphinx's content generation by injecting raw HTML.