### PR TITLE
Have describe() print instead of returning str

### DIFF
--- a/client/verta/verta/_repository/commit.py
+++ b/client/verta/verta/_repository/commit.py
@@ -78,7 +78,7 @@ class Commit(object):
             contents = "<no contents>"
 
         components = [self.__repr__(), 'Contents:', contents]
-        return '\n'.join(components)
+        print('\n'.join(components))
 
     def __repr__(self):
         branch_and_tag = ' '.join((


### PR DESCRIPTION
Probably makes more sense than the current
<img width="695" alt="Screen Shot 2020-04-13 at 2 52 38 PM" src="https://user-images.githubusercontent.com/7754936/79164990-0bd0fa00-7d97-11ea-98af-a6d3db35cb47.png">
