### PR TITLE
VR-3726: Make dataset type more transparent to user

### DIFF
--- a/client/verta/tests/test_datasets.py
+++ b/client/verta/tests/test_datasets.py
@@ -50,14 +50,14 @@ class TestBaseDatasets:
         dataset = Dataset(client._conn, client._conf,
                           dataset_type=_DatasetService.DatasetTypeEnum.PATH)
         created_datasets.append(dataset)
-        assert dataset.dataset_type == _DatasetService.DatasetTypeEnum.PATH
+        assert dataset._dataset_type == _DatasetService.DatasetTypeEnum.PATH
         assert dataset.id
 
     def test_creation_by_id(self, client, created_datasets):
         dataset = Dataset(client._conn, client._conf,
                           dataset_type=_DatasetService.DatasetTypeEnum.PATH)
         created_datasets.append(dataset)
-        assert dataset.dataset_type == _DatasetService.DatasetTypeEnum.PATH
+        assert dataset._dataset_type == _DatasetService.DatasetTypeEnum.PATH
         assert dataset.id
 
         same_dataset = Dataset(client._conn, client._conf,
@@ -74,7 +74,7 @@ class TestBaseDatasetVersions:
                                  dataset_id=dataset.id,
                                  dataset_version_info=_DatasetVersionService.PathDatasetVersionInfo(),
                                  dataset_type=_DatasetService.DatasetTypeEnum.PATH)
-        assert version.dataset_type == _DatasetService.DatasetTypeEnum.PATH
+        assert version._dataset_type == _DatasetService.DatasetTypeEnum.PATH
         assert version.id
 
     def test_creation_by_id(self, client, created_datasets):
@@ -85,7 +85,7 @@ class TestBaseDatasetVersions:
                                  dataset_id=dataset.id,
                                  dataset_version_info=_DatasetVersionService.PathDatasetVersionInfo(),
                                  dataset_type=_DatasetService.DatasetTypeEnum.PATH)
-        assert version.dataset_type == _DatasetService.DatasetTypeEnum.PATH
+        assert version._dataset_type == _DatasetService.DatasetTypeEnum.PATH
         assert version.id
 
         same_version = DatasetVersion(client._conn, client._conf,
@@ -108,14 +108,14 @@ class TestPathDatasets:
         dataset = Dataset(client._conn, client._conf,
                           dataset_type=_DatasetService.DatasetTypeEnum.PATH)
         created_datasets.append(dataset)
-        assert dataset.dataset_type == _DatasetService.DatasetTypeEnum.PATH
+        assert dataset._dataset_type == _DatasetService.DatasetTypeEnum.PATH
         assert dataset.id
 
     def test_creation_by_id(self, client, created_datasets):
         dataset = Dataset(client._conn, client._conf,
                           dataset_type=_DatasetService.DatasetTypeEnum.PATH)
         created_datasets.append(dataset)
-        assert dataset.dataset_type == _DatasetService.DatasetTypeEnum.PATH
+        assert dataset._dataset_type == _DatasetService.DatasetTypeEnum.PATH
         assert dataset.id
 
         same_dataset = Dataset(client._conn, client._conf,
@@ -127,13 +127,13 @@ class TestClientDatasetFunctions:
     def test_creation_from_scratch_client_api(self, client, created_datasets):
         dataset = client.set_dataset(type="s3")
         created_datasets.append(dataset)
-        assert dataset.dataset_type == _DatasetService.DatasetTypeEnum.PATH
+        assert dataset._dataset_type == _DatasetService.DatasetTypeEnum.PATH
         assert dataset.id
 
     def test_creation_by_id_client_api(self, client, created_datasets):
         dataset = client.set_dataset(type="s3")
         created_datasets.append(dataset)
-        assert dataset.dataset_type == _DatasetService.DatasetTypeEnum.PATH
+        assert dataset._dataset_type == _DatasetService.DatasetTypeEnum.PATH
         assert dataset.id
 
         same_dataset = client.set_dataset(id=dataset.id)
@@ -143,7 +143,7 @@ class TestClientDatasetFunctions:
     def test_get_dataset_client_api(self, client, created_datasets):
         dataset = client.set_dataset(type="s3")
         created_datasets.append(dataset)
-        assert dataset.dataset_type == _DatasetService.DatasetTypeEnum.PATH
+        assert dataset._dataset_type == _DatasetService.DatasetTypeEnum.PATH
         assert dataset.id
 
         same_dataset = client.get_dataset(id=dataset.id)
@@ -158,18 +158,18 @@ class TestClientDatasetFunctions:
         tags = ["test1-{}".format(_utils.now()), "test2-{}".format(_utils.now())]
         dataset1 = client.set_dataset(type="big query", tags=tags)
         created_datasets.append(dataset1)
-        assert dataset1.dataset_type == _DatasetService.DatasetTypeEnum.QUERY
+        assert dataset1._dataset_type == _DatasetService.DatasetTypeEnum.QUERY
         assert dataset1.id
 
         dataset2 = client.set_dataset(type="s3", tags=["test1"])
         created_datasets.append(dataset2)
-        assert dataset2.dataset_type == _DatasetService.DatasetTypeEnum.PATH
+        assert dataset2._dataset_type == _DatasetService.DatasetTypeEnum.PATH
         assert dataset2.id
 
         # TODO: update once RAW is supported
         # dataset3 = client.set_dataset(type="raw")
         # created_datasets.append(dataset3)
-        # assert dataset3.dataset_type == _DatasetService.DatasetTypeEnum.RAW
+        # assert dataset3._dataset_type == _DatasetService.DatasetTypeEnum.RAW
         # assert dataset3.id
 
         # datasets = client.find_datasets()
@@ -200,7 +200,7 @@ class TestClientDatasetVersionFunctions:
         created_datasets.append(dataset)
 
         version = dataset.create_version(__file__)
-        assert version.dataset_type == _DatasetService.DatasetTypeEnum.PATH
+        assert version._dataset_type == _DatasetService.DatasetTypeEnum.PATH
         assert version.id
 
     def test_creation_by_id(self, client, created_datasets):
@@ -208,7 +208,7 @@ class TestClientDatasetVersionFunctions:
         created_datasets.append(dataset)
 
         version = dataset.create_version(__file__)
-        assert version.dataset_type == _DatasetService.DatasetTypeEnum.PATH
+        assert version._dataset_type == _DatasetService.DatasetTypeEnum.PATH
         assert version.id
 
         same_version = client.get_dataset_version(id=version.id)
@@ -219,11 +219,11 @@ class TestClientDatasetVersionFunctions:
         created_datasets.append(dataset)
 
         version1 = dataset.create_version(path=__file__)
-        assert version1.dataset_type == _DatasetService.DatasetTypeEnum.PATH
+        assert version1._dataset_type == _DatasetService.DatasetTypeEnum.PATH
         assert version1.id
 
         version2 = dataset.create_version(path=pytest.__file__)
-        assert version2.dataset_type == _DatasetService.DatasetTypeEnum.PATH
+        assert version2._dataset_type == _DatasetService.DatasetTypeEnum.PATH
         assert version2.id
 
         versions = dataset.get_all_versions()
@@ -261,7 +261,7 @@ class TestPathBasedDatasetVersions:
                                  dataset_id=dataset.id,
                                  dataset_version_info=_DatasetVersionService.PathDatasetVersionInfo(),
                                  dataset_type=_DatasetService.DatasetTypeEnum.PATH)
-        assert version.dataset_type == _DatasetService.DatasetTypeEnum.PATH
+        assert version._dataset_type == _DatasetService.DatasetTypeEnum.PATH
         assert version.id
 
     def test_creation_by_id(self, client, created_datasets):
@@ -273,7 +273,7 @@ class TestPathBasedDatasetVersions:
                                  dataset_id=dataset.id,
                                  dataset_version_info=_DatasetVersionService.PathDatasetVersionInfo(),
                                  dataset_type=_DatasetService.DatasetTypeEnum.PATH)
