### PR TITLE
Return full response for getUrlFromArtifact

### DIFF
--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -777,8 +777,8 @@ class _ModelDBEntity(object):
 
         Returns
         -------
-        str
-            Generated URL.
+        response_msg : `_CommonService.GetUrlForArtifact.Response`
+            Backend response.
 
         """
         if method.upper() not in ("GET", "PUT"):
@@ -793,8 +793,8 @@ class _ModelDBEntity(object):
         _utils.raise_for_http_error(response)
 
         response_msg = _utils.json_to_proto(response.json(), Message.Response)
-        url = response_msg.url
 
+        url = response_msg.url
         # accommodate port-forwarded NFS store
         if 'https://localhost' in url[:20]:
             url = 'http' + url[5:]
@@ -802,8 +802,9 @@ class _ModelDBEntity(object):
             url = url.replace('localhost%3a', 'localhost:')
         if 'localhost%3A' in url[:20]:
             url = url.replace('localhost%3A', 'localhost:')
+        response_msg.url = url
 
-        return url
+        return response_msg
 
     def _cache(self, filename, contents):
         """
@@ -1088,7 +1089,7 @@ class _ModelDBEntity(object):
 
         if msg.code_version.WhichOneof("code") == 'code_archive':
             # upload artifact to artifact store
-            url = self._get_url_for_artifact("verta_code_archive", "PUT", msg.code_version.code_archive.artifact_type)
+            url = self._get_url_for_artifact("verta_code_archive", "PUT", msg.code_version.code_archive.artifact_type).url
 
             response = _utils.make_request("PUT", url, self._conn, data=zipstream)
             _utils.raise_for_http_error(response)
@@ -1143,7 +1144,7 @@ class _ModelDBEntity(object):
             return git_snapshot
         elif which_code == 'code_archive':
             # download artifact from artifact store
-            url = self._get_url_for_artifact("verta_code_archive", "GET", code_ver_msg.code_archive.artifact_type)
+            url = self._get_url_for_artifact("verta_code_archive", "GET", code_ver_msg.code_archive.artifact_type).url
 
             response = _utils.make_request("GET", url, self._conn)
             _utils.raise_for_http_error(response)
@@ -2039,7 +2040,7 @@ class ExperimentRun(_ModelDBEntity):
                 _utils.raise_for_http_error(response)
 
         # upload artifact to artifact store
-        url = self._get_url_for_artifact(key, "PUT")
+        url = self._get_url_for_artifact(key, "PUT").url
         artifact_stream.seek(0)  # reuse stream that was created for checksum
         if self._conf.debug:
             print("[DEBUG] uploading {} bytes ({})".format(len(artifact_stream.read()), basename))
@@ -2117,7 +2118,7 @@ class ExperimentRun(_ModelDBEntity):
             return artifact.path, artifact.path_only
         else:
             # download artifact from artifact store
-            url = self._get_url_for_artifact(key, "GET")
+            url = self._get_url_for_artifact(key, "GET").url
 
             response = _utils.make_request("GET", url, self._conn)
             _utils.raise_for_http_error(response)


### PR DESCRIPTION
This is so the caller can check `multipart_upload_ok` from the backend response.