### PR TITLE
 VR-4528 Create a Dataset Blob from local path for Scala client

### DIFF
--- a/client/scala/src/main/scala/ai/verta/blobs/Blob.scala
+++ b/client/scala/src/main/scala/ai/verta/blobs/Blob.scala
@@ -1,5 +1,3 @@
 package ai.verta.blobs.dataset
 
-import ai.verta.swagger._public.modeldb.versioning.model._
-
 trait Blob {}

--- a/client/scala/src/main/scala/ai/verta/blobs/Blob.scala
+++ b/client/scala/src/main/scala/ai/verta/blobs/Blob.scala
@@ -1,0 +1,5 @@
+package ai.verta.blobs.dataset
+
+import ai.verta.swagger._public.modeldb.versioning.model._
+
+trait Blob {}

--- a/client/scala/src/main/scala/ai/verta/blobs/Blob.scala
+++ b/client/scala/src/main/scala/ai/verta/blobs/Blob.scala
@@ -1,3 +1,3 @@
-package ai.verta.blobs.dataset
+package ai.verta.blobs
 
 trait Blob {}

--- a/client/scala/src/main/scala/ai/verta/blobs/dataset/Dataset.scala
+++ b/client/scala/src/main/scala/ai/verta/blobs/dataset/Dataset.scala
@@ -1,6 +1,7 @@
 package ai.verta.blobs.dataset
 
 import ai.verta.swagger._public.modeldb.versioning.model._
+import ai.verta.blobs._
 
 import scala.collection.mutable.HashMap
 import scala.util.{Failure, Success, Try}

--- a/client/scala/src/main/scala/ai/verta/blobs/dataset/Dataset.scala
+++ b/client/scala/src/main/scala/ai/verta/blobs/dataset/Dataset.scala
@@ -36,7 +36,7 @@ trait Dataset extends Blob {
   }
 
   /** Get all the Dataset blob's corresponding list of components */
-  protected def components = getAllMetadata.map(toComponent _).toList
+  protected def components = getAllMetadata.map(toComponent).toList
 
   /** Get the set of all the files' metadata managed by the Dataset blob  */
   def getAllMetadata = contents.values.filter(_.isSuccess).map(_.get)

