### PR TITLE
VR-4744: Don't follow 302s

### DIFF
--- a/client/verta/tests/test_utils.py
+++ b/client/verta/tests/test_utils.py
@@ -58,6 +58,24 @@ class TestMakeRequest:
             )
         assert str(excinfo.value).strip().startswith("received status 302")
 
+    @pytest.mark.parametrize("status_code", [302, 400, 500])
+    def test_ignore_conn_err(self, client, status_code):
+        previous_setting = client.ignore_conn_err
+
+        client.ignore_conn_err = True
+        try:
+            response = _utils.make_request(
+                "GET",
+                "http://httpbin.org/status/{}".format(status_code),
+                client._conn,
+            )
+
+            assert response.status_code == 200
+            assert response.json() == {}
+        finally:
+            client.ignore_conn_err = previous_setting
+
+
 class TestToBuiltin:
     def test_string(self):
         val = "banana"

--- a/client/verta/tests/test_utils.py
+++ b/client/verta/tests/test_utils.py
@@ -16,7 +16,7 @@ from . import utils
 class TestMakeRequest:
     def test_200_no_history(self, client):
         """
-        The util injects the initial response into the final history after resolving redirects.
+        The util manually tracks and assigns the response history after resolving redirects.
 
         If no redirects occurred, the history should be empty.
 

--- a/client/verta/tests/test_utils.py
+++ b/client/verta/tests/test_utils.py
@@ -14,6 +14,22 @@ from . import utils
 
 
 class TestMakeRequest:
+    def test_200_no_history(self, client):
+        """
+        The util injects the initial response into the final history after resolving redirects.
+
+        If no redirects occurred, the history should be empty.
+
+        """
+        response = _utils.make_request(
+            "GET",
+            "http://httpbin.org/status/200",
+            client._conn,
+        )
+
+        assert not response.history
+        assert response.status_code == 200
+
     def test_301_continue(self, client):
         response = _utils.make_request(
             "GET",
@@ -25,6 +41,7 @@ class TestMakeRequest:
             },
         )
 
+        assert len(response.history) == 1
         assert response.history[0].status_code == 301
         assert response.status_code == 200
 

--- a/client/verta/tests/test_utils.py
+++ b/client/verta/tests/test_utils.py
@@ -13,6 +13,34 @@ import pytest
 from . import utils
 
 
+class TestMakeRequest:
+    def test_301_continue(self, client):
+        response = _utils.make_request(
+            "GET",
+            "http://httpbin.org/redirect-to",
+            client._conn,
+            params={
+                'url': "http://httpbin.org/get",
+                'status_code': 301,
+            },
+        )
+
+        assert response.history[0].status_code == 301
+        assert response.status_code == 200
+
+    def test_302_stop(self, client):
+        with pytest.raises(RuntimeError) as excinfo:
+            _utils.make_request(
+                "GET",
+                "http://httpbin.org/redirect-to",
+                client._conn,
+                params={
+                    'url': "http://httpbin.org/get",
+                    'status_code': 302,
+                },
+            )
+        assert str(excinfo.value).strip().startswith("received status 302")
+
 class TestToBuiltin:
     def test_string(self):
         val = "banana"

--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -263,7 +263,7 @@ def make_request(method, url, conn, **kwargs):
             request = requests.Request(method, url, **kwargs).prepare()
             response = s.send(request, allow_redirects=False)
 
-            # manually inspect redirects to stop on 302s
+            # manually inspect initial response and subsequent redirects to stop on 302s
             history = []  # track history because `requests` doesn't since we're redirecting manually
             responses = itertools.chain([response], s.resolve_redirects(response, request))
             for response in responses:

--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -272,8 +272,7 @@ def make_request(method, url, conn, **kwargs):
                             " which is not supported by the Client".format(response.url)
                         )
                     else:
-                        # TODO: make it so this actually falls through
-                        break  # fall through to fabricate 200 response
+                        return fabricate_200()
             if response is not initial_response:
                 # insert initial response back into history, b/c `resolve_redirects()` removed it
                 response.history.insert(0, initial_response)
@@ -286,11 +285,25 @@ def make_request(method, url, conn, **kwargs):
             if response.ok or not conn.ignore_conn_err:
                 return response
             # else fall through to fabricate 200 response
-        # fabricate 200 response
-        response = requests.Response()
-        response.status_code = 200  # success
-        response._content = six.ensure_binary("{}")  # empty contents
-        return response
+        return fabricate_200()
+
+
+def fabricate_200():
+    """
+    Returns an HTTP response with ``status_code`` 200 and empty JSON contents.
+
+    This is used when the Client has ``ignore_conn_err=True``, so that backend responses can be
+    spoofed to minimize execution-halting errors.
+
+    Returns
+    -------
+    :class:`requests.Response`
+
+    """
+    response = requests.Response()
+    response.status_code = 200  # success
+    response._content = six.ensure_binary("{}")  # empty contents
+    return response
 
 
 def raise_for_http_error(response):

--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -266,13 +266,14 @@ def make_request(method, url, conn, **kwargs):
             # manually inspect redirects to stop on 302s
             for response in itertools.chain([response], s.resolve_redirects(response, request)):
                 if response.status_code == 302:
-                    # TODO: break if conn.ignore_conn_err
+                    # TODO: break without error if conn.ignore_conn_err
                     raise RuntimeError(
                         "received status 302 from {},"
                         " which is not supported by the Client".format(response.url)
                     )
-            # insert initial response back into history
-            response.history.insert(0, initial_response)
+            # insert initial response back into history, b/c `resolve_redirects()` removes
+            if response is not initial_response:
+                response.history.insert(0, initial_response)
         except (requests.exceptions.BaseHTTPError,
                 requests.exceptions.RequestException) as e:
             if not conn.ignore_conn_err:

--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -277,7 +277,6 @@ def make_request(method, url, conn, **kwargs):
                         return fabricate_200()
 
                 history.append(response)
-
             # set full history
             response.history = history[:-1]  # last element is this response, so drop it
         except (requests.exceptions.BaseHTTPError,

--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -267,8 +267,6 @@ def make_request(method, url, conn, **kwargs):
             history = []  # track history because `requests` doesn't since we're redirecting manually
             responses = itertools.chain([response], s.resolve_redirects(response, request))
             for response in responses:
-                history.append(response)
-
                 if response.status_code == 302:
                     if not conn.ignore_conn_err:
                         raise RuntimeError(
@@ -277,6 +275,8 @@ def make_request(method, url, conn, **kwargs):
                         )
                     else:
                         return fabricate_200()
+
+                history.append(response)
 
             # set full history
             response.history = history[:-1]  # last element is this response, so drop it


### PR DESCRIPTION
Neither `requests` nor `urllib3` has a filter for specific redirect codes, so the redirect chain has to be manually inspected.