### PR TITLE
VR-4151: Always save Keras as HDF5

### DIFF
--- a/client/verta/verta/_internal_utils/_artifact_utils.py
+++ b/client/verta/verta/_internal_utils/_artifact_utils.py
@@ -16,6 +16,15 @@ except ImportError:  # joblib not installed
     pass
 
 try:
+    import tensorflow as tf
+except ImportError:
+    tf = None
+    TF_MAJOR_VERSION = None
+else:
+    TF_MAJOR_VERSION = int(tf.__version__.split('.')[0])  # TODO: use in TF integration module
+
+# TODO: use the newly-added tf = None above for this module's install checks
+try:
     from tensorflow import keras
 except ImportError:  # TensorFlow not installed
     pass
@@ -229,7 +238,11 @@ def serialize_model(model):
         elif module_name.startswith("tensorflow.python.keras"):
             model_type = "tensorflow"
             tempf = tempfile.NamedTemporaryFile()
-            model.save(tempf.name)  # Keras provides this fn
+            if (TF_MAJOR_VERSION is not None
+                    and TF_MAJOR_VERSION >= 2):  # save_format param may not exist in TF 1.X
+                model.save(tempf.name, save_format='h5')  # TF 2.X uses SavedModel by default
+            else:
+                model.save(tempf.name)
             tempf.seek(0)
             bytestream = tempf
             method = "keras"


### PR DESCRIPTION
`keras_model.save(path)` has been failing in TF 2.X
because it was trying to write a **SavedModel** to **directory** `path`,
but the Client wanted it to write an **HDF5** to **file** `path`.

This PR asserts the Client's dominance.