### PR TITLE
VR-4452: check response contents when retrieving Proj/Expt/Run/Dataset

### DIFF
--- a/client/verta/verta/_dataset.py
+++ b/client/verta/verta/_dataset.py
@@ -46,7 +46,7 @@ class Dataset(object):
 
         if _dataset_id is not None:
             dataset = Dataset._get(conn, _dataset_id=_dataset_id)
-            if dataset is not None:
+            if dataset is not None and dataset.id:
                 print("set existing Dataset: {}".format(dataset.name))
             else:
                 raise ValueError("Dataset with ID {} not found".format(_dataset_id))
@@ -58,7 +58,7 @@ class Dataset(object):
             except requests.HTTPError as e:
                 if e.response.status_code == 403:  # cannot create in other workspace
                     dataset = Dataset._get(conn, name, workspace)
-                    if dataset is not None:
+                    if dataset is not None and dataset.id:
                         print("set existing Dataset: {} from {}".format(dataset.name, WORKSPACE_PRINT_MSG))
                     else:  # no accessible dataset in other workspace
                         six.raise_from(e, None)
@@ -69,7 +69,11 @@ class Dataset(object):
                             " cannot set `desc`, `tags`, `attrs`, or `public_within_org`".format(name)
                         )
                     dataset = Dataset._get(conn, name, workspace)
-                    print("set existing Dataset: {} from {}".format(dataset.name, WORKSPACE_PRINT_MSG))
+                    if dataset is not None and dataset.id:
+                        print("set existing Dataset: {} from {}".format(dataset.name, WORKSPACE_PRINT_MSG))
+                    else:
+                        raise RuntimeError("unable to retrieve Dataset {};"
+                                           " please notify the Verta development team".format(name))
                 else:
                     raise e
             else:
@@ -464,7 +468,7 @@ class DatasetVersion(object):
         if _dataset_version_id is not None:
             # retrieve dataset version by id
             dataset_version = DatasetVersion._get(conn, _dataset_version_id)
-            if dataset_version is None:
+            if dataset_version is None or not dataset.id:
                 raise ValueError("DatasetVersion with ID {} not found".format(_dataset_version_id))
         else:
             # create new version under dataset

--- a/client/verta/verta/_dataset.py
+++ b/client/verta/verta/_dataset.py
@@ -468,7 +468,7 @@ class DatasetVersion(object):
         if _dataset_version_id is not None:
             # retrieve dataset version by id
             dataset_version = DatasetVersion._get(conn, _dataset_version_id)
-            if dataset_version is None or not dataset.id:
+            if dataset_version is None or not dataset_version.id:
                 raise ValueError("DatasetVersion with ID {} not found".format(_dataset_version_id))
         else:
             # create new version under dataset

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -1190,7 +1190,7 @@ class Project(_ModelDBEntity):
 
         if _proj_id is not None:
             proj = Project._get(conn, _proj_id=_proj_id)
-            if proj is not None and proj.id:
+            if proj is not None:
                 print("set existing Project: {}".format(proj.name))
             else:
                 raise ValueError("Project with ID {} not found".format(_proj_id))
@@ -1202,7 +1202,7 @@ class Project(_ModelDBEntity):
             except requests.HTTPError as e:
                 if e.response.status_code == 403:  # cannot create in other workspace
                     proj = Project._get(conn, proj_name, workspace)
-                    if proj is not None and proj.id:
+                    if proj is not None:
                         print("set existing Project: {} from {}".format(proj.name, WORKSPACE_PRINT_MSG))
                     else:  # no accessible project in other workspace
                         six.raise_from(e, None)
@@ -1213,7 +1213,7 @@ class Project(_ModelDBEntity):
                             " cannot set `desc`, `tags`, `attrs`, or `public_within_org`".format(proj_name)
                         )
                     proj = Project._get(conn, proj_name, workspace)
