### PR TITLE
Fix import

### DIFF
--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -23,7 +23,7 @@ from google.protobuf.struct_pb2 import Value, ListValue, Struct, NULL_VALUE
 from ..external import six
 from ..external.six.moves.urllib.parse import urljoin  # pylint: disable=import-error, no-name-in-module
 
-from .._protos.public.modeldb import CommonService_pb2 as _CommonService
+from .._protos.public.common import CommonService_pb2 as _CommonCommonService
 
 try:
     import pandas as pd


### PR DESCRIPTION
Followup to https://github.com/VertaAI/modeldb/pull/749

This wasn't caught by testing because it's for logging artifacts as observations, which the Client doesn't actually even support.