### PR TITLE
Update index.rst

### DIFF
--- a/client/verta/docs/index.rst
+++ b/client/verta/docs/index.rst
@@ -10,7 +10,7 @@ and access the API reference.
 
     Verta <verta>
     Quickstart <quickstart>
-    Examples & Tutorials <examples>
+    Tutorials & Examples <examples>
     API Reference <api_reference>
     Support & Community <support>
     Resources <learn>


### PR DESCRIPTION
The sidebar lists "Tutorials" then "Examples", and this discrepancy keeps making me misclick
<img width="172" alt="Screen Shot 2020-04-14 at 11 11 30 AM" src="https://user-images.githubusercontent.com/7754936/79258920-b8b38180-7e40-11ea-813b-fa4ddaea5bef.png">