-        assert version.dataset_type == _DatasetService.DatasetTypeEnum.PATH
+        assert version._dataset_type == _DatasetService.DatasetTypeEnum.PATH
         assert version.id
 
         same_version = DatasetVersion(client._conn, client._conf,
@@ -286,14 +286,14 @@ class TestQueryDatasets:
         dataset = Dataset(client._conn, client._conf,
                           dataset_type=_DatasetService.DatasetTypeEnum.DatasetType.QUERY)
         created_datasets.append(dataset)
-        assert dataset.dataset_type == _DatasetService.DatasetTypeEnum.DatasetType.QUERY
+        assert dataset._dataset_type == _DatasetService.DatasetTypeEnum.DatasetType.QUERY
         assert dataset.id
 
     def test_creation_by_id(self, client, created_datasets):
         dataset = Dataset(client._conn, client._conf,
                           dataset_type=_DatasetService.DatasetTypeEnum.DatasetType.QUERY)
         created_datasets.append(dataset)
-        assert dataset.dataset_type == _DatasetService.DatasetTypeEnum.DatasetType.QUERY
+        assert dataset._dataset_type == _DatasetService.DatasetTypeEnum.DatasetType.QUERY
         assert dataset.id
 
         same_dataset = Dataset(client._conn, client._conf,
@@ -311,7 +311,7 @@ class TestQueryDatasetVersions:
                                  dataset_id=dataset.id,
                                  dataset_version_info=_DatasetVersionService.QueryDatasetVersionInfo(),
                                  dataset_type=_DatasetService.DatasetTypeEnum.QUERY)
-        assert version.dataset_type == _DatasetService.DatasetTypeEnum.QUERY
+        assert version._dataset_type == _DatasetService.DatasetTypeEnum.QUERY
         assert version.id
 
     def test_creation_by_id(self, client, created_datasets):
@@ -323,7 +323,7 @@ class TestQueryDatasetVersions:
                                  dataset_id=dataset.id,
                                  dataset_version_info=_DatasetVersionService.QueryDatasetVersionInfo(),
                                  dataset_type=_DatasetService.DatasetTypeEnum.QUERY)
