### PR TITLE
VR-3738: Fix client config merging/discovery

### DIFF
--- a/client/verta/tests/conftest.py
+++ b/client/verta/tests/conftest.py
@@ -7,6 +7,7 @@ import os
 import random
 import shutil
 import string
+import tempfile
 
 import requests
 
@@ -218,6 +219,15 @@ def output_path():
             break
     else:
         raise RuntimeError("dirpath length exceeded 1024")
+    shutil.rmtree(dirpath)
+
+
+@pytest.fixture
+def tempdir():
+    dirpath = tempfile.mkdtemp()
+
+    yield dirpath
+
     shutil.rmtree(dirpath)
 
 

--- a/client/verta/tests/test_config.py
+++ b/client/verta/tests/test_config.py
@@ -32,9 +32,9 @@ def config_filetree(tempdir):
     ]
     config_iter = iter(config_items)
 
-    # home dir
+    # ~/.verta/
     home_dir = os.path.expanduser('~')
-    with open(os.path.join(home_dir, config_filename), 'w') as f:
+    with open(os.path.join(home_dir, ".verta", config_filename), 'w') as f:
         key, value = next(config_iter)
         yaml.safe_dump({key: value}, f)
 
@@ -83,19 +83,6 @@ def config_filetree(tempdir):
             yield dict(config_items)
     finally:
         os.remove(os.path.join(home_dir, config_filename))
-
-
-@pytest.fixture
-def home_config_filepath():
-    config_filepath = os.path.join('~', "verta_config.yaml")
-    config_filepath = os.path.expanduser(config_filepath)
-
-    with open(config_filepath, 'w') as f:
-        yaml.safe_dump({}, f)
-
-    yield config_filepath
-
-    os.remove(config_filepath)
 
 
 class TestRead:

--- a/client/verta/tests/test_config.py
+++ b/client/verta/tests/test_config.py
@@ -108,7 +108,28 @@ class TestRead:
             assert config == expected_config
 
     def test_merge_and_overwrite(self, expected_config):
-        pass
+        cwd_config_filepath = os.path.abspath(_config_utils.CONFIG_YAML_FILENAME)
+
+        # pick an key from config
+        config_keys = set(expected_config.keys())
+        #     don't pick the key that's already in cwd config
+        with open(cwd_config_filepath, 'r') as f:
+            nearest_config = yaml.safe_load(f)
+            config_keys -= nearest_config.keys()
+        key = config_keys.pop()
+
+        # arbitrary new value
+        value = "NEW_VALUE"
+
+        # add item to cwd config
+        nearest_config[key] = value
+        with open(cwd_config_filepath, 'w') as f:
+            yaml.safe_dump(nearest_config, f)
+
+        # merged config has new value, not old value
+        expected_config[key] = value
+        with _config_utils.read_config() as config:
+            assert config == expected_config
 
 
 class TestWrite:
@@ -132,7 +153,7 @@ class TestWrite:
             assert new_key not in nearest_config
 
         with _config_utils.write_config() as config:
-            config.update({new_key: new_value})
+            config[new_key] = new_value
 
         # config in cwd updated with new item
         with open(cwd_config_filepath, 'r') as f:

--- a/client/verta/tests/test_config.py
+++ b/client/verta/tests/test_config.py
@@ -1,0 +1,64 @@
+import os
+
+import yaml
+
+import pytest
+
+from verta._internal_utils import _config_utils
+
+from . import utils
+
+
+@pytest.fixture
+def within_tempdir(tempdir):
+    """Creates and ``cd``s into a nested empty directory."""
+    pass # TODO: 5 parent dirs
+
+    pass # TODO: cwd
+
+    pass # TODO: children dirs (should not be picked up)
+
+    pass # TODO: cousin dirs (should not be picked up)
+
+    with utils.chdir():  # TODO: cwd
+        yield
+
+
+@pytest.fixture
+def home_config_filepath():
+    config_filepath = os.path.join('~', "verta_config.yaml")
+    config_filepath = os.path.expanduser(config_filepath)
+
+    with open(config_filepath, 'w') as f:
+        yaml.safe_dump({}, f)
+
+    yield config_filepath
+
+    os.remove(config_filepath)
+
+
+class TestRead:
+    def test_merge(self):
+        pass
+
+    def test_merge_and_overwrite(self):
+        pass
+
+    def test_ignore_children_dirs(self):
+        pass
+
+
+class TestWrite:
+    @pytest.mark.parametrize("dirpath", ['~', '.', '..'])
+    def test_create_empty(self, within_tempdir, dirpath):
+        config_filepath = _config_utils.create_empty_config_file(dirpath)
+        try:
+            with open(config_filepath, 'r') as f:
+                assert yaml.safe_load(f) == {}
+        finally:
+            os.remove(config_filepath)
+
+    def test_update_closest(self, tempdir):
+        config_filepath1 = "~"
+        config_filepath2 = "../.."
+        config_filepath3 = ".."

