### PR TITLE
Use different names for different Dataset types to avoid conflict

### DIFF
--- a/client/workflows/demos/census-end-to-end-local-data-example.ipynb
+++ b/client/workflows/demos/census-end-to-end-local-data-example.ipynb
@@ -159,7 +159,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dataset = client.set_dataset(name=\"Census Income\", type=\"local\")\n",
+    "dataset = client.set_dataset(name=\"Census Income Local\", type=\"local\")\n",
     "version = dataset.create_version(path=\"census-train.csv\")"
    ]
   },

--- a/client/workflows/demos/census-end-to-end-s3-example.ipynb
+++ b/client/workflows/demos/census-end-to-end-s3-example.ipynb
@@ -159,7 +159,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dataset = client.set_dataset(name=\"Census Income\", type=\"s3\")\n",
+    "dataset = client.set_dataset(name=\"Census Income S3\", type=\"s3\")\n",
     "version = dataset.create_version(bucket_name=\"verta-starter\")"
    ]
   },


### PR DESCRIPTION
The same name `Dataset` (`"Census Income"`) can't be used for different dataset types; making the names in the notebooks different resolves a issue we've come across while running these notebooks.