### PR TITLE
VR-3736: Allow slashes (and more!) in branch names

### DIFF
--- a/client/verta/tests/test_versioning/test_repository.py
+++ b/client/verta/tests/test_versioning/test_repository.py
@@ -191,6 +191,24 @@ class TestBranch:
         finally:
             utils.delete_commit(repository.id, commit.id, repository._conn)
 
+    def test_slash(self, repository):
+        branch = "banana/coconut"
+
+        blob = verta.environment.Python(["a==1"])
+        path = "a"
+
+        commit = repository.get_commit()
+        commit.update(path, blob)
+        commit.save(message="a")
+        try:
+            commit.branch(branch)
+
+            retrieved_commit = repository.get_commit(branch=branch)
+            assert retrieved_commit.id == commit.id
+            assert retrieved_commit.branch_name == branch
+        finally:
+            utils.delete_commit(repository.id, commit.id, repository._conn)
+
     def test_change(self, repository):
         branch = "banana"
 

--- a/client/verta/verta/_repository/commit.py
+++ b/client/verta/verta/_repository/commit.py
@@ -9,6 +9,7 @@ import heapq
 from .._protos.public.modeldb.versioning import VersioningService_pb2 as _VersioningService
 
 from ..external import six
+from ..external.six.moves import urllib  # pylint: disable=import-error
 
 from .._internal_utils import _utils
 from .. import code
@@ -421,7 +422,7 @@ class Commit(object):
             self._conn.scheme,
             self._conn.socket,
             self._repo.id,
-            branch,
+            urllib.parse.quote(branch, safe=''),  # URL-encode slashes, etc.
         )
         response = _utils.make_request("PUT", endpoint, self._conn, json=data)
         _utils.raise_for_http_error(response)


### PR DESCRIPTION
Blocked on UAC being surprised by `%2F`s in the URL, and returning a `400`.