### PR TITLE
VR-3885: Expand ~ to user directory

### DIFF
--- a/client/verta/verta/_dataset.py
+++ b/client/verta/verta/_dataset.py
@@ -704,7 +704,7 @@ class PathDatasetVersionInfo(object):
 
 class FilesystemDatasetVersionInfo(PathDatasetVersionInfo):
     def __init__(self, path):
-        self.base_path = os.path.abspath(path)
+        self.base_path = os.path.abspath(os.path.expanduser(path))
         super(FilesystemDatasetVersionInfo, self).__init__()
         self.location_type = _DatasetVersionService.PathLocationTypeEnum.LOCAL_FILE_SYSTEM
         self.dataset_part_infos = self.get_dataset_part_infos()

--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -322,6 +322,7 @@ def find_filepaths(paths, extensions=None, include_hidden=False, include_venv=Fa
     """
     if isinstance(paths, six.string_types):
         paths = [paths]
+    paths = list(map(os.path.expanduser, paths))
 
     if isinstance(extensions, six.string_types):
         extensions = [extensions]

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -968,6 +968,7 @@ class _ModelDBEntity(object):
                 except OSError:  # script not found
                     print("unable to find code file; skipping")
         else:
+            exec_path = os.path.expanduser(exec_path)
             if not os.path.isfile(exec_path):
                 raise ValueError("`exec_path` \"{}\" must be a valid filepath".format(exec_path))
 
@@ -1981,6 +1982,7 @@ class ExperimentRun(_ModelDBEntity):
 
         """
         if isinstance(artifact, six.string_types):
+            os.path.expanduser(artifact)
             artifact = open(artifact, 'rb')
 
         if hasattr(artifact, 'read') and method is not None:  # already a verta-produced stream
@@ -3406,6 +3408,7 @@ class ExperimentRun(_ModelDBEntity):
         if isinstance(paths, six.string_types):
             paths = [paths]
         if paths is not None:
+            paths = list(map(os.path.expanduser, paths))
             paths = list(map(os.path.abspath, paths))
 
         # collect local sys paths

--- a/client/verta/verta/code/_notebook.py
+++ b/client/verta/verta/code/_notebook.py
@@ -53,6 +53,7 @@ class Notebook(_code._Code):
         super(Notebook, self).__init__()
 
         if notebook_path is not None:
+            notebook_path = os.path.expanduser(notebook_path)
             self._msg.notebook.path.CopyFrom(_path.Path(notebook_path)._msg.path.components[0])
             try:
                 self._git_blob = _git.Git()

--- a/client/verta/verta/dataset/_path.py
+++ b/client/verta/verta/dataset/_path.py
@@ -40,6 +40,7 @@ class Path(_dataset._Dataset):
     def __init__(self, paths):
         if isinstance(paths, six.string_types):
             paths = [paths]
+        paths = map(os.path.expanduser, paths)
 
         super(Path, self).__init__()
 

--- a/client/verta/verta/environment/_python.py
+++ b/client/verta/verta/environment/_python.py
@@ -3,6 +3,7 @@
 from __future__ import print_function
 
 import copy
+import os
 import sys
 
 from ..external import six
@@ -210,6 +211,7 @@ class Python(_environment._Environment):
             Requirement specifiers.
 
         """
+        filepath = os.path.expanduser(filepath)
         with open(filepath, 'r') as f:
             return _pip_requirements_utils.clean_reqs_file_lines(f.readlines())
 


### PR DESCRIPTION
I kind of wish `os.path` had a way to enable this behavior across the module, but it doesn't so I manually looked for places where we take a filepath from the user.

I'm certain I got all the spots in the versioning ingredient submodules. I'm not certain I got everything in the rest of the client 😵 