### PR TITLE
VR-3794: verta remote add, verta remote use

### DIFF
--- a/client/verta/tests/test_cli.py
+++ b/client/verta/tests/test_cli.py
@@ -19,3 +19,26 @@ class TestInit:
             result = runner.invoke(cli, ['init'])
             assert not result.exception
             assert result.output.startswith("found existing config file ")
+
+
+class TestRemote:
+    def test_add(self):
+        # TODO: create a new repo and use it
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            runner.invoke(cli, ['init'])
+
+            result = runner.invoke(cli, ['remote', 'add', 'banana', 'https://www.verta.ai/'])
+            assert not result.exception
+            # TODO: assert remote added
+
+    def test_use(self):
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            runner.invoke(cli, ['init'])
+            runner.invoke(cli, ['remote', 'add', 'banana', 'https://www.verta.ai/'])
+
+            result = runner.invoke(cli, ['remote', 'use', 'banana'])
+            assert not result.exception
+            # TODO: assert remote is current

--- a/client/verta/tests/test_cli.py
+++ b/client/verta/tests/test_cli.py
@@ -1,0 +1,21 @@
+import os
+
+import pytest
+from click.testing import CliRunner
+from verta._cli import cli
+
+from verta._internal_utils import _config_utils
+
+
+class TestInit:
+    def test_init(self):
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(cli, ['init'])
+            assert not result.exception
+            assert result.output.startswith("initialized empty config file ")
+            assert os.path.isfile(_config_utils.CONFIG_YAML_FILENAME)
+
+            result = runner.invoke(cli, ['init'])
+            assert not result.exception
+            assert result.output.startswith("found existing config file ")

--- a/client/verta/verta/_cli/__init__.py
+++ b/client/verta/verta/_cli/__init__.py
@@ -15,8 +15,6 @@ from . import blob
 @click.group()
 def cli():
     """ModelDB versioning CLI for snapshotting and tracking model ingredients."""
-    # TODO: load config and pass content (or None) to subcommands
-    # TODO: pass pointer to closest config file for writing
     pass
 
 

--- a/client/verta/verta/_internal_utils/_config_utils.py
+++ b/client/verta/verta/_internal_utils/_config_utils.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import contextlib
 import json
 import os
 
@@ -13,6 +14,46 @@ CONFIG_FILENAMES = {
     CONFIG_YAML_FILENAME,
     CONFIG_JSON_FILENAME,
 }
+
+
+@contextlib.contextmanager
+def read_config():
+    """
+    Yields the merged contents of all recursively-found config files.
+
+    """
+    # TODO: unify with Client's config methods
+    # TODO: recursively search for and merge config files
+    with open(CONFIG_YAML_FILENAME, 'r') as f:
+        config = yaml.safe_load(f)
+
+    yield config
+
+
+@contextlib.contextmanager
+def write_config():
+    """
+    Updates the nearest config file.
+
+    """
+    # TODO: unify with Client's config methods
+    # TODO: recursively search for nearest config file
+    config_filepath = CONFIG_YAML_FILENAME
+
+    if config_filepath.endswith('.yaml'):
+        load = yaml.safe_load
+        dump = yaml.dump
+    else:  # JSON
+        load = json.load
+        dump = json.dump
+
+    with open(config_filepath, 'r') as f:
+        config = load(f)
+
+    yield config
+
+    with open(config_filepath, 'w') as f:
+        dump(config, f)
 
 
 def create_empty_config_file(dirpath):


### PR DESCRIPTION
~Blocked because the tests require a way to find the nearest config file, and I felt that if I'm writing that logic, I might as well close out VR-3738 (merging found Client config files into one dict) while I'm at it.~

Actually, I can totally write tentative tests for these.