### PR TITLE
Remove unnecessary print message

### DIFF
--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -2131,7 +2131,7 @@ class ExperimentRun(_ModelDBEntity):
                 # TODO: increase retries
                 response = _utils.make_request("POST", url, self._conn, json=data)
                 _utils.raise_for_http_error(response)
-            print("upload complete")
+            print()
 
             # complete upload
             url = "{}://{}/api/v1/modeldb/experiment-run/commitMultipartArtifact".format(


### PR DESCRIPTION
Method already prints `"upload complete"` on line 2150.
Still need `print()` to go to the next line, because the print in the loop used carriage return.