### PR TITLE
VR-4144: Skip spaCy models that sneak into requirements.txt

### DIFF
--- a/client/verta/tests/test_versioning/test_environment.py
+++ b/client/verta/tests/test_versioning/test_environment.py
@@ -16,7 +16,7 @@ from verta._internal_utils import _pip_requirements_utils
 @pytest.fixture
 def requirements_file():
     with tempfile.NamedTemporaryFile('w+') as tempf:
-        # create constraints file from pip freeze
+        # create requirements file from pip freeze
         pip_freeze = subprocess.check_output([sys.executable, '-m', 'pip', 'freeze'])
         pip_freeze = six.ensure_str(pip_freeze)
         tempf.write(pip_freeze)
@@ -30,7 +30,7 @@ def requirements_file():
 @pytest.fixture
 def requirements_file_without_versions():
     with tempfile.NamedTemporaryFile('w+') as tempf:
-        # create constraints file from pip freeze
+        # create requirements file from pip freeze
         pip_freeze = subprocess.check_output([sys.executable, '-m', 'pip', 'freeze'])
         pip_freeze = six.ensure_str(pip_freeze)
         stripped_pip_freeze = '\n'.join(
@@ -39,6 +39,32 @@ def requirements_file_without_versions():
             in pip_freeze.splitlines()
         )
         tempf.write(stripped_pip_freeze)
+        tempf.flush()  # flush object buffer
+        os.fsync(tempf.fileno())  # flush OS buffer
+        tempf.seek(0)
+
+        yield tempf
+
+
+@pytest.fixture
+def requirements_file_with_unsupported_lines():
+    with tempfile.NamedTemporaryFile('w+') as tempf:
+        requirements = [
+            "",
+            "# this is a comment",
+            "--no-binary :all:",
+            "--only-binary :none:",
+            "--require-hashes",
+            "--pre",
+            "--trusted-host localhost:3000",
+            "-c some_constraints.txt",
+            "-f file://dummy",
+            "-i https://pypi.org/simple",
+            "-e git+git@github.com:VertaAI/modeldb.git@master#egg=verta&subdirectory=client/verta",
+            "-r more_requirements.txt",
+            "en-core-web-sm==2.2.5",
+        ]
+        tempf.write('\n'.join(requirements))
         tempf.flush()  # flush object buffer
         os.fsync(tempf.fileno())  # flush OS buffer
         tempf.seek(0)
@@ -111,6 +137,11 @@ class TestPython:
         reqs = verta.environment.Python.read_pip_file(requirements_file_without_versions.name)
         with pytest.raises(ValueError):
             verta.environment.Python(constraints=reqs)
+
+    def test_reqs_no_unsupported_lines(self, requirements_file_with_unsupported_lines):
+        reqs = verta.environment.Python.read_pip_file(requirements_file_with_unsupported_lines.name)
+        env = verta.environment.Python(requirements=reqs)
+        assert not env._msg.python.requirements
 
     def test_no_autocapture(self):
         env_ver = verta.environment.Python(_autocapture=False)

--- a/client/verta/verta/_internal_utils/_pip_requirements_utils.py
+++ b/client/verta/verta/_internal_utils/_pip_requirements_utils.py
@@ -319,16 +319,20 @@ def clean_reqs_file_lines(requirements):
     for req in requirements:
         # https://pip.pypa.io/en/stable/reference/pip_install/#requirements-file-format
         if req.startswith(('--', '-c ', '-f ', '-i ')):
+            print("skipping unsupported option \"{}\"".format(req))
             continue
         # https://pip.pypa.io/en/stable/reference/pip_install/#vcs-support
         # TODO: upgrade protos and Client to handle VCS-installed packages
         if req.startswith(('-e ', 'git:', 'git+', 'hg+', 'svn+', 'bzr+')):
+            print("skipping unsupported VCS-installed package \"{}\"".format(req))
             continue
         # TODO: follow references to other requirements files
         if req.startswith('-r '):
+            print("skipping unsupported file reference \"{}\"".format(req))
             continue
-        # non-PyPI-installable SpaCy models
+        # non-PyPI-installable spaCy models
         if SPACY_MODEL_REGEX.match(req):
+            print("skipping non-PyPI-installable spaCy model \"{}\"".format(req))
             continue
 
         supported_requirements.append(req)

--- a/client/verta/verta/_internal_utils/_pip_requirements_utils.py
+++ b/client/verta/verta/_internal_utils/_pip_requirements_utils.py
@@ -53,12 +53,6 @@ def get_pip_freeze():
 
     req_specs = clean_reqs_file_lines(req_specs)
 
-    # remove non-PyPI-installable SpaCy models:
-    req_specs = [
-        req_spec for req_spec in req_specs
-        if not SPACY_MODEL_REGEX.match(req_spec)
-    ]
-
     return req_specs
 
 
@@ -329,5 +323,7 @@ def clean_reqs_file_lines(requirements):
     requirements = [req for req in requirements if not req.startswith(('-e ', 'git:', 'git+', 'hg+', 'svn+', 'bzr+'))]
     #     TODO: follow references to other requirements files
     requirements = [req for req in requirements if not req.startswith('-r ')]
+    #     non-PyPI-installable SpaCy models:
+    requirements = [req for req in requirements if not SPACY_MODEL_REGEX.match(req)]
 
     return requirements

--- a/client/verta/verta/_internal_utils/_pip_requirements_utils.py
+++ b/client/verta/verta/_internal_utils/_pip_requirements_utils.py
@@ -315,15 +315,22 @@ def clean_reqs_file_lines(requirements):
     requirements = [req for req in requirements if not req.startswith('#')]  # comment line
 
     # remove unsupported options
-    #     https://pip.pypa.io/en/stable/reference/pip_install/#requirements-file-format
-    requirements = [req for req in requirements if not req.startswith('--')]
-    requirements = [req for req in requirements if not req.startswith(('-c ', '-f ', '-i '))]
-    #     https://pip.pypa.io/en/stable/reference/pip_install/#vcs-support
-    #     TODO: upgrade protos and Client to handle VCS-installed packages
-    requirements = [req for req in requirements if not req.startswith(('-e ', 'git:', 'git+', 'hg+', 'svn+', 'bzr+'))]
-    #     TODO: follow references to other requirements files
-    requirements = [req for req in requirements if not req.startswith('-r ')]
-    #     non-PyPI-installable SpaCy models:
-    requirements = [req for req in requirements if not SPACY_MODEL_REGEX.match(req)]
+    supported_requirements = []
+    for req in requirements:
+        # https://pip.pypa.io/en/stable/reference/pip_install/#requirements-file-format
+        if req.startswith(('--', '-c ', '-f ', '-i ')):
+            continue
+        # https://pip.pypa.io/en/stable/reference/pip_install/#vcs-support
+        # TODO: upgrade protos and Client to handle VCS-installed packages
+        if req.startswith(('-e ', 'git:', 'git+', 'hg+', 'svn+', 'bzr+')):
+            continue
+        # TODO: follow references to other requirements files
+        if req.startswith('-r '):
+            continue
+        # non-PyPI-installable SpaCy models
+        if SPACY_MODEL_REGEX.match(req):
+            continue
 
-    return requirements
+        supported_requirements.append(req)
+
+    return supported_requirements


### PR DESCRIPTION
Filter out spaCy models in `requirements.txt` (previously, they were only filtered out when reading from the environment).

Also adds a test to verify that unsupported options are indeed being filtered out.