### PR TITLE
VR-{3283, 4119}: Support NumPy and pandas 1.X in ModelAPI

### DIFF
--- a/client/verta/tests/modelapi_hypothesis/test_modelapi.py
+++ b/client/verta/tests/modelapi_hypothesis/test_modelapi.py
@@ -12,7 +12,7 @@ import hypothesis
 from value_generator import api_and_values, series_api_and_values, dataframe_api_and_values
 
 
-pandas_skip_reason = "pandas v1.X introduces np.bool_ somewhere, which isn't supported by model API (VR-3283)"
+pandas_skip_reason = "ModelAPI's typecheck for a Series is broken in pandas v1.X (VR-4119)"
 
 
 # Verify that, given a sample created from an api, the same api can be inferred
@@ -36,7 +36,6 @@ def test_series_modelapi_and_values(series_api_and_values):
 
 
 @hypothesis.given(dataframe_api_and_values)
-@pytest.mark.skipif(int(pd.__version__.split('.')[0]) >= 1, reason=pandas_skip_reason)
 def test_dataframe_modelapi_and_values(dataframe_api_and_values):
     api, values = dataframe_api_and_values
     predicted_api = ModelAPI._data_to_api(values)

--- a/client/verta/tests/modelapi_hypothesis/test_modelapi.py
+++ b/client/verta/tests/modelapi_hypothesis/test_modelapi.py
@@ -12,9 +12,6 @@ import hypothesis
 from value_generator import api_and_values, series_api_and_values, dataframe_api_and_values
 
 
-pandas_skip_reason = "ModelAPI's typecheck for a Series is broken in pandas v1.X (VR-4119)"
-
-
 # Verify that, given a sample created from an api, the same api can be inferred
 @hypothesis.given(api_and_values)
 @pytest.mark.skipif(sys.version_info.major == 2, reason="test is flaky")
@@ -27,7 +24,6 @@ def test_modelapi_and_values(api_and_values):
 
 
 @hypothesis.given(series_api_and_values)
-@pytest.mark.skipif(int(pd.__version__.split('.')[0]) >= 1, reason=pandas_skip_reason)
 def test_series_modelapi_and_values(series_api_and_values):
     api, values = series_api_and_values
     predicted_api = ModelAPI._data_to_api(values)

--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -55,6 +55,13 @@ else:
         pass
 
 
+try:
+    import numpy as np
+except ImportError:  # NumPy not installed
+    BOOL_TYPES = (bool,)
+else:
+    BOOL_TYPES = (bool, np.bool_)
+
 _GRPC_PREFIX = "Grpc-Metadata-"
 
 _VALID_HTTP_METHODS = {'GET', 'POST', 'PUT', 'DELETE'}
@@ -423,6 +430,10 @@ def to_builtin(obj):
     cls_ = obj.__class__
     obj_class = getattr(cls_, '__name__', None)
     obj_module = getattr(cls_, '__module__', None)
+
+    # booleans
+    if isinstance(obj, BOOL_TYPES):
+        return True if obj else False
 
     # NumPy scalars
     if obj_module == "numpy" and obj_class.startswith(('int', 'uint', 'float', 'str')):

--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -441,11 +441,11 @@ def to_builtin(obj):
         return obj.item()
 
     # scientific library collections
-    if obj_module == "numpy" and obj_class == "ndarray":
+    if obj_class == "ndarray":
         return obj.tolist()
-    if obj_module == "pandas" and obj_class == "Series":
+    if obj_class == "Series":
         return obj.values.tolist()
-    if obj_module == "pandas" and obj_class == "DataFrame":
+    if obj_class == "DataFrame":
         return obj.values.tolist()
     if obj_class == "Tensor" and obj_module == "torch":
         return obj.detach().numpy().tolist()

--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -58,6 +58,7 @@ else:
 try:
     import numpy as np
 except ImportError:  # NumPy not installed
+    np = None
     BOOL_TYPES = (bool,)
 else:
     BOOL_TYPES = (bool, np.bool_)

--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -441,11 +441,11 @@ def to_builtin(obj):
         return obj.item()
 
     # scientific library collections
-    if np is not None and isinstance(obj, np.ndarray):
+    if obj_module == "numpy" and obj_class == "ndarray":
         return obj.tolist()
