### PR TITLE
Get host from env for test

### DIFF
--- a/client/verta/tests/test_entities.py
+++ b/client/verta/tests/test_entities.py
@@ -89,26 +89,25 @@ class TestClient:
             else:
                 raise RuntimeError("faulty test; expected error")
 
-    @pytest.mark.skipif('VERTA_EMAIL' not in os.environ or 'VERTA_DEV_KEY' not in os.environ, reason="insufficient Verta credentials")
+    @pytest.mark.skipif(not all(env_var in os.environ for env_var in ('VERTA_HOST', 'VERTA_EMAIL', 'VERTA_DEV_KEY')), reason="insufficient Verta credentials")
     def test_config_file(self):
         self.config_file_with_type_util(connect = False)
 
-    @pytest.mark.skipif('VERTA_EMAIL' not in os.environ or 'VERTA_DEV_KEY' not in os.environ, reason="insufficient Verta credentials")
+    @pytest.mark.skipif(not all(env_var in os.environ for env_var in ('VERTA_HOST', 'VERTA_EMAIL', 'VERTA_DEV_KEY')), reason="insufficient Verta credentials")
     def test_config_file_connect(self):
         self.config_file_with_type_util(connect = True)
-        
+
     def config_file_with_type_util(self, connect):
         PROJECT_NAME = verta._internal_utils._utils.generate_default_name()
         DATASET_NAME = verta._internal_utils._utils.generate_default_name()
         EXPERIMENT_NAME = verta._internal_utils._utils.generate_default_name()
         CONFIG_FILENAME = "verta_config.json"
 
-        HOST = "app.verta.ai"
-        EMAIL_KEY, DEV_KEY_KEY = "VERTA_EMAIL", "VERTA_DEV_KEY"
+        HOST_KEY, EMAIL_KEY, DEV_KEY_KEY = "VERTA_HOST", "VERTA_EMAIL", "VERTA_DEV_KEY"
 
-        EMAIL, DEV_KEY = os.environ[EMAIL_KEY], os.environ[DEV_KEY_KEY]
+        HOST, EMAIL, DEV_KEY = os.environ[HOST_KEY], os.environ[EMAIL_KEY], os.environ[DEV_KEY_KEY]
         try:
-            del os.environ[EMAIL_KEY], os.environ[DEV_KEY_KEY]
+            del os.environ[HOST_KEY], os.environ[EMAIL_KEY], os.environ[DEV_KEY_KEY]
 
             try:
                 with open(CONFIG_FILENAME, 'w') as f:
@@ -152,7 +151,7 @@ class TestClient:
                 if os.path.exists(CONFIG_FILENAME):
                     os.remove(CONFIG_FILENAME)
         finally:
-            os.environ[EMAIL_KEY], os.environ[DEV_KEY_KEY] = EMAIL, DEV_KEY
+            os.environ[HOST_KEY], os.environ[EMAIL_KEY], os.environ[DEV_KEY_KEY] = HOST, EMAIL, DEV_KEY
 
 class TestEntities:
     def test_cache(self, client, strs):


### PR DESCRIPTION
Because of #537, `Client` checks the environment for a `$VERTA_HOST` before checking the config, so this test needs to be updated to account for that.

This also indicates that since #537, anyone who

- has started using the config file since it was released (exactly!) a month ago
- is relying on the config file to set their host
- has `$VERTA_HOST` set in their environment, and it's different from the confiig file

now has to update their setup. But I don't think anyone is.