### PR TITLE
VR-4525: Retry part uploads on ConnectionErrors

### DIFF
--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -2116,7 +2116,14 @@ class ExperimentRun(_ModelDBEntity):
                 part_stream = six.BytesIO(file_part)
 
                 # upload part
-                response = _utils.make_request("PUT", url, self._conn, data=part_stream)
+                #     Retry connection errors, to make large multipart uploads more robust.
+                for _ in range(3):
+                    try:
+                        response = _utils.make_request("PUT", url, self._conn, data=part_stream)
+                    except requests.ConnectionError:
+                        continue  # try again
+                    else:
+                        break
                 response.raise_for_status()
 
                 # commit part

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -2121,6 +2121,7 @@ class ExperimentRun(_ModelDBEntity):
                     try:
                         response = _utils.make_request("PUT", url, self._conn, data=part_stream)
                     except requests.ConnectionError:
+                        time.sleep(10)
                         continue  # try again
                     else:
                         break

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -2120,7 +2120,7 @@ class ExperimentRun(_ModelDBEntity):
                 for _ in range(3):
                     try:
                         response = _utils.make_request("PUT", url, self._conn, data=part_stream)
-                    except requests.ConnectionError:
+                    except requests.ConnectionError:  # e.g. broken pipe
                         time.sleep(10)
                         continue  # try again
                     else:

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -2121,7 +2121,7 @@ class ExperimentRun(_ModelDBEntity):
                     try:
                         response = _utils.make_request("PUT", url, self._conn, data=part_stream)
                     except requests.ConnectionError:  # e.g. broken pipe
-                        time.sleep(10)
+                        time.sleep(1)
                         continue  # try again
                     else:
                         break


### PR DESCRIPTION
I wanted to specifically only catch broken pipes, but unwrapping a `requests` exception is tedious and undocumented! This is how deep I had to go in my investigation:
<img width="473" alt="Screen Shot 2020-06-08 at 3 57 28 PM" src="https://user-images.githubusercontent.com/7754936/84088312-111a8180-a9a1-11ea-92e8-81354bc5b913.png">
Rather than have a series of `if`s that I can't even justify with docs because there are none, I'm comfortable with retrying on all `ConnectionError`s for just this presigned URL upload.