### PR TITLE
Properly find and merge config files

### DIFF
--- a/client/verta/tests/conftest.py
+++ b/client/verta/tests/conftest.py
@@ -7,6 +7,7 @@ import os
 import random
 import shutil
 import string
+import tempfile
 
 import requests
 
@@ -218,6 +219,15 @@ def output_path():
             break
     else:
         raise RuntimeError("dirpath length exceeded 1024")
+    shutil.rmtree(dirpath)
+
+
+@pytest.fixture
+def tempdir():
+    dirpath = tempfile.mkdtemp()
+
+    yield dirpath
+
     shutil.rmtree(dirpath)
 
 

--- a/client/verta/verta/_internal_utils/_config_utils.py
+++ b/client/verta/verta/_internal_utils/_config_utils.py
@@ -123,9 +123,9 @@ def get_possible_config_file_dirs():
 
     """
     dirpaths = []
-    root = os.path.abspath(os.sep)
     cur_dir = os.getcwd()
-    while cur_dir != root:
+    while (not dirpaths  # first iteration (dirpaths empty)
+           or cur_dir != dirpaths[-1]):
         dirpaths.append(cur_dir)
         cur_dir = os.path.dirname(cur_dir)
     dirpaths.append(os.path.expanduser("~/.verta"))

--- a/client/verta/verta/_internal_utils/_config_utils.py
+++ b/client/verta/verta/_internal_utils/_config_utils.py
@@ -185,8 +185,8 @@ def merge(accum, other):
     """
     Merges `other` into `accum` in place.
 
-    This function will encounter bugs if values at the same location are of different types, so it
-    should only be called after the configs have been validated against the protobuf spec.
+    A ``dict`` at the same location will be updated. A ``list`` at the same location will be
+    appended to. A scalar at the same location will be overwritten.
 
     Parameters
     ----------
@@ -194,6 +194,11 @@ def merge(accum, other):
         Config (or field, if being called recursively) being accumulated.
     other : dict
         Incoming config (or field, if being called recursively).
+
+    Warnings
+    --------
+    This function will encounter bugs if values at the same location are of different types, so it
+    should only be called after the configs have been validated against the protobuf spec.
 
     Notes
     -----

--- a/client/verta/verta/_internal_utils/_config_utils.py
+++ b/client/verta/verta/_internal_utils/_config_utils.py
@@ -148,7 +148,8 @@ def find_closest_config_file():
         filepaths = CONFIG_FILENAMES.intersection(os.listdir(dirpath))
         if filepaths:
             return os.path.join(dirpath, filepaths.pop())
-    return None
+    else:
+        return None
 
 def find_config_files():
     """

--- a/client/verta/verta/_internal_utils/_config_utils.py
+++ b/client/verta/verta/_internal_utils/_config_utils.py
@@ -107,6 +107,23 @@ def get_possible_config_file_dirs():
     return dirpaths
 
 
+def find_closest_config_file():
+    """
+    Returns the location of the closest Verta config file.
+
+    Returns
+    -------
+    config_filepath: str or None
+        Path to config file.
+
+    """
+    for dirpath in get_possible_config_file_dirs():
+        # TODO: raise error if YAML and JSON in same dir
+        filepaths = CONFIG_FILENAMES.intersection(os.listdir(dirpath))
+        if filepaths:
+            return os.path.join(dirpath, filepaths.pop())
+    return None
+
 def find_config_files():
     """
     Returns the locations of accessible Verta config files.
@@ -117,13 +134,13 @@ def find_config_files():
         Paths to config files, with the closest to the current directory being first.
 
     """
-    config_filepaths = []
+    filepaths = []
     for dirpath in get_possible_config_file_dirs():
         # TODO: raise error if YAML and JSON in same dir
-        config_filepaths.extend(
+        filepaths.extend(
             os.path.join(dirpath, config_filename)
             for config_filename
             in CONFIG_FILENAMES.intersection(os.listdir(dirpath))
         )
 
-    return config_filepaths
+    return filepaths

--- a/client/verta/verta/_internal_utils/_config_utils.py
+++ b/client/verta/verta/_internal_utils/_config_utils.py
@@ -80,11 +80,11 @@ def create_empty_config_file(dirpath):
     return config_filepath
 
 
-def find_config_files():
+def get_possible_config_file_dirs():
     """