-    if pd is not None and isinstance(obj, pd.Series):
+    if obj_module == "pandas" and obj_class == "Series":
         return obj.values.tolist()
-    if pd is not None and isinstance(obj, pd.DataFrame):
+    if obj_module == "pandas" and obj_class == "DataFrame":
         return obj.values.tolist()
     if obj_class == "Tensor" and obj_module == "torch":
         return obj.detach().numpy().tolist()

--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -28,7 +28,7 @@ from .._protos.public.modeldb import CommonService_pb2 as _CommonService
 try:
     import pandas as pd
 except ImportError:  # pandas not installed
-    pass
+    pd = None
 
 try:
     import tensorflow as tf
@@ -441,11 +441,11 @@ def to_builtin(obj):
         return obj.item()
 
     # scientific library collections
-    if obj_class == "ndarray":
+    if np is not None and isinstance(obj, np.ndarray):
         return obj.tolist()
-    if obj_class == "Series":
+    if pd is not None and isinstance(obj, pd.Series):
         return obj.values.tolist()
-    if obj_class == "DataFrame":
+    if pd is not None and isinstance(obj, pd.DataFrame):
         return obj.values.tolist()
     if obj_class == "Tensor" and obj_module == "torch":
         return obj.detach().numpy().tolist()

--- a/client/verta/verta/utils.py
+++ b/client/verta/verta/utils.py
@@ -118,7 +118,6 @@ class ModelAPI(object):
             A model API value node.
 
         """
-        print(data, name)
         if data is None:
             return {'type': "VertaNull",
                     'name': str(name)}

--- a/client/verta/verta/utils.py
+++ b/client/verta/verta/utils.py
@@ -114,10 +114,11 @@ class ModelAPI(object):
             A model API value node.
 
         """
+        print(data, name)
         if data is None:
             return {'type': "VertaNull",
                     'name': str(name)}
-        elif isinstance(data, bool):  # did you know that `bool` is a subclass of `int`?
+        elif isinstance(data, _utils.BOOL_TYPES):  # did you know that `bool` is a subclass of `int`?
             return {'type': "VertaBool",
                     'name': str(name)}
         elif isinstance(data, numbers.Integral):

--- a/client/verta/verta/utils.py
+++ b/client/verta/verta/utils.py
@@ -73,19 +73,20 @@ class ModelAPI(object):
 
     @staticmethod
     def _data_to_api(data, name=""):
-        if pd is not None and isinstance(data, pd.DataFrame):
-            if len(set(data.columns)) < len(data.columns):
-                raise ValueError("column names must all be unique")
-            return {'type': "VertaList",
-                    'name': name,
-                    'value': [ModelAPI._data_to_api(data[name], str(name)) for name in data.columns]}
-        if pd is not None and isinstance(data, pd.Series):
-            name = data.name
-            data = data.iloc[0]
-            if hasattr(data, 'item'):
-                data = data.item()
-            # TODO: probably should use dtype instead of inferring the type?
-            return ModelAPI._single_data_to_api(data, name)
+        if pd is not None:
+            if isinstance(data, pd.DataFrame):
+                if len(set(data.columns)) < len(data.columns):
+                    raise ValueError("column names must all be unique")
+                return {'type': "VertaList",
+                        'name': name,
+                        'value': [ModelAPI._data_to_api(data[name], str(name)) for name in data.columns]}
+            if isinstance(data, pd.Series):
+                name = data.name
+                data = data.iloc[0]
+                if hasattr(data, 'item'):
+                    data = data.item()
+                # TODO: probably should use dtype instead of inferring the type?
+                return ModelAPI._single_data_to_api(data, name)
         # TODO: check if it's safe to use _utils.to_builtin()
         if tf is not None and isinstance(data, tf.Tensor):
             try:


### PR DESCRIPTION
This was the cause of the ModelAPI test failures that have been plaguing the Client for months

The problem was two-fold:

- pandas 1.X `Series` return `np.bool_`s instead of Python-builtin `bool`s, which weren't supported anywhere in the Client
- pandas 1.X `Series` no longer had a `from_array()` method, breaking `ModelAPI`'s terrible typecheck