### PR TITLE
VR-4415: Move log_training_data() to bottom of census notebooks

### DIFF
--- a/client/workflows/demos/census-end-to-end-local-data-example.ipynb
+++ b/client/workflows/demos/census-end-to-end-local-data-example.ipynb
@@ -255,7 +255,6 @@
     "    # save and log model\n",
     "    run.log_model(model, model_api=model_api)\n",
     "    run.log_requirements([\"scikit-learn\"])\n",
-    "    run.log_training_data(X_train, y_train)\n",
     "    \n",
     "    # log dataset snapshot as version\n",
     "    run.log_dataset_version(\"train\", version)\n",
@@ -346,7 +345,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Make Live Predictions"
+    "# Deployment and Live Predictions"
    ]
   },
   {
@@ -355,19 +354,37 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model_id = 'YOUR_MODEL_ID' "
+    "model_id = 'YOUR_MODEL_ID'\n",
+    "\n",
+    "run = client.set_experiment_run(id=model_id)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Prepare Data"
+    "## Log Training Data for Reference"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run.log_training_data(X_train, y_train)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare \"Live\" Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -379,18 +396,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Load Deployed Model"
+    "## Deploy Model"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from verta._demo_utils import DeployedModel\n",
+    "run.deploy(wait=True)\n",
     "\n",
-    "deployed_model = DeployedModel(HOST, model_id)"
+    "run"
    ]
   },
   {
@@ -402,10 +419,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
+    "deployed_model = run.get_deployed_model()\n",
     "for x in itertools.cycle(X_test.values.tolist()):\n",
     "    print(deployed_model.predict([x]))\n",
     "    time.sleep(.5)"
@@ -435,7 +453,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.5"
   }
  },
  "nbformat": 4,

--- a/client/workflows/demos/census-end-to-end-local-data-example.ipynb
+++ b/client/workflows/demos/census-end-to-end-local-data-example.ipynb
@@ -127,6 +127,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "This section demonstrates logging model metadata and training artifacts to ModelDB."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Instantiate Client"
    ]
   },
@@ -284,6 +291,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "This section demonstrates querying and retrieving runs via the Client."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Retrieve Best Run"
    ]
   },
@@ -346,6 +360,13 @@
    "metadata": {},
    "source": [
     "# Deployment and Live Predictions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates model deployment and predictions, if supported by your version of ModelDB."
    ]
   },
   {

--- a/client/workflows/demos/census-end-to-end-s3-example.ipynb
+++ b/client/workflows/demos/census-end-to-end-s3-example.ipynb
@@ -269,7 +269,6 @@
     "    # save and log model\n",
     "    run.log_model(model, model_api=model_api)\n",
     "    run.log_requirements(requirements)\n",
-    "    run.log_training_data(X_train, y_train)\n",
     "    \n",
     "    # log dataset snapshot as version\n",
     "    run.log_dataset_version(\"train\", version)\n",
@@ -360,7 +359,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Make Live Predictions"
+    "# Deployment and Live Predictions"
    ]
   },
   {
@@ -369,19 +368,37 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model_id = 'YOUR_MODEL_ID' "
+    "model_id = 'YOUR_MODEL_ID'\n",
+    "\n",
+    "run = client.set_experiment_run(id=model_id)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Prepare Data"
+    "## Log Training Data for Reference"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run.log_training_data(X_train, y_train)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare \"Live\" Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -393,18 +410,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Load Deployed Model"
+    "## Deploy Model"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from verta._demo_utils import DeployedModel\n",
+    "run.deploy(wait=True)\n",
     "\n",
-    "deployed_model = DeployedModel(HOST, model_id)"
+    "run"
    ]
   },
   {
@@ -416,10 +433,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
+    "deployed_model = run.get_deployed_model()\n",
     "for x in itertools.cycle(X_test.values.tolist()):\n",
     "    print(deployed_model.predict([x]))\n",
     "    time.sleep(.5)"
@@ -449,7 +467,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.5"
   }
  },
  "nbformat": 4,

--- a/client/workflows/demos/census-end-to-end-s3-example.ipynb
+++ b/client/workflows/demos/census-end-to-end-s3-example.ipynb
@@ -127,6 +127,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "This section demonstrates logging model metadata and training artifacts to ModelDB."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Instantiate Client"
    ]
   },
@@ -298,6 +305,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "This section demonstrates querying and retrieving runs via the Client."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Retrieve Best Run"
    ]
   },
@@ -360,6 +374,13 @@
    "metadata": {},
    "source": [
     "# Deployment and Live Predictions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates model deployment and predictions, if supported by your version of ModelDB."
    ]
   },
   {

--- a/client/workflows/demos/census-end-to-end.ipynb
+++ b/client/workflows/demos/census-end-to-end.ipynb
@@ -128,6 +128,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "This section demonstrates logging model metadata and training artifacts to ModelDB."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Prepare Data"
    ]
   },
@@ -279,6 +286,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "This section demonstrates querying and retrieving runs via the Client."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Retrieve Best Run"
    ]
   },
@@ -341,6 +355,13 @@
    "metadata": {},
    "source": [
     "# Deployment and Live Predictions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates model deployment and predictions, if supported by your version of ModelDB."
    ]
   },
   {

--- a/client/workflows/demos/census-end-to-end.ipynb
+++ b/client/workflows/demos/census-end-to-end.ipynb
@@ -252,7 +252,6 @@
     "    # save and log model\n",
     "    run.log_model(model, model_api=model_api)\n",
     "    run.log_requirements(requirements)\n",
-    "    run.log_training_data(X_train, y_train)\n",
     "    \n",
     "    # log Git information as code version\n",
     "    run.log_code()\n",
@@ -341,7 +340,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Make Live Predictions"
+    "# Deployment and Live Predictions"
    ]
   },
   {
@@ -350,19 +349,37 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model_id = "
+    "model_id = 'YOUR_MODEL_ID'\n",
+    "\n",
+    "run = client.set_experiment_run(id=model_id)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Prepare Data"
+    "## Log Training Data for Reference"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run.log_training_data(X_train, y_train)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare \"Live\" Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -374,18 +391,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Load Deployed Model"
+    "## Deploy Model"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from verta._demo_utils import DeployedModel\n",
+    "run.deploy(wait=True)\n",
     "\n",
-    "deployed_model = DeployedModel(HOST, model_id)"
+    "run"
    ]
   },
   {
@@ -397,10 +414,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
+    "deployed_model = run.get_deployed_model()\n",
     "for x in itertools.cycle(X_test.values.tolist()):\n",
     "    print(deployed_model.predict([x]))\n",
     "    time.sleep(.5)"
@@ -430,7 +448,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Moves `run.log_training_data()` to the last section of the notebook for deployment.
This enables the training loop in the middle of the notebook to run successfully against `app`.