### PR TITLE
Resolve hypothesis deprecation warning

### DIFF
--- a/client/verta/tests/modelapi_hypothesis/api_generator.py
+++ b/client/verta/tests/modelapi_hypothesis/api_generator.py
@@ -16,7 +16,7 @@ def dict_replace(d, key, value):
 # Takes a generator for a subtree of the API and returns either a list of mapping composition of it
 def recursive(children):
     # Create a list of subtrees
-    lst = st.lists(children, 1, 10)
+    lst = st.lists(children, min_size=1, max_size=10)
     # Then iterate over them replacing the given name (which is empty) with the index
     lst = lst.map(lambda v: [dict_replace(el, 'name', str(i)) for i, el in enumerate(v)])
     # Then convert the newly created to the dictionary format
@@ -25,7 +25,7 @@ def recursive(children):
     # Create printable text for the keys
     name = st.text(printable)
     # Create a list of (name, subtree) where the names are unique
-    dikt = st.lists(st.tuples(name, children), 1, 10, unique_by=lambda v: v[0])
+    dikt = st.lists(st.tuples(name, children), min_size=1, max_size=10, unique_by=lambda v: v[0])
     # Then iterate over them replacing the given name (which is empty) with the given name
     dikt = dikt.map(lambda lst: sorted([dict_replace(el, 'name', n) for n, el in lst], key=lambda value: value['name']))
     # Then convert the newly created to the dictionary format
@@ -40,4 +40,4 @@ model_api = st.recursive(modelapi_base, recursive)
 # pandas-specific types
 name = st.text(printable)
 model_api_series = st.tuples(name, modelapi_base).map(lambda arg: dict_replace(arg[1], 'name', arg[0]))
-model_api_dataframe = st.lists(model_api_series, 1, unique_by=lambda x: x['name']).map(lambda v: {'type': 'VertaList', 'name': '', 'value': v})
+model_api_dataframe = st.lists(model_api_series, min_size=1, unique_by=lambda x: x['name']).map(lambda v: {'type': 'VertaList', 'name': '', 'value': v})

--- a/client/verta/tests/modelapi_hypothesis/value_generator.py
+++ b/client/verta/tests/modelapi_hypothesis/value_generator.py
@@ -47,7 +47,7 @@ def verta_type_to_dtype(name):
     return map[name]
 
 def _sized_series_from_api(api, size):
-    values = st.lists(value_from_api(api), size, size)
+    values = st.lists(value_from_api(api), min_size=size, max_size=size)
     return values.map(lambda vals: pd.Series(data=vals, name=api['name'], dtype=verta_type_to_dtype(api['type'])))
 
 def series_from_api(api):
@@ -61,7 +61,7 @@ def dataframe_from_api(api):
     return dataframe
 
 # Converts a generator to a model api to a generator of (model api, list of samples)
-api_and_values = model_api.flatmap(lambda api: st.tuples(st.just(api), st.lists(value_from_api(api), 1, 100)))
+api_and_values = model_api.flatmap(lambda api: st.tuples(st.just(api), st.lists(value_from_api(api), min_size=1, max_size=100)))
 
 series_api_and_values = model_api_series.flatmap(lambda api: st.tuples(st.just(api), series_from_api(api)))
 dataframe_api_and_values = model_api_dataframe.flatmap(lambda api: st.tuples(st.just(api), dataframe_from_api(api)))


### PR DESCRIPTION
These were making it difficult to read the `pytest` logs.
```
/Users/miliu/Documents/modeldb/client/verta/venv-dev/lib/python3.7/site-packages/hypothesis/internal/reflection.py:649:
  HypothesisDeprecationWarning: lists was passed min_size=40 as a positional argument, which will be a keyword-only argument in a future version.
  since="2020-02-07",
```
but like, several dozen of these in the test summary.