-    Returns the locations of accessible Verta config files.
+    Returns the directories where config files could be found.
 
-    Config files are searched for in the following locations, in order:
+    Config files may be found in the following locations, in order:
 
     * current directory
     * parent directories until the root
@@ -92,19 +92,33 @@ def find_config_files():
 
     Returns
     -------
+    dirpaths : list of str
+        Directories that could contain config files, with the closest to the current directory
+        being first.
+
+    """
+    dirpaths = []
+    cur_dir = os.getcwd()
+    while cur_dir:
+        dirpaths.append(cur_dir)
+        cur_dir = os.path.dirname(cur_dir)
+    dirpaths.append(os.path.expanduser("~/.verta"))
+
+    return dirpaths
+
+
+def find_config_files():
+    """
+    Returns the locations of accessible Verta config files.
+
+    Returns
+    -------
     config_filepaths : list of str
         Paths to config files, with the closest to the current directory being first.
 
     """
-    dirs_to_search = []
-    cur_dir = os.getcwd()
-    while cur_dir:
-        dirs_to_search.append(cur_dir)
-        cur_dir = os.path.dirname(cur_dir)
-    dirs_to_search.append(os.path.expanduser("~/.verta"))
-
     config_filepaths = []
-    for dirpath in dirs_to_search:
+    for dirpath in get_possible_config_file_dirs():
         # TODO: raise error if YAML and JSON in same dir
         config_filepaths.extend(
             os.path.join(dirpath, config_filename)

--- a/client/verta/verta/_internal_utils/_config_utils.py
+++ b/client/verta/verta/_internal_utils/_config_utils.py
@@ -34,8 +34,6 @@ def read_config():
         Merged contents of all accessible config files.
 
     """
-    # TODO: unify with Client's config methods
-
     config = {}
     for filepath in reversed(find_config_files()):
         merge(config, load(filepath))
@@ -54,7 +52,6 @@ def write_config():
         Contents of the nearest config file.
 
     """
-    # TODO: unify with Client's config methods
     config_filepath = find_closest_config_file()
 
     config = load(config_filepath)

--- a/client/verta/verta/_internal_utils/_config_utils.py
+++ b/client/verta/verta/_internal_utils/_config_utils.py
@@ -166,3 +166,33 @@ def find_config_files():
         )
 
     return filepaths
+
+
+def merge(accum, other):
+    """
+    Merges `other` into `accum` in place.
+
+    This function will encounter bugs if values at the same location are of different types, so it
+    should only be called after the configs have been validated against the protobuf spec.
+
+    Parameters
+    ----------
+    accum : dict
+        Config (or field, if being called recursively) being accumulated.
+    other : dict
+        Incoming config (or field, if being called recursively).
+
+    Notes
+    -----
+    Adapted from https://stackoverflow.com/a/20666342/8651995.
+
+    """
+    for key, value in other.items():
+        if isinstance(value, dict):
+            node = accum.setdefault(key, {})
+            merge(node, value)
+        elif isinstance(value, list):
+            node = accum.set_default(key, [])
+            node.extend(value)
+        else:
+            accum[key] = value

--- a/client/verta/verta/_internal_utils/_config_utils.py
+++ b/client/verta/verta/_internal_utils/_config_utils.py
@@ -120,8 +120,9 @@ def get_possible_config_file_dirs():
 
     """
     dirpaths = []
+    root = os.path.abspath(os.sep)
     cur_dir = os.getcwd()
-    while cur_dir:
+    while cur_dir != root:
         dirpaths.append(cur_dir)
         cur_dir = os.path.dirname(cur_dir)
     dirpaths.append(os.path.expanduser("~/.verta"))

--- a/client/verta/verta/_internal_utils/_config_utils.py
+++ b/client/verta/verta/_internal_utils/_config_utils.py
@@ -6,6 +6,10 @@ import os
 
 import yaml
 
+from .._protos.public.client import Config_pb2 as _ConfigProtos
+
+from . import _utils
+
 
 # TODO: make this a named tuple, if it would help readability
 CONFIG_YAML_FILENAME = "verta_config.yaml"
@@ -66,6 +70,8 @@ def load(config_filepath):
             config = yaml.safe_load(f)
         else:  # JSON
             config = json.load(f)
+
+    validate(config)
 
     return config
 
@@ -167,6 +173,14 @@ def find_config_files():
         )
 
     return filepaths