--- a/client/verta/tests/test_config.py
+++ b/client/verta/tests/test_config.py
@@ -72,8 +72,8 @@ def expected_config(tempdir):
 
         # cousin dirs (should not be picked up)
         cousin_dirs = [
-            os.path.join(curr_dir, "..", "..", "..", "cousinA"),
-            os.path.join(curr_dir, "..", "..", "cousinB"),
+            os.path.join(curr_dir, '..', '..', '..', "cousinA"),
+            os.path.join(curr_dir, '..', '..', "cousinB"),
         ]
         for cousin_dir in cousin_dirs:
             os.mkdir(cousin_dir)
@@ -88,8 +88,20 @@ def expected_config(tempdir):
 
 class TestRead:
     def test_discovery(self, expected_config):
-        pass
-    # NOTE: make sure this matches the fixture
+        config_filename = _config_utils.CONFIG_YAML_FILENAME
+
+        # NOTE: make sure this matches the fixture
+        expected_config_filepaths = list(map(os.path.abspath, [
+            config_filename,
+            os.path.join('..', config_filename),
+            os.path.join('..', '..', config_filename),
+            os.path.join('..', '..', '..', config_filename),
+            os.path.join('..', '..', '..', '..', config_filename),
+            os.path.join('..', '..', '..', '..', '..', config_filename),
+            os.path.join(os.path.expanduser('~'), ".verta", config_filename),
+        ]))
+
+        assert _config_utils.find_config_files() == expected_config_filepaths
 
     def test_merge(self, expected_config):
         with _config_utils.read_config() as config:

--- a/client/verta/tests/test_config.py
+++ b/client/verta/tests/test_config.py
@@ -37,6 +37,7 @@ def config_filetree(tempdir):
     with open(os.path.join(home_dir, config_filename), 'w') as f:
         key, value = next(config_iter)
         yaml.safe_dump({key: value}, f)
+
     try:  # delete home config during teardown
         # 5 parent dirs
         curr_dir = tempdir

--- a/client/verta/tests/test_config.py
+++ b/client/verta/tests/test_config.py
@@ -10,7 +10,7 @@ from . import utils
 
 
 @pytest.fixture
-def config_filetree(tempdir):
+def expected_config(tempdir):
     """
     Creates config files and ``cd``s into a nested directory.
 
@@ -87,15 +87,15 @@ def config_filetree(tempdir):
 
 
 class TestRead:
-    def test_discovery(self, config_filetree):
+    def test_discovery(self, expected_config):
         pass
     # NOTE: make sure this matches the fixture
 
-    def test_merge(self, config_filetree):
+    def test_merge(self, expected_config):
         with _config_utils.read_config() as config:
-            assert config == config_filetree
+            assert config == expected_config
 
-    def test_merge_and_overwrite(self, config_filetree):
+    def test_merge_and_overwrite(self, expected_config):
         pass
 
 
@@ -109,7 +109,7 @@ class TestWrite:
         finally:
             os.remove(config_filepath)
 
-    def test_update_closest(self, config_filetree):
+    def test_update_closest(self, expected_config):
         cwd_config_filepath = os.path.abspath(_config_utils.CONFIG_YAML_FILENAME)
         new_key = 'NEW_KEY'
         new_value = "NEW_VALUE"

--- a/client/verta/tests/test_config.py
+++ b/client/verta/tests/test_config.py
@@ -20,7 +20,7 @@ def config_filetree(tempdir):
         Expected merged config.
 
     """