--- a/client/scala/src/main/scala/ai/verta/blobs/dataset/Dataset.scala
+++ b/client/scala/src/main/scala/ai/verta/blobs/dataset/Dataset.scala
@@ -6,7 +6,7 @@ import scala.collection.mutable.HashMap
 import scala.util.{Failure, Success, Try}
 
 trait Dataset extends Blob {
-  protected var contents = new HashMap[String, Try[FileMetadata]]() // for deduplication and comparing
+  protected var contents: HashMap[String, FileMetadata] // for deduplication and comparing
 
   /** Helper to convert VersioningPathDatasetComponentBlob to FileMetadata
    */
@@ -30,28 +30,11 @@ trait Dataset extends Blob {
    *  @param path path to the file
    *  @return None if path is not in dataset blob, or some file metadata.
    */
-  def getMetadata(path: String): Try[FileMetadata] = contents.get(path) match {
-    case Some(v) => v
-    case None => Failure(new IllegalArgumentException("Path is not stored, or is a directory."))
-  }
+  def getMetadata(path: String) = contents.get(path)
 
   /** Get all the Dataset blob's corresponding list of components */
   protected def components = getAllMetadata.map(toComponent).toList
 
   /** Get the set of all the files' metadata managed by the Dataset blob  */
-  def getAllMetadata = contents.values.filter(_.isSuccess).map(_.get)
-}
-
-/** Represent a file's metadata stored in Dataset Blob
- *  @param lastModified last time file was modified
- *  @param md5 MD5 hash of the file
- *  @param path path of the file
- *  @param size size of the file
- */
-class FileMetadata(val lastModified: BigInt, val md5: String, val path: String, val size: BigInt) {
-  override def equals(other: Any) = other match {
-    case other: FileMetadata => lastModified == other.lastModified &&
-    md5 == other.md5 && path == other.path && size == other.size
-    case _ => false
-  }
+  def getAllMetadata = contents.values
 }

--- a/client/scala/src/main/scala/ai/verta/blobs/dataset/Dataset.scala
+++ b/client/scala/src/main/scala/ai/verta/blobs/dataset/Dataset.scala
@@ -1,0 +1,50 @@
+package ai.verta.blobs.dataset
+
+import ai.verta.swagger._public.modeldb.versioning.model._
+
+import scala.collection.mutable.HashMap
+
+trait Dataset extends Blob {
+  protected var contents = new HashMap[String, FileMetadata]() // for deduplication and comparing
+
+  /** Helper to convert VersioningPathDatasetComponentBlob to FileMetadata
+   */
+  protected def toMetadata(component: VersioningPathDatasetComponentBlob) = new FileMetadata(
+    component.last_modified_at_source.get,
+    component.md5.get,
+    component.path.get,
+    component.size.get
+  )
+
+  /** Helper to convert VersioningPathDatasetComponentBlob to FileMetadata
+   */
+  protected def toComponent(metadata: FileMetadata) = VersioningPathDatasetComponentBlob(
+    last_modified_at_source = Some(metadata.lastModified),
+    md5 = Some(metadata.md5),
+    path = Some(metadata.path),
+    size = Some(metadata.size)
+  )
+
+  /** Get the metadata of a certain file stored in the dataset blob
+   *  @param path path to the file
+   *  @return None if path is not in dataset blob, or some file metadata.
+   */
+  def getMetadata(path: String): Option[FileMetadata] = contents.get(path)
+
+  /** Get all the files' metadata managed by the Dataset blob */
+  protected def components = contents.values.map(toComponent _).toList
+}
+
+/** Represent a file's metadata stored in Dataset Blob
+ *  @param lastModified last time file was modified
+ *  @param md5 MD5 hash of the file
+ *  @param path path of the file
+ *  @param size size of the file
+ */
+class FileMetadata(val lastModified: BigInt, val md5: String, val path: String, val size: BigInt) {
+  override def equals(other: Any) = other match {
+    case other: FileMetadata => lastModified == other.lastModified &&
+    md5 == other.md5 && path == other.path && size == other.size
+    case _ => false
+  }
+}

--- a/client/scala/src/main/scala/ai/verta/blobs/dataset/FileMetadata.scala
+++ b/client/scala/src/main/scala/ai/verta/blobs/dataset/FileMetadata.scala
@@ -1,0 +1,17 @@
+package ai.verta.blobs.dataset
+
+/** Represent a file's metadata stored in Dataset Blob
+ *  @param lastModified last time file was modified
+ *  @param md5 MD5 hash of the file
+ *  @param path path of the file
+ *  @param size size of the file
+ */
+class FileMetadata(val lastModified: BigInt, val md5: String, val path: String, val size: BigInt) {
+  override def equals(other: Any) = other match {
+    case other: FileMetadata => lastModified == other.lastModified &&
+    md5 == other.md5 && path == other.path && size == other.size
+    case _ => false
+  }
+
+  override def toString = lastModified + " " + md5 + " " + path + " " + size
+}

--- a/client/scala/src/main/scala/ai/verta/blobs/dataset/FileMetadata.scala
+++ b/client/scala/src/main/scala/ai/verta/blobs/dataset/FileMetadata.scala
@@ -12,6 +12,4 @@ class FileMetadata(val lastModified: BigInt, val md5: String, val path: String, 
     md5 == other.md5 && path == other.path && size == other.size
     case _ => false
   }
-
-  override def toString = lastModified + " " + md5 + " " + path + " " + size
 }