+
+
+def validate(config):
+    """Validates `config` against the protobuf spec."""
+    _utils.json_to_proto(
+        config, _ConfigProtos.Config,
+        ignore_unknown_fields=True,  # TODO: reset to False when protos are impl
+    )
 
 
 def merge(accum, other):

--- a/client/verta/verta/_internal_utils/_config_utils.py
+++ b/client/verta/verta/_internal_utils/_config_utils.py
@@ -78,3 +78,38 @@ def create_empty_config_file(dirpath):
         yaml.dump({}, f)
 
     return config_filepath
+
+
+def find_config_files():
+    """
+    Returns the locations of accessible Verta config files.
+
+    Config files are searched for in the following locations, in order:
+
+    * current directory
+    * parent directories until the root
+    * ``$HOME/.verta/``
+
+    Returns
+    -------
+    config_filepaths : list of str
+        Paths to config files, with the closest to the current directory being first.
+
+    """
+    dirs_to_search = []
+    cur_dir = os.getcwd()
+    while cur_dir:
+        dirs_to_search.append(cur_dir)
+        cur_dir = os.path.dirname(cur_dir)
+    dirs_to_search.append(os.path.expanduser("~/.verta"))
+
+    config_filepaths = []
+    for dirpath in dirs_to_search:
+        # TODO: raise error if YAML and JSON in same dir
+        config_filepaths.extend(
+            os.path.join(dirpath, config_filename)
+            for config_filename
+            in CONFIG_FILENAMES.intersection(os.listdir(dirpath))
+        )
+
+    return config_filepaths

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -30,7 +30,6 @@ from ._protos.public.modeldb import CommonService_pb2 as _CommonService
 from ._protos.public.modeldb import ProjectService_pb2 as _ProjectService
 from ._protos.public.modeldb import ExperimentService_pb2 as _ExperimentService
 from ._protos.public.modeldb import ExperimentRunService_pb2 as _ExperimentRunService
-from ._protos.public.client import Config_pb2 as _ConfigProtos
 
 from .external import six
 from .external.six.moves import cPickle as pickle  # pylint: disable=import-error, no-name-in-module
@@ -262,11 +261,7 @@ class Client(object):
             stream = open(config_file, 'r')
             self._config = yaml.load(stream, Loader=yaml.FullLoader)
             # validate config against proto spec
-            _utils.json_to_proto(
-                self._config,
-                _ConfigProtos.Config,
-                ignore_unknown_fields=False,
-            )
+            _config_utils.validate(self._config)
         else:
             self._config = {}
 

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -256,31 +256,8 @@ class Client(object):
         return _OSS_DEFAULT_WORKSPACE
 
     def _load_config(self):
-        config_file = self._find_config_in_all_dirs()
-        if config_file is not None:
-            stream = open(config_file, 'r')
-            self._config = yaml.load(stream, Loader=yaml.FullLoader)
-            # validate config against proto spec
-            _config_utils.validate(self._config)
-        else:
-            self._config = {}
-
-    def _find_config_in_all_dirs(self):
-        res = self._find_config('./', True)
-        if res is None:
-            return self._find_config("{}/.verta/".format(os.path.expanduser("~")))
-        return res
-
-    def _find_config(self, prefix, recursive=False):
-        for ff in _config_utils.CONFIG_FILENAMES:
-            if os.path.isfile(prefix + ff):
-                return prefix + ff
-        if recursive:
-            for dir in [os.path.join(prefix, o) for o in os.listdir(prefix) if os.path.isdir(os.path.join(prefix, o))]:
-                config_file = self._find_config(dir + "/", True)
-                if config_file is not None:
-                    return config_file
-        return None
+        with _config_utils.read_config() as config:
+            self._config = config
 
     def _set_from_config_if_none(self, var, resource_name):
         if var is None:


### PR DESCRIPTION
# Blocked until tests are written

The current implementation of config file loading doesn't actually satisfy our requirements:

- [it recurses into child directories to find config files, instead of searching back through parent directories](https://github.com/VertaAI/modeldb/blob/9549541/client/verta/verta/client.py#L284)
- [it loads the first-found config file, instead of merging them](https://github.com/VertaAI/modeldb/blob/9549541/client/verta/verta/client.py#L259)

This PR resolves those issues and consolidates config file utils into their own submodule to share between the Client and the CLI.