-    config_filename = "verta_config.yaml"
+    config_filename = _config_utils.CONFIG_YAML_FILENAME
     config_items = [
         ('email', "hello@verta.ai"),
         ('dev_key', "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"),
@@ -94,9 +94,6 @@ class TestRead:
     def test_merge_and_overwrite(self):
         pass
 
-    def test_ignore_children_dirs(self):
-        pass
-
 
 class TestWrite:
     @pytest.mark.parametrize("dirpath", ['~', '.'])
@@ -108,5 +105,26 @@ class TestWrite:
         finally:
             os.remove(config_filepath)
 
-    def test_update_closest(self):
-        pass
+    def test_update_closest(self, config_filetree):
+        config_filename = _config_utils.CONFIG_YAML_FILENAME
+        new_key = 'NEW_KEY'
+        new_value = "NEW_VALUE"
+
+        # config in cwd does not yet have new item
+        with open(config_filename, 'r') as f:
+            nearest_config = yaml.safe_load(f)
+            assert new_key not in nearest_config
+
+        with _config_utils.write_config() as config:
+            config.update({new_key: new_value})
+
+        # config in cwd updated with new item
+        with open(config_filename, 'r') as f:
+            nearest_config = yaml.safe_load(f)
+            assert new_key in nearest_config
+            assert nearest_config[new_key] == new_value
+
+        # parent config not updated with new item
+        with open(os.path.join("..", config_filename), 'r') as f:
+            parent_config = yaml.safe_load(f)
+            assert new_key not in parent_config

--- a/client/verta/tests/test_config.py
+++ b/client/verta/tests/test_config.py
@@ -34,7 +34,8 @@ def config_filetree(tempdir):
 
     # ~/.verta/
     home_dir = os.path.expanduser('~')
-    with open(os.path.join(home_dir, ".verta", config_filename), 'w') as f:
+    home_verta_dir = os.path.join(home_dir, ".verta", config_filename)
+    with open(home_verta_dir, 'w') as f:
         key, value = next(config_iter)
         yaml.safe_dump({key: value}, f)
 
@@ -82,7 +83,7 @@ def config_filetree(tempdir):
         with utils.chdir(curr_dir):
             yield dict(config_items)
     finally:
-        os.remove(os.path.join(home_dir, config_filename))
+        os.remove(home_verta_dir)
 
 
 class TestRead:

--- a/client/verta/tests/test_config.py
+++ b/client/verta/tests/test_config.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 
 import yaml
 
@@ -34,8 +35,8 @@ def expected_config(tempdir):
 
     # ~/.verta/
     home_dir = os.path.expanduser('~')
-    home_verta_dir = os.path.join(home_dir, ".verta", config_filename)
-    with open(home_verta_dir, 'w') as f:
+    home_verta_dir = os.path.join(home_dir, ".verta")
+    with open(os.path.join(home_verta_dir, config_filename), 'w') as f:
         key, value = next(config_iter)
         yaml.safe_dump({key: value}, f)
 
@@ -83,7 +84,7 @@ def expected_config(tempdir):
         with utils.chdir(curr_dir):
             yield dict(config_items)
     finally:
-        os.remove(home_verta_dir)
+        shutil.rmtree(home_verta_dir)
 
 
 class TestRead:

--- a/client/verta/tests/test_config.py
+++ b/client/verta/tests/test_config.py
@@ -110,7 +110,7 @@ class TestRead:
     def test_merge_and_overwrite(self, expected_config):
         cwd_config_filepath = os.path.abspath(_config_utils.CONFIG_YAML_FILENAME)
 
-        # pick an key from config
+        # pick a key from config
         config_keys = set(expected_config.keys())
         #     don't pick the key that's already in cwd config
         with open(cwd_config_filepath, 'r') as f:

--- a/client/verta/tests/test_config.py
+++ b/client/verta/tests/test_config.py
@@ -36,7 +36,7 @@ def config_filetree(tempdir):
     home_dir = os.path.expanduser('~')
     with open(os.path.join(home_dir, config_filename), 'w') as f:
         key, value = next(config_iter)
-        yaml.safe_dump({key: value})
+        yaml.safe_dump({key: value}, f)
     try:  # delete home config during teardown
         # 5 parent dirs
         curr_dir = tempdir
@@ -45,14 +45,14 @@ def config_filetree(tempdir):
             os.mkdir(curr_dir)
             with open(os.path.join(curr_dir, config_filename), 'w') as f:
                 key, value = next(config_iter)
-                yaml.safe_dump({key: value})
+                yaml.safe_dump({key: value}, f)
 
         # cwd-to-be
         curr_dir = os.path.join(curr_dir, "current")
         os.mkdir(curr_dir)
         with open(os.path.join(curr_dir, config_filename), 'w') as f:
             key, value = next(config_iter)
-            yaml.safe_dump({key: value})
+            yaml.safe_dump({key: value}, f)
 
         # make sure we've used every config item
         with pytest.raises(StopIteration):
@@ -66,7 +66,7 @@ def config_filetree(tempdir):
         for child_dir in child_dirs:
             os.mkdir(child_dir)
             with open(os.path.join(child_dir, config_filename), 'w') as f:
-                yaml.safe_dump({'INVALID_KEY': "INVALID_VALUE"})
+                yaml.safe_dump({'INVALID_KEY': "INVALID_VALUE"}, f)
 
         # cousin dirs (should not be picked up)
         cousin_dirs = [
@@ -76,7 +76,7 @@ def config_filetree(tempdir):
         for cousin_dir in cousin_dirs:
             os.mkdir(cousin_dir)
             with open(os.path.join(cousin_dir, config_filename), 'w') as f:
-                yaml.safe_dump({'INVALID_KEY': "INVALID_VALUE"})
+                yaml.safe_dump({'INVALID_KEY': "INVALID_VALUE"}, f)
 
         with utils.chdir(curr_dir):
             yield dict(config_items)
@@ -98,8 +98,9 @@ def home_config_filepath():
 
 
 class TestRead:
-    def test_merge(self):
-        pass
+    def test_merge(self, config_filetree):
+        with _config_utils.read_config() as config:
+            assert config == config_filetree
 
     def test_merge_and_overwrite(self):
         pass
@@ -118,7 +119,5 @@ class TestWrite:
         finally:
             os.remove(config_filepath)
 
-    def test_update_closest(self, config_filetree):
-        config_filepath1 = "~"
-        config_filepath2 = "../.."
-        config_filepath3 = ".."
+    def test_update_closest(self):
+        pass

--- a/client/verta/verta/_internal_utils/_config_utils.py
+++ b/client/verta/verta/_internal_utils/_config_utils.py
@@ -123,9 +123,9 @@ def get_possible_config_file_dirs():
 
     """
     dirpaths = []
-    root = os.path.abspath(os.sep)
     cur_dir = os.getcwd()
-    while cur_dir != root:
+    while (not dirpaths  # first iteration (dirpaths empty)
+           or cur_dir != dirpaths[-1]):
         dirpaths.append(cur_dir)
         cur_dir = os.path.dirname(cur_dir)
     dirpaths.append(os.path.expanduser("~/.verta"))

--- a/client/verta/verta/_internal_utils/_config_utils.py
+++ b/client/verta/verta/_internal_utils/_config_utils.py
@@ -185,8 +185,8 @@ def merge(accum, other):
     """
     Merges `other` into `accum` in place.
 
-    This function will encounter bugs if values at the same location are of different types, so it
-    should only be called after the configs have been validated against the protobuf spec.
+    A ``dict`` at the same location will be updated. A ``list`` at the same location will be
+    appended to. A scalar at the same location will be overwritten.
 
     Parameters
     ----------
@@ -194,6 +194,11 @@ def merge(accum, other):
         Config (or field, if being called recursively) being accumulated.
     other : dict
         Incoming config (or field, if being called recursively).
+
+    Warnings
+    --------
+    This function will encounter bugs if values at the same location are of different types, so it
+    should only be called after the configs have been validated against the protobuf spec.
 
     Notes
     -----

--- a/client/verta/verta/_internal_utils/_config_utils.py
+++ b/client/verta/verta/_internal_utils/_config_utils.py
@@ -148,7 +148,8 @@ def find_closest_config_file():
         filepaths = CONFIG_FILENAMES.intersection(os.listdir(dirpath))
         if filepaths:
             return os.path.join(dirpath, filepaths.pop())
-    return None
+    else:
+        return None
 
 def find_config_files():
     """

--- a/client/verta/verta/_internal_utils/_config_utils.py
+++ b/client/verta/verta/_internal_utils/_config_utils.py
@@ -107,6 +107,23 @@ def get_possible_config_file_dirs():
     return dirpaths
 
 
+def find_closest_config_file():
+    """
+    Returns the location of the closest Verta config file.
+
+    Returns
+    -------
+    config_filepath: str or None
+        Path to config file.
+
+    """
+    for dirpath in get_possible_config_file_dirs():
+        # TODO: raise error if YAML and JSON in same dir
+        filepaths = CONFIG_FILENAMES.intersection(os.listdir(dirpath))
+        if filepaths:
+            return os.path.join(dirpath, filepaths.pop())
+    return None
+
 def find_config_files():
     """
     Returns the locations of accessible Verta config files.
@@ -117,13 +134,13 @@ def find_config_files():
         Paths to config files, with the closest to the current directory being first.
 
     """
-    config_filepaths = []
+    filepaths = []
     for dirpath in get_possible_config_file_dirs():
         # TODO: raise error if YAML and JSON in same dir
-        config_filepaths.extend(
+        filepaths.extend(
             os.path.join(dirpath, config_filename)
             for config_filename
             in CONFIG_FILENAMES.intersection(os.listdir(dirpath))
         )
 
-    return config_filepaths
+    return filepaths

--- a/client/verta/verta/_internal_utils/_config_utils.py
+++ b/client/verta/verta/_internal_utils/_config_utils.py
@@ -70,6 +70,9 @@ def load(config_filepath):
         else:  # JSON
             config = json.load(f)
 
+    if config is None:  # config file was empty
+        config = {}
+
     validate(config)
 
     return config

--- a/client/verta/verta/_internal_utils/_config_utils.py
+++ b/client/verta/verta/_internal_utils/_config_utils.py
@@ -80,11 +80,11 @@ def create_empty_config_file(dirpath):
     return config_filepath
 
 
-def find_config_files():
+def get_possible_config_file_dirs():
     """
-    Returns the locations of accessible Verta config files.
+    Returns the directories where config files could be found.
 
-    Config files are searched for in the following locations, in order:
+    Config files may be found in the following locations, in order:
 
     * current directory
     * parent directories until the root
@@ -92,19 +92,33 @@ def find_config_files():
 
     Returns
     -------
+    dirpaths : list of str
+        Directories that could contain config files, with the closest to the current directory
+        being first.
+
+    """
+    dirpaths = []
+    cur_dir = os.getcwd()
+    while cur_dir:
+        dirpaths.append(cur_dir)
+        cur_dir = os.path.dirname(cur_dir)
+    dirpaths.append(os.path.expanduser("~/.verta"))
+
+    return dirpaths
+
+
+def find_config_files():
+    """
+    Returns the locations of accessible Verta config files.
+
+    Returns
+    -------
     config_filepaths : list of str
         Paths to config files, with the closest to the current directory being first.
 
     """
-    dirs_to_search = []
-    cur_dir = os.getcwd()
-    while cur_dir:
-        dirs_to_search.append(cur_dir)
-        cur_dir = os.path.dirname(cur_dir)
-    dirs_to_search.append(os.path.expanduser("~/.verta"))
-
     config_filepaths = []
-    for dirpath in dirs_to_search:
+    for dirpath in get_possible_config_file_dirs():
         # TODO: raise error if YAML and JSON in same dir
         config_filepaths.extend(
             os.path.join(dirpath, config_filename)

--- a/client/verta/verta/_internal_utils/_config_utils.py
+++ b/client/verta/verta/_internal_utils/_config_utils.py
@@ -34,8 +34,6 @@ def read_config():
         Merged contents of all accessible config files.
 
     """
-    # TODO: unify with Client's config methods
-
     config = {}
     for filepath in reversed(find_config_files()):
         merge(config, load(filepath))
@@ -54,7 +52,6 @@ def write_config():
         Contents of the nearest config file.
 
     """
-    # TODO: unify with Client's config methods
     config_filepath = find_closest_config_file()
 
     config = load(config_filepath)

--- a/client/verta/verta/_internal_utils/_config_utils.py
+++ b/client/verta/verta/_internal_utils/_config_utils.py
@@ -166,3 +166,33 @@ def find_config_files():
         )
 
     return filepaths
+
+
+def merge(accum, other):
+    """
+    Merges `other` into `accum` in place.
+
+    This function will encounter bugs if values at the same location are of different types, so it
+    should only be called after the configs have been validated against the protobuf spec.
+
+    Parameters
+    ----------
+    accum : dict
+        Config (or field, if being called recursively) being accumulated.
+    other : dict
+        Incoming config (or field, if being called recursively).
+
+    Notes
+    -----
+    Adapted from https://stackoverflow.com/a/20666342/8651995.
+
+    """
+    for key, value in other.items():
+        if isinstance(value, dict):
+            node = accum.setdefault(key, {})
+            merge(node, value)
+        elif isinstance(value, list):
+            node = accum.set_default(key, [])
+            node.extend(value)
+        else:
+            accum[key] = value

--- a/client/verta/verta/_internal_utils/_config_utils.py
+++ b/client/verta/verta/_internal_utils/_config_utils.py
@@ -120,8 +120,9 @@ def get_possible_config_file_dirs():
 
     """
     dirpaths = []
+    root = os.path.abspath(os.sep)
     cur_dir = os.getcwd()
-    while cur_dir:
+    while cur_dir != root:
         dirpaths.append(cur_dir)
         cur_dir = os.path.dirname(cur_dir)
     dirpaths.append(os.path.expanduser("~/.verta"))

--- a/client/verta/verta/_internal_utils/_config_utils.py
+++ b/client/verta/verta/_internal_utils/_config_utils.py
@@ -131,11 +131,11 @@ def get_possible_config_file_dirs():
 
     """
     dirpaths = []
-    cur_dir = os.getcwd()
+    curr_dir = os.getcwd()
     while (not dirpaths  # first iteration (dirpaths empty)
-           or cur_dir != dirpaths[-1]):
-        dirpaths.append(cur_dir)
-        cur_dir = os.path.dirname(cur_dir)
+           or curr_dir != dirpaths[-1]):
+        dirpaths.append(curr_dir)
+        curr_dir = os.path.dirname(curr_dir)
     dirpaths.append(os.path.expanduser("~/.verta"))
 
     return dirpaths

--- a/client/verta/verta/_internal_utils/_config_utils.py
+++ b/client/verta/verta/_internal_utils/_config_utils.py
@@ -6,6 +6,10 @@ import os
 
 import yaml
 
+from .._protos.public.client import Config_pb2 as _ConfigProtos
+
+from . import _utils
+
 
 # TODO: make this a named tuple, if it would help readability
 CONFIG_YAML_FILENAME = "verta_config.yaml"
@@ -66,6 +70,8 @@ def load(config_filepath):
             config = yaml.safe_load(f)
         else:  # JSON
             config = json.load(f)
+
+    validate(config)
 
     return config
 
@@ -167,6 +173,14 @@ def find_config_files():
         )
 
     return filepaths
+
+
+def validate(config):
+    """Validates `config` against the protobuf spec."""
+    _utils.json_to_proto(
+        config, _ConfigProtos.Config,
+        ignore_unknown_fields=True,  # TODO: reset to False when protos are impl
+    )
 
 
 def merge(accum, other):

--- a/client/verta/verta/_internal_utils/_config_utils.py
+++ b/client/verta/verta/_internal_utils/_config_utils.py
@@ -62,6 +62,8 @@ def write_config():
 
 
 def load(config_filepath):
+    config_filepath = os.path.expanduser(config_filepath)
+
     with open(config_filepath, 'r') as f:
         if config_filepath.endswith('.yaml'):
             config = yaml.safe_load(f)
@@ -74,6 +76,8 @@ def load(config_filepath):
 
 
 def dump(config, config_filepath):
+    config_filepath = os.path.expanduser(config_filepath)
+
     with open(config_filepath, 'w') as f:
         if config_filepath.endswith('.yaml'):
             yaml.safe_dump(config, f)
@@ -97,6 +101,7 @@ def create_empty_config_file(dirpath):
 
     """
     config_filepath = os.path.join(dirpath, CONFIG_YAML_FILENAME)
+    config_filepath = os.path.expanduser(config_filepath)
     config_filepath = os.path.abspath(config_filepath)
 
     with open(config_filepath, 'w') as f:

--- a/client/verta/verta/_internal_utils/_config_utils.py
+++ b/client/verta/verta/_internal_utils/_config_utils.py
@@ -78,3 +78,38 @@ def create_empty_config_file(dirpath):
         yaml.dump({}, f)
 
     return config_filepath
+
+
+def find_config_files():
+    """
+    Returns the locations of accessible Verta config files.
+
+    Config files are searched for in the following locations, in order:
+
+    * current directory
+    * parent directories until the root
+    * ``$HOME/.verta/``
+
+    Returns
+    -------
+    config_filepaths : list of str
+        Paths to config files, with the closest to the current directory being first.
+
+    """
+    dirs_to_search = []
+    cur_dir = os.getcwd()
+    while cur_dir:
+        dirs_to_search.append(cur_dir)
+        cur_dir = os.path.dirname(cur_dir)
+    dirs_to_search.append(os.path.expanduser("~/.verta"))
+
+    config_filepaths = []
+    for dirpath in dirs_to_search:
+        # TODO: raise error if YAML and JSON in same dir
+        config_filepaths.extend(
+            os.path.join(dirpath, config_filename)
+            for config_filename
+            in CONFIG_FILENAMES.intersection(os.listdir(dirpath))
+        )
+
+    return config_filepaths

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -257,31 +257,8 @@ class Client(object):
         return _OSS_DEFAULT_WORKSPACE
 
     def _load_config(self):
-        config_file = self._find_config_in_all_dirs()
-        if config_file is not None:
-            stream = open(config_file, 'r')
-            self._config = yaml.load(stream, Loader=yaml.FullLoader)
-            # validate config against proto spec
-            _config_utils.validate(self._config)
-        else:
-            self._config = {}
-
-    def _find_config_in_all_dirs(self):
-        res = self._find_config('./', True)
-        if res is None:
-            return self._find_config("{}/.verta/".format(os.path.expanduser("~")))
-        return res
-
-    def _find_config(self, prefix, recursive=False):
-        for ff in _config_utils.CONFIG_FILENAMES:
-            if os.path.isfile(prefix + ff):
-                return prefix + ff
-        if recursive:
-            for dir in [os.path.join(prefix, o) for o in os.listdir(prefix) if os.path.isdir(os.path.join(prefix, o))]:
-                config_file = self._find_config(dir + "/", True)
-                if config_file is not None:
-                    return config_file
-        return None
+        with _config_utils.read_config() as config:
+            self._config = config
 
     def _set_from_config_if_none(self, var, resource_name):
         if var is None:

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -30,7 +30,6 @@ from ._protos.public.modeldb import CommonService_pb2 as _CommonService
 from ._protos.public.modeldb import ProjectService_pb2 as _ProjectService
 from ._protos.public.modeldb import ExperimentService_pb2 as _ExperimentService
 from ._protos.public.modeldb import ExperimentRunService_pb2 as _ExperimentRunService
-from ._protos.public.client import Config_pb2 as _ConfigProtos
 
 from .external import six
 from .external.six.moves import cPickle as pickle  # pylint: disable=import-error, no-name-in-module
@@ -263,11 +262,7 @@ class Client(object):
             stream = open(config_file, 'r')
             self._config = yaml.load(stream, Loader=yaml.FullLoader)
             # validate config against proto spec
-            _utils.json_to_proto(
-                self._config,
-                _ConfigProtos.Config,
-                ignore_unknown_fields=False,
-            )
+            _config_utils.validate(self._config)
         else:
             self._config = {}
 


### PR DESCRIPTION
Turns out there were two issues with the implementation of Client config:

- It didn't merge config files. Instead, it only loaded the one with the highest precedence.
- It actually didn't check parent directories for config files; it checked child directories instead.
-----
This PR

- moves config file discovery logic to `_config_utils` so it can be shared between the Python Client and the CLI
- merges discovered config files
- looks in parent directories for config files
- adds much more comprehensive testing