### PR TITLE
VR-4522: Add methods for uploading artifacts in commit

### DIFF
--- a/client/verta/verta/_repository/commit.py
+++ b/client/verta/verta/_repository/commit.py
@@ -5,6 +5,10 @@ from __future__ import print_function
 import collections
 from datetime import datetime
 import heapq
+import os
+import time
+
+import requests
 
 from .._protos.public.modeldb.versioning import VersioningService_pb2 as _VersioningService
 
@@ -122,6 +126,154 @@ class Commit(object):
     def _raise_lookup_error(path):
         e = LookupError("Commit does not contain path \"{}\"".format(path))
         six.raise_from(e, None)
+
+    # TODO: consolidate this with similar method in `_ModelDBEntity`
+    def _get_url_for_artifact(self, blob_path, dataset_component_path, method, part_num=0):
+        """
+        Obtains a URL to use for accessing stored artifacts.
+
+        Parameters
+        ----------
+        blob_path : str
+            Path to blob within repo.
+        dataset_component_path : str
+            Filepath in dataset component blob.
+        method : {'GET', 'PUT'}
+            HTTP method to request for the generated URL.
+        part_num : int, optional
+            If using Multipart Upload, number of part to be uploaded.
+
+        Returns
+        -------
+        response_msg : `_VersioningService.GetUrlForBlobVersioned.Response`
+            Backend response.
+
+        """
+        if method.upper() not in ("GET", "PUT"):
+            raise ValueError("`method` must be one of {'GET', 'PUT'}")
+
+        Message = _VersioningService.GetUrlForBlobVersioned
+        msg = Message(
+            location=path_to_location(blob_path),
+            path_dataset_component_blob_path=dataset_component_path,
+            method=method,
+            part_number=part_num,
+        )
+        data = _utils.proto_to_json(msg)
+        endpoint = "{}://{}/api/v1/modeldb/versioning/repositories/{}/commits/{}/getUrlForBlobVersioned".format(
+            self._conn.scheme,
+            self._conn.socket,
+            self._repo.id,
+            self.id,
+        )
+        response = _utils.make_request("POST", endpoint, self._conn, json=data)
+        _utils.raise_for_http_error(response)
+
+        response_msg = _utils.json_to_proto(response.json(), Message.Response)
+
+        url = response_msg.url
+        # accommodate port-forwarded NFS store
+        if 'https://localhost' in url[:20]:
+            url = 'http' + url[5:]
+        if 'localhost%3a' in url[:20]:
+            url = url.replace('localhost%3a', 'localhost:')
+        if 'localhost%3A' in url[:20]:
+            url = url.replace('localhost%3A', 'localhost:')
+        response_msg.url = url
+
+        return response_msg
+
+    # TODO: consolidate this with similar method in `ExperimentRun`
+    def _upload_artifact(self, blob_path, component_blob, file_handle, part_size=64*(10**6)):
+        """
+        Uploads `file_handle` to ModelDB artifact store.
+
+        Parameters
+        ----------
+        blob_path : str
+            Path to blog withiin repo.
+        component_blob : protobuf Message
+            Dataset component blob.
+        file_handle : file-like
+            Artifact to be uploaded.
+        part_size : int, default 64 MB
+            If using multipart upload, number of bytes to upload per part.
+
+        """
+        file_handle.seek(0)
+
+        # check if multipart upload ok
+        url_for_artifact = self._get_url_for_artifact(blob_path, component_blob.path.path, "PUT", part_num=1)
+
+        print("uploading {} to ModelDB".format(component_blob.path.path))
+        if url_for_artifact.multipart_upload_ok:
+            # TODO: parallelize this
+            file_parts = iter(lambda: file_handle.read(part_size), b'')
+            for part_num, file_part in enumerate(file_parts, start=1):
+                print("uploading part {}".format(part_num), end='\r')
+
+                # get presigned URL
+                url = self._get_url_for_artifact(blob_path, component_blob.path.path, "PUT", part_num=part_num).url
+
+                # wrap file part into bytestream to avoid OverflowError
+                #     Passing a bytestring >2 GB (num bytes > max val of int32) directly to
+                #     ``requests`` will overwhelm CPython's SSL lib when it tries to sign the
+                #     payload. But passing a buffered bytestream instead of the raw bytestring
+                #     indicates to ``requests`` that it should perform a streaming upload via
+                #     HTTP/1.1 chunked transfer encoding and avoid this issue.
+                #     https://github.com/psf/requests/issues/2717
+                part_stream = six.BytesIO(file_part)
+
+                # upload part
+                #     Retry connection errors, to make large multipart uploads more robust.
+                for _ in range(3):
+                    try:
+                        response = _utils.make_request("PUT", url, self._conn, data=part_stream)
+                    except requests.ConnectionError:  # e.g. broken pipe
+                        time.sleep(1)
+                        continue  # try again
+                    else:
+                        break
+                response.raise_for_status()
+
+                # commit part
+                url = "{}://{}/api/v1/modeldb/versioning/commitVersionedBlobArtifactPart".format(
+                    self._conn.scheme,
+                    self._conn.socket,
+                )
+                msg = _VersioningService.CommitVersionedBlobArtifactPart(
+                    commit_sha=self.id,
+                    location=path_to_location(blob_path),
+                    path_dataset_component_blob_path=component_blob.path.path,
+                )
+                msg.repository_id.repo_id = self._repo.id
+                msg.artifact_part.part_number = part_num
+                msg.artifact_part.etag = response.headers['ETag']
+                data = _utils.proto_to_json(msg)
+                response = _utils.make_request("POST", url, self._conn, json=data)
+                _utils.raise_for_http_error(response)
+            print()
+
+            # complete upload
+            url = "{}://{}/api/v1/modeldb/versioning/commitMultipartVersionedBlobArtifact".format(
+                self._conn.scheme,
+                self._conn.socket,
+            )
+            msg = _VersioningService.CommitMultipartVersionedBlobArtifact(
+                commit_sha=self.id,
+                location=path_to_location(blob_path),
+                path_dataset_component_blob_path=component_blob.path.path,
+            )
+            msg.repository_id.repo_id = self._repo.id
+            data = _utils.proto_to_json(msg)
+            response = _utils.make_request("POST", url, self._conn, json=data)
+            _utils.raise_for_http_error(response)
+        else:
+            # upload full artifact
+            response = _utils.make_request("PUT", url_for_artifact.url, self._conn, data=file_handle)
+            _utils.raise_for_http_error(response)
+
+        print("upload complete")
 
     def _update_blobs_from_commit(self, id_):
         """Fetches commit `id_`'s blobs and stores them as objects in `self._blobs`."""
@@ -335,8 +487,12 @@ class Commit(object):
             Description of this Commit.
 
         """
+        # TODO: prepare ModelDB-versioned blobs, and track for upload after commit save
+
         msg = self._to_create_msg(commit_message=message)
         self._save(msg)
+
+        # TODO: upload ModelDB-versioned blobs
 
     def _save(self, proto_message):
         data = _utils.proto_to_json(proto_message)

--- a/client/verta/verta/_repository/commit.py
+++ b/client/verta/verta/_repository/commit.py
@@ -191,7 +191,7 @@ class Commit(object):
         Parameters
         ----------
         blob_path : str
-            Path to blog withiin repo.
+            Path to blog within repo.
         dataset_component_path : str
             Filepath in dataset component blob.
         file_handle : file-like


### PR DESCRIPTION
Copied from [_ModelDBEntity._get_url_for_artifact()](https://github.com/VertaAI/modeldb/blob/master/client/verta/verta/client.py#L768) and [ExperimentRun._upload_artifact()](https://github.com/VertaAI/modeldb/blob/master/client/verta/verta/client.py#L2085).

Logic is identical.
Differences are really only the `Message`s, endpoints, and params.