### PR TITLE
VR-3505: Capture versioning information from S3

### DIFF
--- a/client/verta/tests/test_versioning/test_dataset.py
+++ b/client/verta/tests/test_versioning/test_dataset.py
@@ -95,7 +95,7 @@ class TestS3:
         dataset = verta.dataset.S3("s3://{}/{}".format(bucket, key))
 
         assert len(dataset._msg.s3.components) == 1
-        assert dataset._msg.s3.components[0].version_id == latest_version_id
+        assert dataset._msg.s3.components[0].s3_version_id == latest_version_id
 
     @pytest.mark.skip("Not yet implemented.")
     def test_versioned_object_by_id(self):

--- a/client/verta/tests/test_versioning/test_dataset.py
+++ b/client/verta/tests/test_versioning/test_dataset.py
@@ -60,6 +60,7 @@ class TestS3:
 
         assert len(multiple_dataset._msg.s3.components) == len(bucket_dataset._msg.s3.components)
 
+    @pytest.mark.skip("Not yet implemented.")
     def test_versioned_bucket(self):
         pass
 
@@ -79,6 +80,7 @@ class TestS3:
 
         assert dataset._msg.s3.components[0].version_id == latest_version_id
 
+    @pytest.mark.skip("Not yet implemented.")
     def test_versioned_object_by_id(self):
         pass
 

--- a/client/verta/tests/test_versioning/test_dataset.py
+++ b/client/verta/tests/test_versioning/test_dataset.py
@@ -102,6 +102,7 @@ class TestS3:
 
         bucket = "verta-versioned-bucket"
         key = "data/census-train.csv"
+        s3_url = "s3://{}/{}".format(bucket, key)
 
         # pick a version that's not the latest
         version_ids = [
@@ -113,7 +114,7 @@ class TestS3:
         ]
         version_id = version_ids[0]
 
-        s3_loc = verta.dataset._s3.S3Location(bucket, key, version_id)
+        s3_loc = verta.dataset._s3.S3Location(s3_url, version_id)
         dataset = verta.dataset.S3(s3_loc)
 
         assert len(dataset._msg.s3.components) == 1

--- a/client/verta/tests/test_versioning/test_dataset.py
+++ b/client/verta/tests/test_versioning/test_dataset.py
@@ -97,9 +97,27 @@ class TestS3:
         assert len(dataset._msg.s3.components) == 1
         assert dataset._msg.s3.components[0].s3_version_id == latest_version_id
 
-    @pytest.mark.skip("Not yet implemented.")
     def test_versioned_object_by_id(self):
-        pass
+        s3 = pytest.importorskip("boto3").client('s3')
+
+        bucket = "verta-versioned-bucket"
+        key = "data/census-train.csv"
+
+        # pick a version that's not the latest
+        version_ids = [
+            obj['VersionId']
+            for obj in
+            s3.list_object_versions(Bucket=bucket)['Versions']
+            if not obj['IsLatest']
+            and obj['Key'] == key
+        ]
+        version_id = version_ids[0]
+
+        s3_loc = verta.dataset._s3._S3Location(bucket, key, version_id)
+        dataset = verta.dataset.S3(s3_loc)
+
+        assert len(dataset._msg.s3.components) == 1
+        assert dataset._msg.s3.components[0].s3_version_id == version_id
 
     def test_repr(self):
         """Tests that __repr__() executes without error"""

--- a/client/verta/tests/test_versioning/test_dataset.py
+++ b/client/verta/tests/test_versioning/test_dataset.py
@@ -113,7 +113,7 @@ class TestS3:
         ]
         version_id = version_ids[0]
 
-        s3_loc = verta.dataset._s3._S3Location(bucket, key, version_id)
+        s3_loc = verta.dataset._s3.S3Location(bucket, key, version_id)
         dataset = verta.dataset.S3(s3_loc)
 
         assert len(dataset._msg.s3.components) == 1