--- a/client/scala/src/main/scala/ai/verta/blobs/dataset/PathBlob.scala
+++ b/client/scala/src/main/scala/ai/verta/blobs/dataset/PathBlob.scala
@@ -1,0 +1,123 @@
+package ai.verta.blobs.dataset
+
+import ai.verta.swagger._public.modeldb.versioning.model._
+
+import java.security.{MessageDigest, DigestInputStream}
+import java.io.{File, FileInputStream}
+
+import scala.collection.mutable.HashMap
+import scala.util.{Failure, Success, Try}
+
+/** Captures metadata about files
+ *  @param paths list of filepaths or directory paths
+ */
+ case class PathBlob(private val paths: List[String]) extends Dataset {
+  private val BufferSize = 8192
+  paths.map(expanduser _).map((path: String) => processPath(new File(path)))
+
+  override def equals(other: Any) = other match {
+    case other: PathBlob => contents.equals(other.contents)
+    case _ => false
+  }
+
+  /** Hash the file's content
+   *  From https://stackoverflow.com/questions/41642595/scala-file-hashing
+   *  @param path filepath
+   */
+  private def hash(file: File): String = {
+     val buffer = new Array[Byte](BufferSize)
+     val messageDigest = MessageDigest.getInstance("MD5")
+
+     val dis = new DigestInputStream(
+       new FileInputStream(file),
+       messageDigest
+     )
+
+     try {
+       while (dis.read(buffer) != -1) {}
+     } finally {
+       dis.close()
+     }
+
+     // Convert to hexadecimal
+     messageDigest.digest.map("%02x".format(_)).mkString
+   }
+
+   /** Get the metadata of path.
+    *  @param file a file object, representing the path
+    *  @return a list of components of file under the path
+    */
+   private def processPath(file: File) = {
+     var files = List(file) // stack
+
+     while (files.length > 0) {
+       var fileToProcess = files.head
+       files = files.drop(1)
+
+       if (fileToProcess.isDirectory()) {
+         files = fileToProcess.listFiles().toList ::: files
+       }
+       else {
+         processFile(fileToProcess)
+       }
+     }
+   }
+
+  /** Extract the metadata of the file
+   *  If the file has already been processed, or if the path is invalid, return None
+   *  @param file file
+   *  @return the metadata of the file, wrapped in (some) VersioningPathDatasetComponentBlob
+   */
+   private def processFile(file: File) = {
+    if (!contents.contains(file.getPath())) {
+      Try {
+        new FileMetadata(
+          BigInt(file.lastModified()),
+          hash(file),
+          file.getPath(),
+          BigInt(file.length)
+        )
+      } match {
+        case Success(metadata) => {
+          contents.put(file.getPath(), metadata)
+          Success(())
+        }
+        case Failure(e) => Failure(e)
+      }
+    }
+    else Failure(new IllegalArgumentException("File has already been added."))
+   }
+
+  /** Analogous to Python's os.path.expanduser
+   *  From https://stackoverflow.com/questions/6803913/java-analogous-to-python-os-path-expanduser-os-path-expandvars
+   *  @param path path
+   *  @return path, but with (first occurence of) ~ replace with user's home directory
+   */
+  private def expanduser(path: String) = path.replaceFirst("~", System.getProperty("user.home"))
+}
+
+/** Companion object to handle interaction with versioning blob */
+object PathBlob {
+  /** Factory method to convert a versioning path dataset blob instance
+   *  @param pathVersioningBlob the versioning blob to convert
+   *  @return equivalent PathBlob instance
+   */
+  def apply(pathVersioningBlob: VersioningPathDatasetBlob) = {
+    var pathBlob = new PathBlob(List())
+
+    pathVersioningBlob.components.get.map(
+      comp => pathBlob.contents.put(comp.path.get, pathBlob.toMetadata(comp))
+    )
+    pathBlob
+  }
+
+  /** Convert a PathBlob instance to a VersioningBlob
+   *  @param blob PathBlob instance
+   *  @return equivalent VersioningBlob instance
+   */
+  def toVersioningBlob(blob: PathBlob) = VersioningBlob(
+      dataset = Some(VersioningDatasetBlob(
+        path = Some(VersioningPathDatasetBlob(Some(blob.components)))
+      ))
+  )
+}

--- a/client/scala/src/main/scala/ai/verta/blobs/dataset/PathBlob.scala
+++ b/client/scala/src/main/scala/ai/verta/blobs/dataset/PathBlob.scala
@@ -18,8 +18,8 @@ case class PathBlob(private val paths: List[String]) extends Dataset {
   private val BufferSize = 8192
 
   private val metadataList = paths.map(expanduser)
-  .flatMap((path: String) => processPath(new File(path)))
-  .map(metadata => metadata.path -> metadata)
+    .flatMap((path: String) => processPath(new File(path)))
+    .map(metadata => metadata.path -> metadata)
 
   protected var contents = HashMap(metadataList: _*)
 

--- a/client/scala/src/main/scala/ai/verta/blobs/dataset/PathBlob.scala
+++ b/client/scala/src/main/scala/ai/verta/blobs/dataset/PathBlob.scala
@@ -64,7 +64,7 @@ import scala.util.{Failure, Success, Try}
    }
 
   /** Extract the metadata of the file
-   *  If the file has already been processed, or if the path is invalid, return None
+   *  If the file has already been processed, or if the path is invalid, the file is skipped
    *  @param file file
    *  @return the metadata of the file, wrapped in (some) VersioningPathDatasetComponentBlob
    */

--- a/client/scala/src/main/scala/ai/verta/blobs/dataset/PathBlob.scala
+++ b/client/scala/src/main/scala/ai/verta/blobs/dataset/PathBlob.scala
@@ -16,7 +16,7 @@ import scala.util.{Failure, Success, Try}
   paths.map(expanduser _).map((path: String) => processPath(new File(path)))
 
   override def equals(other: Any) = other match {
-    case other: PathBlob => getAllMetadata equals other.getAllMetadata
+    case other: PathBlob => getAllMetadata.equals(other.getAllMetadata)
     case _ => false
   }
 

--- a/client/scala/src/main/scala/ai/verta/blobs/dataset/PathBlob.scala
+++ b/client/scala/src/main/scala/ai/verta/blobs/dataset/PathBlob.scala
@@ -39,7 +39,6 @@ object PathBlob {
            .map((path: String) => processPath(new File(path)))
            .map(_.get)
     )
