### PR TITLE
VR-4127: Ignore S3 folders for versioning blob

### DIFF
--- a/client/verta/tests/test_versioning/test_dataset.py
+++ b/client/verta/tests/test_versioning/test_dataset.py
@@ -120,6 +120,33 @@ class TestS3:
         assert len(dataset._msg.s3.components) == 1
         assert dataset._msg.s3.components[0].s3_version_id == version_id
 
+    def test_versioned_folder(self):
+        s3 = pytest.importorskip("boto3").client('s3')
+        S3_PATH = verta.dataset.S3._S3_PATH
+
+        bucket = "verta-versioned-bucket"
+        folder = "data/"
+        s3_url = "s3://{}/{}".format(bucket, folder)
+
+        # collect latest versions of objects with folder as prefix
+        version_ids = {
+            S3_PATH.format(bucket, obj['Key']): obj['VersionId']
+            for obj in
+            s3.list_object_versions(Bucket=bucket, Prefix=folder)['Versions']
+            if obj['IsLatest']
+        }
+        for path, version_id in version_ids.items():
+            if version_id == "null":
+                # S3 returns "null" in its API, but we handle that as empty string
+                version_ids[path] = ""
+
+        dataset = verta.dataset.S3(s3_url)
+
+        for component in dataset._msg.s3.components:
+            assert component.s3_version_id == version_ids[component.path.path]
+            assert not component.path.path.endswith('/')
+            assert component.path.size != 0
+
     def test_repr(self):
         """Tests that __repr__() executes without error"""
         pytest.importorskip("boto3")

--- a/client/verta/tests/test_versioning/test_dataset.py
+++ b/client/verta/tests/test_versioning/test_dataset.py
@@ -12,7 +12,6 @@ class TestS3:
         assert len(dataset._msg.s3.components) > 1
 
         for s3_obj_metadata in (component.path for component in dataset._msg.s3.components):
-            print(s3_obj_metadata)
             assert s3_obj_metadata.path != ""
             assert s3_obj_metadata.size != 0
             assert s3_obj_metadata.last_modified_at_source != 0

--- a/client/verta/tests/test_versioning/test_dataset.py
+++ b/client/verta/tests/test_versioning/test_dataset.py
@@ -31,6 +31,16 @@ class TestS3:
         assert s3_obj_metadata.last_modified_at_source != 0
         assert s3_obj_metadata.md5 != ""
 
+    def test_nonexistent_s3_folder_error(self, strs):
+        # pylint: disable=no-member
+        pytest.importorskip("boto3")
+
+        with pytest.raises(ValueError) as excinfo:
+            verta.dataset.S3("s3://verta-starter/{}/".format(strs[0]))
+        err_msg = str(excinfo.value).strip()
+        assert err_msg.startswith("folder ")
+        assert err_msg.endswith(" does not exist")
+
     def test_s3_multiple_keys(self):
         # pylint: disable=no-member
         pytest.importorskip("boto3")

--- a/client/verta/tests/test_versioning/test_dataset.py
+++ b/client/verta/tests/test_versioning/test_dataset.py
@@ -12,6 +12,7 @@ class TestS3:
         assert len(dataset._msg.s3.components) > 1
 
         for s3_obj_metadata in (component.path for component in dataset._msg.s3.components):
+            print(s3_obj_metadata)
             assert s3_obj_metadata.path != ""
             assert s3_obj_metadata.size != 0
             assert s3_obj_metadata.last_modified_at_source != 0

--- a/client/verta/verta/dataset/_s3.py
+++ b/client/verta/verta/dataset/_s3.py
@@ -97,10 +97,15 @@ class S3(_dataset._Dataset):
         if s3_loc.key is None:
             # TODO: handle `bucket_name` not found
             for obj in s3.list_object_versions(Bucket=s3_loc.bucket)['Versions']:
+                if obj['Key'].endswith('/'):  # folder, not object
+                    continue
                 if obj['IsLatest']:
                     yield cls._get_s3_obj_metadata(obj, s3_loc.bucket, obj['Key'])
         else:
             # TODO: handle `key` not found
+            if s3_loc.key.endswith('/'):
+                s3_path = cls._S3_PATH.format(s3_loc.bucket, s3_loc.key)
+                raise ValueError("{} must be a bucket or an object, not a folder".format(s3_path))
             if s3_loc.version_id is not None:
                 # TODO: handle `version_id` not found
                 obj = s3.head_object(Bucket=s3_loc.bucket, Key=s3_loc.key, VersionId=s3_loc.version_id)

--- a/client/verta/verta/dataset/_s3.py
+++ b/client/verta/verta/dataset/_s3.py
@@ -95,11 +95,14 @@ class S3(_dataset._Dataset):
 
         if (s3_loc.key is None  # bucket
                 or s3_loc.key.endswith('/')):  # folder
-            # TODO: handle `bucket_name` and `prefix` not found
             if s3_loc.key is None:
+                # TODO: handle `bucket_name` not found
                 obj_versions = s3.list_object_versions(Bucket=s3_loc.bucket)
             else:
                 obj_versions = s3.list_object_versions(Bucket=s3_loc.bucket, Prefix=s3_loc.key)
+                if 'Versions' not in obj_versions:  # boto3 doesn't error, so we have to catch this
+                    s3_path = cls._S3_PATH.format(s3_loc.bucket, s3_loc.key)
+                    raise ValueError("folder {} not found".format(s3_path))
 
             for obj in obj_versions['Versions']:
                 if obj['Key'].endswith('/'):  # folder, not object

--- a/client/verta/verta/dataset/_s3.py
+++ b/client/verta/verta/dataset/_s3.py
@@ -99,8 +99,9 @@ class S3(_dataset._Dataset):
             for obj in s3.list_object_versions(Bucket=s3_loc.bucket)['Versions']:
                 if obj['Key'].endswith('/'):  # folder, not object
                     continue
-                if obj['IsLatest']:
-                    yield cls._get_s3_obj_metadata(obj, s3_loc.bucket, obj['Key'])
+                if not obj['IsLatest']:
+                    continue
+                yield cls._get_s3_obj_metadata(obj, s3_loc.bucket, obj['Key'])
         else:
             # TODO: handle `key` not found
             if s3_loc.key.endswith('/'):


### PR DESCRIPTION
Interestingly, the tests [should've failed](https://github.com/VertaAI/modeldb/blob/cf8926a/client/verta/tests/test_versioning/test_dataset.py#L16) since folders (with size 0) were being captured by the versioning utility.

~And they **do** fail on my machine, but they **succeed** in our automated tests. I've verified that it's not related to the installed `boto3` version. I have no idea what is causing the difference.~
edit 1: I've been able to reproduce this in run-pytest 281 (which I was running to test PR #630), so I'm not really sure what S3's deal is, here.
edit 2: Now our automated Client tests are failing. I wonder if—while testing this PR—I had changed the state of the metadata on our test bucket so that folders are now returned, when they weren't before?
