### PR TITLE
Delete child before deleting parent in test

### DIFF
--- a/client/verta/tests/conftest.py
+++ b/client/verta/tests/conftest.py
@@ -285,7 +285,10 @@ def commit(repository):
     yield commit
 
     if commit.id is not None:
-        utils.delete_commit(repository.id, commit.id, repository._conn)
+        try:
+            utils.delete_commit(repository.id, commit.id, repository._conn)
+        except:
+            pass  # may have already been deleted in test
 
 
 @pytest.fixture

--- a/client/verta/tests/conftest.py
+++ b/client/verta/tests/conftest.py
@@ -7,6 +7,8 @@ import random
 import shutil
 import string
 
+import requests
+
 import verta
 from verta import Client
 from verta._internal_utils import _utils
@@ -267,14 +269,9 @@ def experiment_run(client):
 def repository(client):
     name = _utils.generate_default_name()
     repo = client.get_or_create_repository(name)
-    root_id = repo.get_commit()
 
     yield repo
 
-    try:
-        utils.delete_commit(repository.id, root_id, repository._conn)
-    except:
-        pass  # may have already been deleted in test
     utils.delete_repository(repo.id, client._conn)
 
 
@@ -287,8 +284,12 @@ def commit(repository):
     if commit.id is not None:
         try:
             utils.delete_commit(repository.id, commit.id, repository._conn)
-        except:
-            pass  # may have already been deleted in test
+        except requests.HTTPError as e:
+            try:
+                if e.response.status_code == 404 and e.response.json()['code'] == 5:
+                    pass  # already deleted in test
+            except:
+                six.raise_from(e, None)
 
 
 @pytest.fixture

--- a/client/verta/tests/test_versioning/test_repository.py
+++ b/client/verta/tests/test_versioning/test_repository.py
@@ -119,7 +119,10 @@ class TestCommit:
             assert commit.get(path1)
 
             commit.save(message="banana")
-            assert commit.id != original_id
+            try:
+                assert commit.id != original_id
+            finally:
+                utils.delete_commit(commit._repo.id, commit.id, commit._conn)
         finally:
             utils.delete_commit(commit._repo.id, original_id, commit._conn)
 


### PR DESCRIPTION
The backend now returns a `Bad Request` when deleting a parent commit while it has children:
```python
{'thread': 'grpc-default-executor-56',
 'level': 'WARN',
 'loggerName': 'ai.verta.modeldb.utils.ModelDBUtils',
 'message': 'Exception occured: Commit has the child, please delete child commit first',
 'endOfBatch': False,
 'loggerFqcn': 'org.apache.logging.log4j.spi.AbstractLogger',
 'instant': {'epochSecond': 1585176229, 'nanoOfSecond': 357000000},
 'threadId': 268,
 'threadPriority': 5}
```

This PR fixes a test.