### PR TITLE
Don't use verta for environment versioning tests

### DIFF
--- a/client/verta/tests/test_versioning/test_environment.py
+++ b/client/verta/tests/test_versioning/test_environment.py
@@ -9,7 +9,6 @@ import six
 
 from google.protobuf import json_format
 
-import verta
 import verta.environment
 from verta._internal_utils import _pip_requirements_utils
 
@@ -166,7 +165,7 @@ class TestPython:
     def test_repr(self):
         """Tests that __repr__() executes without error"""
         env_ver = verta.environment.Python(
-            requirements=['verta=={}'.format(verta.__version__)],
+            requirements=['pytest=={}'.format(pytest.__version__)],
             constraints=['six=={}'.format(six.__version__)],
             env_vars=['HOME'],
         )

--- a/client/verta/tests/test_versioning/test_repository.py
+++ b/client/verta/tests/test_versioning/test_repository.py
@@ -150,19 +150,19 @@ class TestCommit:
 
     def test_merge_conflict(self, repository):
         branch_a = repository.get_commit(branch="master").new_branch("a")
-        branch_a.update("env", verta.environment.Python(["verta==1"]))
+        branch_a.update("env", verta.environment.Python(["pytest==1"]))
         branch_a.save("a")
 
         branch_b = repository.get_commit(branch="master").new_branch("b")
-        branch_b.update("env", verta.environment.Python(["verta==2"]))
+        branch_b.update("env", verta.environment.Python(["pytest==2"]))
         branch_b.save("b")
 
         with pytest.raises(RuntimeError):
             branch_b.merge(branch_a)
 
     def test_revert(self, repository):
-        blob1 = verta.environment.Python(["verta==1"])
-        blob2 = verta.environment.Python(["verta==2"])
+        blob1 = verta.environment.Python(["pytest==1"])
+        blob2 = verta.environment.Python(["pytest==2"])
         loc1 = "loc1"
         loc2 = "loc2"
 


### PR DESCRIPTION
Since #644, the Client rejects inaccurate version pins when passing `"verta"` into environment versioning. So let's just not use it in our test cases