-      // .map(metadata => metadata.path -> metadata)
 
     metadataLists match {
       case Failure(e) => Failure(e)

--- a/client/scala/src/main/scala/ai/verta/blobs/dataset/PathBlob.scala
+++ b/client/scala/src/main/scala/ai/verta/blobs/dataset/PathBlob.scala
@@ -11,7 +11,7 @@ import scala.util.{Failure, Success, Try}
 /** Captures metadata about files
  *  @param paths list of filepaths or directory paths
  */
- case class PathBlob(private val paths: List[String]) extends Dataset {
+case class PathBlob(private val paths: List[String]) extends Dataset {
   private val BufferSize = 8192
 
   private val metadataList = paths.map(expanduser)
@@ -31,62 +31,62 @@ import scala.util.{Failure, Success, Try}
    *  @param path filepath
    */
   private def hash(file: File) = Try {
-     val buffer = new Array[Byte](BufferSize)
-     val messageDigest = MessageDigest.getInstance("MD5")
+    val buffer = new Array[Byte](BufferSize)
+    val messageDigest = MessageDigest.getInstance("MD5")
 
-     val dis = new DigestInputStream(
-       new FileInputStream(file),
-       messageDigest
-     )
+    val dis = new DigestInputStream(
+      new FileInputStream(file),
+      messageDigest
+    )
 
-     try {
-       while (dis.read(buffer) != -1) {}
-     } finally {
-       dis.close()
-     }
+    try {
+      while (dis.read(buffer) != -1) {}
+    } finally {
+      dis.close()
+    }
 
-     // Convert to hexadecimal
-     messageDigest.digest.map("%02x".format(_)).mkString
-   }
+    // Convert to hexadecimal
+    messageDigest.digest.map("%02x".format(_)).mkString
+  }
 
-   /** Get the metadata of path.
-    *  @param file a file object, representing the path
-    *  @return a list of components of file under the path
-    */
-   private def processPath(file: File): List[FileMetadata] = {
-     var files = List(file) // stack
-     var ret: List[FileMetadata] = List()
+  /** Get the metadata of path.
+   *  @param file a file object, representing the path
+   *  @return a list of components of file under the path
+   */
+  private def processPath(file: File): List[FileMetadata] = {
+    var files = List(file) // stack
+    var ret: List[FileMetadata] = List()
 
-     // non-recursive DFS to prevent stack overflow
-     while (files.length > 0) {
-       var fileToProcess = files.head
-       files = files.drop(1)
+    // non-recursive DFS to prevent stack overflow
+    while (files.length > 0) {
+      var fileToProcess = files.head
+      files = files.drop(1)
 
-       if (fileToProcess.isDirectory()) {
-         files = fileToProcess.listFiles().toList ::: files
-       }
-       else {
-         ret = processFile(fileToProcess) :: ret
-       }
-     }
+      if (fileToProcess.isDirectory()) {
+        files = fileToProcess.listFiles().toList ::: files
+      }
+      else {
+        ret = processFile(fileToProcess) :: ret
+      }
+    }
 
-     ret
-   }
+    ret
+  }
 
   /** Extract the metadata of the file
    *  If the file has an invalid path, exception is thrown immediately, and program stops (if not caught outside)
    *  @param file file
    *  @return the metadata of the file, wrapped in a FileMetadata object (if success)
    */
-   private def processFile(file: File) = hash(file) match {
-      case Failure(e) => throw e
-      case Success(fileHash) => new FileMetadata (
-        BigInt(file.lastModified()),
-        fileHash,
-        file.getPath(),
-        BigInt(file.length)
-      )
-    }
+  private def processFile(file: File) = hash(file) match {
+    case Failure(e) => throw e
+    case Success(fileHash) => new FileMetadata (
+      BigInt(file.lastModified()),
+      fileHash,
+      file.getPath(),
+      BigInt(file.length)
+    )
+  }
 
   /** Analogous to Python's os.path.expanduser
    *  From https://stackoverflow.com/questions/6803913/java-analogous-to-python-os-path-expanduser-os-path-expandvars

--- a/client/scala/src/main/scala/ai/verta/blobs/dataset/PathBlob.scala
+++ b/client/scala/src/main/scala/ai/verta/blobs/dataset/PathBlob.scala
@@ -13,7 +13,7 @@ import scala.util.{Failure, Success, Try}
  */
  case class PathBlob(private val paths: List[String]) extends Dataset {
   private val BufferSize = 8192
-  paths.map(expanduser _).map((path: String) => processPath(new File(path)))
+  paths.map(expanduser).map((path: String) => processPath(new File(path)))
 
   override def equals(other: Any) = other match {
     case other: PathBlob => getAllMetadata.equals(other.getAllMetadata)

--- a/client/scala/src/main/scala/ai/verta/blobs/dataset/PathBlob.scala
+++ b/client/scala/src/main/scala/ai/verta/blobs/dataset/PathBlob.scala
@@ -11,6 +11,8 @@ import scala.annotation.tailrec
 
 /** Captures metadata about files
  *  @param paths list of filepaths or directory paths
+ *  @throws IOException - if any path is invalid (i.e non-existent)
+ *  @throws SecurityException - If a security manager exists and its SecurityManager.checkRead(java.lang.String) method denies read access to any file
  */
 case class PathBlob(private val paths: List[String]) extends Dataset {
   private val BufferSize = 8192
@@ -76,6 +78,8 @@ case class PathBlob(private val paths: List[String]) extends Dataset {
    *  If the file has an invalid path, exception is thrown immediately, and program stops (if not caught outside)
    *  @param file file
    *  @return the metadata of the file, wrapped in a FileMetadata object (if success)
+   *  @throws IOException - if the path is invalid (i.e non-existent)
+   *  @throws SecurityException - If a security manager exists and its SecurityManager.checkRead(java.lang.String) method denies read access to the file
    */
   private def processFile(file: File) = hash(file) match {
     case Failure(e) => throw e

--- a/client/scala/src/main/scala/ai/verta/blobs/dataset/PathBlob.scala
+++ b/client/scala/src/main/scala/ai/verta/blobs/dataset/PathBlob.scala
@@ -62,8 +62,7 @@ case class PathBlob(private val paths: List[String]) extends Dataset {
    *  @param stack a stack containing the files/dirs to explore
    *  @param acc accumulator list of file metadata to return
    */
-  @tailrec
-  private def dfs(stack: List[File], acc: List[FileMetadata]): List[FileMetadata] = {
+  @tailrec private def dfs(stack: List[File], acc: List[FileMetadata]): List[FileMetadata] = {
     if (stack.isEmpty) acc
     else if (stack.head.isDirectory) {
       val dir = stack.head

--- a/client/scala/src/main/scala/ai/verta/blobs/dataset/PathBlob.scala
+++ b/client/scala/src/main/scala/ai/verta/blobs/dataset/PathBlob.scala
@@ -17,7 +17,7 @@ import scala.annotation.tailrec
  *  }}}
  *  If an invalid path is passed to the constructor, it will return a failure.
  */
-case class PathBlob(metadataList: List[Tuple2[String, FileMetadata]]) extends Dataset {
+case class PathBlob(private val metadataList: List[Tuple2[String, FileMetadata]]) extends Dataset {
   protected var contents = HashMap(metadataList: _*)
 
   override def equals(other: Any) = other match {

--- a/client/scala/src/main/scala/ai/verta/blobs/dataset/PathBlob.scala
+++ b/client/scala/src/main/scala/ai/verta/blobs/dataset/PathBlob.scala
@@ -85,7 +85,6 @@ import scala.util.{Failure, Success, Try}
         case Failure(e) => Failure(e)
       }
     }
-    else Failure(new IllegalArgumentException("File has already been added."))
    }
 
   /** Analogous to Python's os.path.expanduser

--- a/client/scala/src/main/scala/ai/verta/blobs/dataset/PathBlob.scala
+++ b/client/scala/src/main/scala/ai/verta/blobs/dataset/PathBlob.scala
@@ -66,11 +66,11 @@ case class PathBlob(private val paths: List[String]) extends Dataset {
     if (stack.isEmpty) acc
     else if (stack.head.isDirectory) {
       val dir = stack.head
-      dfs(dir.listFiles().toList ::: stack.drop(1), acc)
+      dfs(dir.listFiles().toList ::: stack.tail, acc)
     }
     else {
       val file = stack.head
-      dfs(stack.drop(1), processFile(file) :: acc)
+      dfs(stack.tail, processFile(file) :: acc)
     }
   }
 

--- a/client/scala/src/main/scala/ai/verta/blobs/dataset/PathBlob.scala
+++ b/client/scala/src/main/scala/ai/verta/blobs/dataset/PathBlob.scala
@@ -125,7 +125,7 @@ object PathBlob {
    *  @return the metadata of the file, wrapped in a FileMetadata object (if success)
    */
   private def processFile(file: File) = hash(file) match {
-    case Failure(e) => throw e
+    case Failure(e) => Failure(e)
     case Success(fileHash) => Try(new FileMetadata (
       BigInt(file.lastModified()),
       fileHash,

--- a/client/scala/src/main/scala/ai/verta/blobs/dataset/PathBlob.scala
+++ b/client/scala/src/main/scala/ai/verta/blobs/dataset/PathBlob.scala
@@ -116,8 +116,8 @@ object PathBlob {
    *  @return equivalent VersioningBlob instance
    */
   def toVersioningBlob(blob: PathBlob) = VersioningBlob(
-      dataset = Some(VersioningDatasetBlob(
-        path = Some(VersioningPathDatasetBlob(Some(blob.components)))
-      ))
+    dataset = Some(VersioningDatasetBlob(
+      path = Some(VersioningPathDatasetBlob(Some(blob.components)))
+    ))
   )
 }

--- a/client/scala/src/main/scala/ai/verta/blobs/dataset/PathBlob.scala
+++ b/client/scala/src/main/scala/ai/verta/blobs/dataset/PathBlob.scala
@@ -34,9 +34,10 @@ object PathBlob {
    *  @return if any path is invalid, a failure along with exception message. Otherwise, the pathblob (wrapped in success)
    */
   def apply(paths: List[String]): Try[PathBlob] = {
-    val metadataLists = Try(paths.map(expanduser)
-      .map((path: String) => processPath(new File(path)))
-      .map(_.get)
+    val metadataLists = Try(
+      paths.map(expanduser)
+           .map((path: String) => processPath(new File(path)))
+           .map(_.get)
     )
       // .map(metadata => metadata.path -> metadata)
 

--- a/client/scala/src/main/scala/ai/verta/blobs/dataset/PathBlob.scala
+++ b/client/scala/src/main/scala/ai/verta/blobs/dataset/PathBlob.scala
@@ -46,7 +46,7 @@ object PathBlob {
     }
   }
 
-  /** Factory method to convert a versioning path dataset blob instance
+  /** Factory method to convert a versioning path dataset blob instance. Not meant to be used by user
    *  @param pathVersioningBlob the versioning blob to convert
    *  @return equivalent PathBlob instance
    */

--- a/client/scala/src/main/scala/ai/verta/blobs/dataset/PathBlob.scala
+++ b/client/scala/src/main/scala/ai/verta/blobs/dataset/PathBlob.scala
@@ -54,9 +54,7 @@ case class PathBlob(private val paths: List[String]) extends Dataset {
    *  @param file a file object, representing the path
    *  @return a list of components of file under the path
    */
-  private def processPath(file: File): List[FileMetadata] = {
-    dfs(List(file), List())
-  }
+  private def processPath(file: File): List[FileMetadata] = dfs(List(file), List())
 
   /** Tail-recursive DFS traversal to prevent stack overflow error
    *  @param stack a stack containing the files/dirs to explore

--- a/client/scala/src/test/scala/ai/verta/blobs/dataset/TestPathBlob.scala
+++ b/client/scala/src/test/scala/ai/verta/blobs/dataset/TestPathBlob.scala
@@ -32,14 +32,14 @@ class TestPathBlob extends FunSuite {
 
   test("PathBlob should retrieve a file's metadata correctly") {
     val f = fixture
-    var pathBlob = PathBlob(List(f.testfile))
+    var pathBlob = PathBlob(List(f.testfile)).get
 
     assertMetadata(pathBlob.getMetadata(f.testfile).get, f.testfile)
   }
 
   test("PathBlob should retrieve multiple files correctly") {
     val f = fixture
-    var pathBlob = PathBlob(List(f.testfile, f.testfile2))
+    var pathBlob = PathBlob(List(f.testfile, f.testfile2)).get
 
     assertMetadata(pathBlob.getMetadata(f.testfile).get, f.testfile)
     assertMetadata(pathBlob.getMetadata(f.testfile2).get, f.testfile2)
@@ -47,7 +47,7 @@ class TestPathBlob extends FunSuite {
 
   test("PathBlob should not store directory") {
     val f = fixture
-    val pathBlob = PathBlob(List(f.testDir, f.testSubdir))
+    val pathBlob = PathBlob(List(f.testDir, f.testSubdir)).get
 
     val dirAttempt = pathBlob.getMetadata(f.testDir)
     val subdirAttempt = pathBlob.getMetadata(f.testDir)
@@ -57,18 +57,16 @@ class TestPathBlob extends FunSuite {
     assert(pathBlob.getMetadata(f.testfile).isDefined)
   }
 
-  test("PathBlob should throw an exception when an invalid path is passed") {
+  test("PathBlob constructor should fail when an invalid path is passed") {
     val f = fixture
     val invalid = f.testDir + "/invalid-file"
-    assertThrows[FileNotFoundException] {
-      val pathBlob = PathBlob(List(invalid, f.testfile))
-    }
+    assert(PathBlob(List(invalid, f.testfile)).isFailure)
   }
 
   test("PathBlob should not contain duplicate paths") {
     val f = fixture
-    val pathBlob1 = PathBlob(List(f.testDir, f.testSubdir, f.testfile, f.testfile2, f.testfile))
-    val pathBlob2 = PathBlob(List(f.testfile, f.testfile2))
+    val pathBlob1 = PathBlob(List(f.testDir, f.testSubdir, f.testfile, f.testfile2, f.testfile)).get
+    val pathBlob2 = PathBlob(List(f.testfile, f.testfile2)).get
 
     assert(pathBlob1 equals pathBlob2)
   }

--- a/client/scala/src/test/scala/ai/verta/blobs/dataset/TestPathBlob.scala
+++ b/client/scala/src/test/scala/ai/verta/blobs/dataset/TestPathBlob.scala
@@ -64,7 +64,7 @@ class TestPathBlob extends FunSuite {
     val invalidAttempt = PathBlob(List(invalid, f.testfile))
 
     assert(invalidAttempt.isFailure)
-    println(invalidAttempt match {case Failure(e) => e.getMessage contains "No such file or directory"})
+    assert(invalidAttempt match {case Failure(e) => e.getMessage contains "No such file or directory"})
   }
 
   test("PathBlob should not contain duplicate paths") {

--- a/client/scala/src/test/scala/ai/verta/blobs/dataset/TestPathBlob.scala
+++ b/client/scala/src/test/scala/ai/verta/blobs/dataset/TestPathBlob.scala
@@ -6,7 +6,8 @@ import scala.language.reflectiveCalls
 
 import org.scalatest.FunSuite
 import org.scalatest.Assertions._
-import scala.util.{Failure, Success, Try}
+
+import java.io.FileNotFoundException
 
 class TestPathBlob extends FunSuite {
   /** Verify that a FileMetadata has correct path and does not have invalid parameter
@@ -51,24 +52,17 @@ class TestPathBlob extends FunSuite {
     val dirAttempt = pathBlob.getMetadata(f.testDir)
     val subdirAttempt = pathBlob.getMetadata(f.testDir)
 
-    assert(dirAttempt.isFailure)
-    assert(subdirAttempt.isFailure)
-    assert(dirAttempt match {case Failure(e) => e.getMessage contains "is a directory"})
-    assert(subdirAttempt match {case Failure(e) => e.getMessage contains "is a directory"})
-
-    assert(pathBlob.getMetadata(f.testfile).isSuccess)
+    assert(dirAttempt.isEmpty)
+    assert(subdirAttempt.isEmpty)
+    assert(pathBlob.getMetadata(f.testfile).isDefined)
   }
 
-  test("PathBlob should not store invalid paths, but should not stop execution") {
+  test("PathBlob should throw an exception when an invalid path is passed") {
     val f = fixture
     val invalid = f.testDir + "/invalid-file"
-    val pathBlob = PathBlob(List(invalid, f.testfile))
-
-
-    val invalidAttempt = pathBlob.getMetadata(invalid)
-    assert(invalidAttempt.isFailure)
-    assert(invalidAttempt match {case Failure(e) => e.getMessage contains "No such file or directory"})
-    assert(pathBlob.getMetadata(f.testfile).isSuccess)
+    assertThrows[FileNotFoundException] {
+      val pathBlob = PathBlob(List(invalid, f.testfile))
+    }
   }
 
   test("PathBlob should not contain duplicate paths") {

--- a/client/scala/src/test/scala/ai/verta/blobs/dataset/TestPathBlob.scala
+++ b/client/scala/src/test/scala/ai/verta/blobs/dataset/TestPathBlob.scala
@@ -1,13 +1,8 @@
 package ai.verta.blobs.dataset
 
-import ai.verta.client._
 import ai.verta.blobs._
-import ai.verta.swagger.client.HttpException
-import ai.verta.swagger._public.modeldb.versioning.model.VersioningSetTagRequestResponse
 
-import scala.concurrent.ExecutionContext
 import scala.language.reflectiveCalls
-import scala.util.{Try, Success, Failure}
 
 import org.scalatest.FunSuite
 import org.scalatest.Assertions._

--- a/client/scala/src/test/scala/ai/verta/blobs/dataset/TestPathBlob.scala
+++ b/client/scala/src/test/scala/ai/verta/blobs/dataset/TestPathBlob.scala
@@ -1,0 +1,76 @@
+package ai.verta.blobs.dataset
+
+import ai.verta.client._
+import ai.verta.blobs._
+import ai.verta.swagger.client.HttpException
+import ai.verta.swagger._public.modeldb.versioning.model.VersioningSetTagRequestResponse
+
+import scala.concurrent.ExecutionContext
+import scala.language.reflectiveCalls
+import scala.util.{Try, Success, Failure}
+
+import org.scalatest.FunSuite
+import org.scalatest.Assertions._
+
+class TestPathBlob extends FunSuite {
+  /** Verify that a FileMetadata has correct path and does not have invalid parameter
+   *  @param metadata file's metadata
+   *  @param path file's path (to be checked)
+   */
+  def assertMetadata(metadata: FileMetadata, path: String) = {
+    assert(metadata.path.equals(path))
+    assert(metadata.size > 0)
+    assert(metadata.lastModified > 0)
+    assert(metadata.md5.length > 0)
+  }
+
+  def fixture =
+    new {
+      val workingDir = System.getProperty("user.dir")
+      val testDir = workingDir + "/src/test/scala/ai/verta/blobs/testdir"
+      val testfile = testDir + "/testfile"
+      val testSubdir = testDir + "/testsubdir"
+      val testfile2 = testSubdir + "/testfile2"
+    }
+
+  test("PathBlob should retrieve a file's metadata correctly") {
+    val f = fixture
+    var pathBlob = PathBlob(List(f.testfile))
+
+    assertMetadata(pathBlob.getMetadata(f.testfile).get, f.testfile)
+  }
+
+  test("PathBlob should retrieve multiple files correctly") {
+    val f = fixture
+    var pathBlob = PathBlob(List(f.testfile, f.testfile2))
+
+    assertMetadata(pathBlob.getMetadata(f.testfile).get, f.testfile)
+    assertMetadata(pathBlob.getMetadata(f.testfile2).get, f.testfile2)
+  }
+
+  test("PathBlob should not store directory") {
+    val f = fixture
+    val pathBlob = PathBlob(List(f.testDir, f.testSubdir))
+
+    assert(pathBlob.getMetadata(f.testDir).isEmpty)
+    assert(pathBlob.getMetadata(f.testSubdir).isEmpty)
+    assert(pathBlob.getMetadata(f.testfile).isDefined)
+  }
+
+  test("PathBlob should not store invalid paths, but should not stop execution") {
+    val f = fixture
+    val invalid = f.testDir + "/invalid-file"
+    val pathBlob = PathBlob(List(invalid, f.testfile))
+
+    assert(pathBlob.getMetadata(invalid).isEmpty)
+    assert(pathBlob.getMetadata(f.testfile).isDefined)
+  }
+
+  test("PathBlob should not contain duplicate paths") {
+    val f = fixture
+    val pathBlob1 = PathBlob(List(f.testDir, f.testSubdir, f.testfile, f.testfile2, f.testfile))
+    val pathBlob2 = PathBlob(List(f.testfile, f.testfile2))
+
+    assert(pathBlob1 equals pathBlob2)
+  }
+}

--- a/client/scala/src/test/scala/ai/verta/blobs/dataset/TestPathBlob.scala
+++ b/client/scala/src/test/scala/ai/verta/blobs/dataset/TestPathBlob.scala
@@ -3,6 +3,7 @@ package ai.verta.blobs.dataset
 import ai.verta.blobs._
 
 import scala.language.reflectiveCalls
+import scala.util.{Failure, Success, Try}
 
 import org.scalatest.FunSuite
 import org.scalatest.Assertions._
@@ -60,7 +61,10 @@ class TestPathBlob extends FunSuite {
   test("PathBlob constructor should fail when an invalid path is passed") {
     val f = fixture
     val invalid = f.testDir + "/invalid-file"
-    assert(PathBlob(List(invalid, f.testfile)).isFailure)
+    val invalidAttempt = PathBlob(List(invalid, f.testfile))
+
+    assert(invalidAttempt.isFailure)
+    println(invalidAttempt match {case Failure(e) => e.getMessage contains "No such file or directory"})
   }
 
   test("PathBlob should not contain duplicate paths") {

--- a/client/scala/src/test/scala/ai/verta/blobs/testdir/testfile
+++ b/client/scala/src/test/scala/ai/verta/blobs/testdir/testfile
@@ -1,0 +1,1 @@
+This file is the first test file.

--- a/client/scala/src/test/scala/ai/verta/blobs/testdir/testsubdir/testfile2
+++ b/client/scala/src/test/scala/ai/verta/blobs/testdir/testsubdir/testfile2
@@ -1,0 +1,1 @@
+This file is the second testfile.


### PR DESCRIPTION
I've decided to broken the Dataset Blob implementation into 2 PRs, since one is already too large. The shared code in Dataset trait is also used for S3 (another type of Dataset).