### PR TITLE
Update docs links repo-wide

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
   <span> · </span>
   <a href="https://docs.verta.ai/en/master/examples/tutorials/workflow.html">Workflow</a>
   <span> · </span>
-  <a href="https://docs.verta.ai/en/master/guides/examples.html">Examples</a>
+  <a href="https://docs.verta.ai/en/master/examples/examples.html">Examples</a>
   <span> · </span>
   <a href="#contributions">Contribute</a>
   <span> · </span>
@@ -199,7 +199,7 @@ Other supporting material for deployment and documentation is at:
 ## Contributions
 
 As seen from the [Architecture](#architecture) ModelDB provides a full stack solution to tracking, versioning and auditing  machine learning models.
-We are open to contributions to any of the modules in form of Pull Requests. 
+We are open to contributions to any of the modules in form of Pull Requests.
 
 The main skill sets for each module are as below:
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ docker-compose -f docker-compose-all.yaml up
 pip install verta
 ```
 
-3. Version a model or log a workflow. *Alternatively, run any of the detailed [examples](https://docs.verta.ai/en/master/guides/examples.html) in our repository.*
+3. Version a model or log a workflow. *Alternatively, run any of the detailed [examples](https://docs.verta.ai/en/master/examples/examples.html) in our repository.*
 
 ```python
 from verta import Client

--- a/chart/modeldb/README.md
+++ b/chart/modeldb/README.md
@@ -20,7 +20,7 @@ By default, the "default" namespace on your Kubernetes cluster is used.
 ### What next?
 
 Now that you have modelDB up and running on your K8s cluster, please visit
-[our user guide and documentation](https://verta.readthedocs.io/en/docs/index.html) to get started.
+[our user guide and documentation](https://docs.verta.ai/en/docs/index.html) to get started.
 
 ### Using Custom Images
 

--- a/chart/modeldb/README.md
+++ b/chart/modeldb/README.md
@@ -20,7 +20,7 @@ By default, the "default" namespace on your Kubernetes cluster is used.
 ### What next?
 
 Now that you have modelDB up and running on your K8s cluster, please visit
-[our user guide and documentation](https://docs.verta.ai/en/docs/index.html) to get started.
+[our user guide and documentation](https://docs.verta.ai/en/master/index.html) to get started.
 
 ### Using Custom Images
 

--- a/client/README.md
+++ b/client/README.md
@@ -2,6 +2,6 @@
 
 Thanks for stopping by, and for taking your first step towards a healthier, more sustainable model lifecycle!
 
-Come see [our user guide and documentation](https://verta.readthedocs.io/en/master/index.html) to get started.
+Come see [our user guide and documentation](https://docs.verta.ai/en/master/index.html) to get started.
 
 Take a look at [our development guide](https://github.com/VertaAI/modeldb/blob/master/client/CONTRIBUTING.md) for source installation and how to contribute.

--- a/client/workflows/demos/setup-script.ipynb
+++ b/client/workflows/demos/setup-script.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This notebook is a quick demonstration of `verta`'s [`run.log_setup_script()`](https://verta.readthedocs.io/en/master/reference/api/experimentrun.html#verta.client.ExperimentRun.log_setup_script) feature.\n",
+    "This notebook is a quick demonstration of `verta`'s [`run.log_setup_script()`](https://docs.verta.ai/en/master/api/api/experimentrun.html#verta.client.ExperimentRun.log_setup_script) feature.\n",
     "\n",
     "We'll create a simple and lightweight text tokenizer and part-of-speech tagger using NLTK,  \n",
     "which will require not only installing the `nltk` package itself,  \n",


### PR DESCRIPTION
Fix for #653.
I did a search through the full repo and manually checked each and every doc link.
Absolutely all of the docs links should now be up-to-date.