-                    if proj is not None and proj.id:
+                    if proj is not None:
                         print("set existing Project: {} from {}".format(proj.name, WORKSPACE_PRINT_MSG))
                     else:
                         raise RuntimeError("unable to retrieve Project {};"
@@ -1284,9 +1284,15 @@ class Project(_ModelDBEntity):
                 response_msg = _utils.json_to_proto(response_json, Message.Response)
                 if workspace is None or response_json.get('project_by_user'):
                     # user's personal workspace
-                    return response_msg.project_by_user
+                    proj = response_msg.project_by_user
                 else:
-                    return response_msg.shared_projects[0]
+                    proj = response_msg.shared_projects[0]
+
+                if not proj.id:  # 200, but empty message
+                    raise RuntimeError("unable to retrieve Project {};"
+                                       " please notify the Verta development team".format(proj_name))
+
+                return proj
             else:
                 if ((response.status_code == 403 and response.json()['code'] == 7)
                         or (response.status_code == 404 and response.json()['code'] == 5)):
@@ -1355,7 +1361,7 @@ class Experiment(_ModelDBEntity):
 
         if _expt_id is not None:
             expt = Experiment._get(conn, _expt_id=_expt_id)
-            if expt is not None and expt.id:
+            if expt is not None:
                 print("set existing Experiment: {}".format(expt.name))
             else:
                 raise ValueError("Experiment with ID {} not found".format(_expt_id))
@@ -1370,7 +1376,7 @@ class Experiment(_ModelDBEntity):
                         warnings.warn("Experiment with name {} already exists;"
                                       " cannot initialize `desc`, `tags`, or `attrs`".format(expt_name))
                     expt = Experiment._get(conn, proj_id, expt_name)
-                    if expt is not None and expt.id:
+                    if expt is not None:
                         print("set existing Experiment: {}".format(expt.name))
                     else:
                         raise RuntimeError("unable to retrieve Experiment {};"
@@ -1432,7 +1438,13 @@ class Experiment(_ModelDBEntity):
 
         if response.ok:
             response_msg = _utils.json_to_proto(response.json(), Message.Response)
-            return response_msg.experiment
+            expt = response_msg.experiment
+
+            if not expt.id:  # 200, but empty message
+                raise RuntimeError("unable to retrieve Experiment {};"
+                                   " please notify the Verta development team".format(expt_name))
+
+            return expt
         else:
             if ((response.status_code == 403 and response.json()['code'] == 7)
                     or (response.status_code == 404 and response.json()['code'] == 5)):
@@ -1805,7 +1817,7 @@ class ExperimentRun(_ModelDBEntity):
 
         if _expt_run_id is not None:
             expt_run = ExperimentRun._get(conn, _expt_run_id=_expt_run_id)
-            if expt_run is not None and expt_run.id:
+            if expt_run is not None:
                 print("set existing ExperimentRun: {}".format(expt_run.name))
             else:
                 raise ValueError("ExperimentRun with ID {} not found".format(_expt_run_id))
@@ -1820,7 +1832,7 @@ class ExperimentRun(_ModelDBEntity):
                         warnings.warn("ExperimentRun with name {} already exists;"
                                       " cannot initialize `desc`, `tags`, or `attrs`".format(expt_run_name))
                     expt_run = ExperimentRun._get(conn, expt_id, expt_run_name)
-                    if expt_run is not None and expt_run.id:
+                    if expt_run is not None:
                         print("set existing ExperimentRun: {}".format(expt_run.name))
                     else:
                         raise RuntimeError("unable to retrieve ExperimentRun {};"
@@ -1944,7 +1956,13 @@ class ExperimentRun(_ModelDBEntity):
 
         if response.ok:
             response_msg = _utils.json_to_proto(response.json(), Message.Response)
-            return response_msg.experiment_run
+            expt_run = response_msg.experiment_run
+
+            if not expt_run.id:  # 200, but empty message
+                raise RuntimeError("unable to retrieve ExperimentRun {};"
+                                   " please notify the Verta development team".format(expt_run_name))
+
+            return expt_run
         else:
             if ((response.status_code == 403 and response.json()['code'] == 7)
                     or (response.status_code == 404 and response.json()['code'] == 5)):

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -1190,7 +1190,7 @@ class Project(_ModelDBEntity):
 
         if _proj_id is not None:
             proj = Project._get(conn, _proj_id=_proj_id)
-            if proj is not None:
+            if proj is not None and proj.id:
                 print("set existing Project: {}".format(proj.name))
             else:
                 raise ValueError("Project with ID {} not found".format(_proj_id))
@@ -1202,7 +1202,7 @@ class Project(_ModelDBEntity):
             except requests.HTTPError as e:
                 if e.response.status_code == 403:  # cannot create in other workspace
                     proj = Project._get(conn, proj_name, workspace)
-                    if proj is not None:
+                    if proj is not None and proj.id:
                         print("set existing Project: {} from {}".format(proj.name, WORKSPACE_PRINT_MSG))
                     else:  # no accessible project in other workspace
                         six.raise_from(e, None)
@@ -1213,7 +1213,11 @@ class Project(_ModelDBEntity):
                             " cannot set `desc`, `tags`, `attrs`, or `public_within_org`".format(proj_name)
                         )
                     proj = Project._get(conn, proj_name, workspace)
-                    print("set existing Project: {} from {}".format(proj.name, WORKSPACE_PRINT_MSG))
+                    if proj is not None and proj.id:
+                        print("set existing Project: {} from {}".format(proj.name, WORKSPACE_PRINT_MSG))
+                    else:
+                        raise RuntimeError("unable to retrieve Project {};"
+                                           " please notify the Verta development team".format(proj_name))
                 else:
                     raise e
             else:
@@ -1351,7 +1355,7 @@ class Experiment(_ModelDBEntity):
 
         if _expt_id is not None:
             expt = Experiment._get(conn, _expt_id=_expt_id)
-            if expt is not None:
+            if expt is not None and expt.id:
                 print("set existing Experiment: {}".format(expt.name))
             else:
                 raise ValueError("Experiment with ID {} not found".format(_expt_id))
@@ -1366,7 +1370,11 @@ class Experiment(_ModelDBEntity):
                         warnings.warn("Experiment with name {} already exists;"
                                       " cannot initialize `desc`, `tags`, or `attrs`".format(expt_name))
                     expt = Experiment._get(conn, proj_id, expt_name)
-                    print("set existing Experiment: {}".format(expt.name))
+                    if expt is not None and expt.id:
+                        print("set existing Experiment: {}".format(expt.name))
+                    else:
+                        raise RuntimeError("unable to retrieve Experiment {};"
+                                           " please notify the Verta development team".format(expt_name))
                 else:
                     raise e
             else:
@@ -1797,8 +1805,8 @@ class ExperimentRun(_ModelDBEntity):
 
         if _expt_run_id is not None:
             expt_run = ExperimentRun._get(conn, _expt_run_id=_expt_run_id)
-            if expt_run is not None:
-                pass
+            if expt_run is not None and expt_run.id:
+                print("set existing ExperimentRun: {}".format(expt_run.name))
             else:
                 raise ValueError("ExperimentRun with ID {} not found".format(_expt_run_id))
         elif None not in (proj_id, expt_id):
@@ -1812,7 +1820,11 @@ class ExperimentRun(_ModelDBEntity):
                         warnings.warn("ExperimentRun with name {} already exists;"
                                       " cannot initialize `desc`, `tags`, or `attrs`".format(expt_run_name))
                     expt_run = ExperimentRun._get(conn, expt_id, expt_run_name)
-                    print("set existing ExperimentRun: {}".format(expt_run.name))
+                    if expt_run is not None and expt_run.id:
+                        print("set existing ExperimentRun: {}".format(expt_run.name))
+                    else:
+                        raise RuntimeError("unable to retrieve ExperimentRun {};"
+                                           " please notify the Verta development team".format(expt_run_name))
                 else:
                     raise e
             else:


### PR DESCRIPTION
This catches cases when the backend returns `409 Conflict` on create, but doesn't provide an actual entity on get.