-        assert version.dataset_type == _DatasetService.DatasetTypeEnum.QUERY
+        assert version._dataset_type == _DatasetService.DatasetTypeEnum.QUERY
         assert version.id
 
         same_version = DatasetVersion(client._conn, client._conf,
@@ -387,7 +387,7 @@ class TestS3ClientFunctions:
         try:
             dataset = client.set_dataset(type="s3")
             created_datasets.append(dataset)
-            assert dataset.dataset_type == _DatasetService.DatasetTypeEnum.PATH
+            assert dataset._dataset_type == _DatasetService.DatasetTypeEnum.PATH
         except botocore.exceptions.ClientError:
             pytest.skip("insufficient AWS credentials")
 
@@ -408,7 +408,7 @@ class TestFilesystemClientFunctions:
     def test_filesystem_dataset_creation(self, client, created_datasets):
         dataset = client.set_dataset(type="local")
         created_datasets.append(dataset)
-        assert dataset.dataset_type == _DatasetService.DatasetTypeEnum.PATH
+        assert dataset._dataset_type == _DatasetService.DatasetTypeEnum.PATH
 
     def test_filesystem_dataset_version_creation(self, client, created_datasets):
         dir_name, _ = self.create_dir_with_files(num_files=3)
@@ -435,7 +435,7 @@ class TestBigQueryDatasetVersionInfo:
     def test_big_query_dataset(self, client, created_datasets):
         dataset = client.set_dataset(type="big query")
         created_datasets.append(dataset)
-        assert dataset.dataset_type == _DatasetService.DatasetTypeEnum.QUERY
+        assert dataset._dataset_type == _DatasetService.DatasetTypeEnum.QUERY
 
     def test_big_query_dataset_version_creation(self, client, bq_query, bq_location, created_datasets):
         google = pytest.importorskip("google")
@@ -459,7 +459,7 @@ class TestRDBMSDatasetVersionInfo:
     def test_rdbms_dataset(self, client, created_datasets):
         dataset = client.set_dataset(type="postgres")
         created_datasets.append(dataset)
-        assert dataset.dataset_type == _DatasetService.DatasetTypeEnum.QUERY
+        assert dataset._dataset_type == _DatasetService.DatasetTypeEnum.QUERY
 
     def test_rdbms_version_creation(self, client, created_datasets):
         dataset = client.set_dataset(type="postgres")
@@ -476,7 +476,7 @@ class TestLogDatasetVersion:
     def test_log_dataset_version(self, client, created_datasets, experiment_run):
         dataset = client.set_dataset(type="local")
         created_datasets.append(dataset)
-        assert dataset.dataset_type == _DatasetService.DatasetTypeEnum.PATH
+        assert dataset._dataset_type == _DatasetService.DatasetTypeEnum.PATH
 
         dataset_version = dataset.create_version(__file__)
         experiment_run.log_dataset_version('train', dataset_version)
@@ -488,7 +488,7 @@ class TestLogDatasetVersion:
     def test_overwrite(self, client, created_datasets, experiment_run, s3_bucket):
         dataset = client.set_dataset(type="local")
         created_datasets.append(dataset)
-        assert dataset.dataset_type == _DatasetService.DatasetTypeEnum.PATH
+        assert dataset._dataset_type == _DatasetService.DatasetTypeEnum.PATH
 
         dataset_version = dataset.create_version(__file__)
         experiment_run.log_dataset_version('train', dataset_version)

--- a/client/verta/verta/_dataset.py
+++ b/client/verta/verta/_dataset.py
@@ -83,13 +83,14 @@ class Dataset(object):
 
         # these could be updated by separate calls
         self.name = dataset.name
-        self.dataset_type = dataset.dataset_type
+        self.dataset_type = self.__class__.__name__
+        self._dataset_type = dataset.dataset_type
         self.desc = dataset.description
         self.attrs = dataset.attributes
         self.tags = dataset.tags
 
     def __repr__(self):
-        return "<Dataset \"{}\">".format(self.name)
+        return "<{} \"{}\">".format(self.__class__.__name__, self.name)
 
     @staticmethod
     def _generate_default_name():
@@ -506,7 +507,7 @@ class DatasetVersion(object):
         self.attrs = dataset_version.attributes
         self.id = dataset_version.id
         self.version = dataset_version.version
-        self.dataset_type = dataset_version.dataset_type
+        self._dataset_type = dataset_version.dataset_type
         self.dataset_version = dataset_version
         self.dataset_version_info = None
 
@@ -521,7 +522,7 @@ class DatasetVersion(object):
             msg_copy.CopyFrom(self.dataset_version_info)
             return msg_copy.__repr__()
         else:
-            return "<DatasetVersion \"{}\">".format(self.version)
+            return "<{} \"{}\">".format(self.__class__.__name__, self.version)
 
     # TODO: get by dataset_id and version is not supported on the backend
     @staticmethod


### PR DESCRIPTION
Based on a customer's feedback, this PR makes `dataset.dataset_type` a little more informative (and upgrades `__repr__()` as well).

The `dataset_type` attribute isn't actually being used anywhere (except in the tests) so this change doesn't impact any other pieces.