--- a/client/verta/tests/test_versioning/test_dataset.py
+++ b/client/verta/tests/test_versioning/test_dataset.py
@@ -60,6 +60,28 @@ class TestS3:
 
         assert len(multiple_dataset._msg.s3.components) == len(bucket_dataset._msg.s3.components)
 
+    def test_versioned_bucket(self):
+        pass
+
+    def test_versioned_object(self):
+        boto3 = pytest.importorskip("boto3")
+        s3 = boto3.client('s3')
+
+        bucket = "verta-versioned-bucket"
+        key = "data/census-train.csv"
+
+        obj = s3.head_object(Bucket=bucket, Key=key)
+        latest_version_id = obj['VersionId']
+
+        dataset = verta.dataset.S3("s3://{}/{}".format(bucket, key))
+
+        assert len(dataset._msg.s3.components) == 1
+
+        assert dataset._msg.s3.components[0].version_id == latest_version_id
+
+    def test_versioned_object_by_id(self):
+        pass
+
     def test_repr(self):
         """Tests that __repr__() executes without error"""
         pytest.importorskip("boto3")

--- a/client/verta/verta/dataset/_s3.py
+++ b/client/verta/verta/dataset/_s3.py
@@ -22,8 +22,8 @@ class S3(_dataset._Dataset):
     Parameters
     ----------
     paths : list
-        List of S3 URLs of the form ``"s3://<bucket-name>/<key>"`` or objects returned by
-        :meth:`S3.location`.
+        List of S3 URLs of the form ``"s3://<bucket-name>"`` or ``"s3://<bucket-name>/<key>"``, or
+        objects returned by :meth:`S3.location`.
 
     Examples
     --------

--- a/client/verta/verta/dataset/_s3.py
+++ b/client/verta/verta/dataset/_s3.py
@@ -133,7 +133,7 @@ class S3(_dataset._Dataset):
         msg.path.size = obj.get('Size') or obj.get('ContentLength') or 0
         msg.path.last_modified_at_source = _utils.timestamp_to_ms(_utils.ensure_timestamp(obj['LastModified']))
         msg.path.md5 = obj['ETag'].strip('"')
-        if obj.get('VersionId', 'null') != 'null':
+        if obj.get('VersionId', 'null') != 'null':  # S3's API returns 'null' when there's no version ID
             msg.s3_version_id = obj['VersionId']
 
         return msg

--- a/client/verta/verta/dataset/_s3.py
+++ b/client/verta/verta/dataset/_s3.py
@@ -17,7 +17,7 @@ class S3(_dataset._Dataset):
     Captures metadata about S3 objects.
 
     If your S3 object requires additional information to identify it, such as its version ID, you
-    can use :meth:`S3.location` to do so.
+    can use :meth:`S3.location`.
 
     Parameters
     ----------

--- a/client/verta/verta/dataset/_s3.py
+++ b/client/verta/verta/dataset/_s3.py
@@ -108,7 +108,7 @@ class S3(_dataset._Dataset):
         # pylint: disable=no-member
         msg = _DatasetService.S3DatasetComponentBlob()
         msg.path.path = cls._S3_PATH.format(bucket_name, key)
-        msg.path.size = obj.get('Size') or obj['ContentLength']
+        msg.path.size = obj.get('Size') or obj.get('ContentLength') or 0
         msg.path.last_modified_at_source = _utils.timestamp_to_ms(_utils.ensure_timestamp(obj['LastModified']))
         msg.path.md5 = obj['ETag'].strip('"')
         if obj.get('VersionId', 'null') != 'null':


### PR DESCRIPTION
Still needs to be able to accept user-specified `version_id`s.
Figuring out the API is complicated because `verta.dataset.S3()` accepts either

- a single string
- a list of strings

that can be either

- a bucket
- a specific key!

I could separate out the multiple argument types into `S3.read_bucket(bucket)` and `S3.read_object(key)` utils [similar to `Python`](https://github.com/VertaAI/modeldb/blob/master/client/verta/verta/environment/_python.py#L198), but that would break the existing API and also make it more verbose to use.