### PR TITLE
VR-4742: Raise more informative error on non-JSON response bodies

### DIFF
--- a/client/verta/tests/test_utils.py
+++ b/client/verta/tests/test_utils.py
@@ -13,6 +13,43 @@ import pytest
 from . import utils
 
 
+class TestBodyToJson:
+    def test_json_response(self, client):
+        response = _utils.make_request(
+            "GET",
+            "http://httpbin.org/json",
+            client._conn,
+        )
+
+        assert isinstance(_utils.body_to_json(response), dict)
+
+    def test_empty_response_error(self, client):
+        response = _utils.make_request(
+            "GET",
+            "http://httpbin.org/status/200",
+            client._conn,
+        )
+
+        with pytest.raises(ValueError) as excinfo:
+            _utils.body_to_json(response)
+        msg = str(excinfo.value).strip()
+        assert msg.startswith("expected JSON response")
+        assert "<empty response>" in msg
+
+    def test_html_response_error(self, client):
+        response = _utils.make_request(
+            "GET",
+            "http://httpbin.org/html",
+            client._conn,
+        )
+
+        with pytest.raises(ValueError) as excinfo:
+            _utils.body_to_json(response)
+        msg = str(excinfo.value).strip()
+        assert msg.startswith("expected JSON response")
+        assert "<!DOCTYPE html>" in msg
+
+
 class TestToBuiltin:
     def test_string(self):
         val = "banana"

--- a/client/verta/verta/_dataset.py
+++ b/client/verta/verta/_dataset.py
@@ -111,10 +111,10 @@ class Dataset(object):
                                            conn, params=data)
 
             if response.ok:
-                dataset = _utils.json_to_proto(response.json(), Message.Response).dataset
+                dataset = _utils.json_to_proto(_utils.body_to_json(response), Message.Response).dataset
                 return dataset
             else:
-                if response.status_code == 404 and response.json()['code'] == 5:
+                if response.status_code == 404 and _utils.body_to_json(response)['code'] == 5:
                     return None
                 else:
                     _utils.raise_for_http_error(response)
@@ -127,7 +127,7 @@ class Dataset(object):
                                            conn, params=data)
 
             if response.ok:
-                response_json = response.json()
+                response_json = _utils.body_to_json(response)
                 response_msg = _utils.json_to_proto(response_json, Message.Response)
                 if workspace is None or response_json.get('dataset_by_user'):
                     # user's personal workspace
@@ -141,7 +141,7 @@ class Dataset(object):
 
                 return dataset
             else:
-                if response.status_code == 404 and response.json()['code'] == 5:
+                if response.status_code == 404 and _utils.body_to_json(response)['code'] == 5:
                     return None
                 else:
                     _utils.raise_for_http_error(response)
@@ -176,7 +176,7 @@ class Dataset(object):
                                        conn, json=data)
 
         if response.ok:
-            dataset = _utils.json_to_proto(response.json(), Message.Response).dataset
+            dataset = _utils.json_to_proto(_utils.body_to_json(response), Message.Response).dataset
             return dataset
         else:
             _utils.raise_for_http_error(response)
@@ -225,7 +225,7 @@ class Dataset(object):
                                        self._conn, params=data)
         _utils.raise_for_http_error(response)
 
-        response_msg = _utils.json_to_proto(response.json(), Message.Response)
+        response_msg = _utils.json_to_proto(_utils.body_to_json(response), Message.Response)
         return DatasetVersion(self._conn, self._conf, _dataset_version_id=response_msg.dataset_version.id)
 
 
@@ -549,7 +549,7 @@ class DatasetVersion(object):
                 conn, params=data
             )
             if response.ok:
-                dataset_version = _utils.json_to_proto(response.json(), Message.Response).dataset_version
+                dataset_version = _utils.json_to_proto(_utils.body_to_json(response), Message.Response).dataset_version
 
                 if not dataset_version.id:  # 200, but empty message
                     raise RuntimeError("unable to retrieve DatasetVersion {};"
@@ -557,7 +557,7 @@ class DatasetVersion(object):
 
                 return dataset_version
             else:
-                if response.status_code == 404 and response.json()['code'] == 5:
+                if response.status_code == 404 and _utils.body_to_json(response)['code'] == 5:
                     return None
                 else:
                     _utils.raise_for_http_error(response)
@@ -608,7 +608,7 @@ class DatasetVersion(object):
                                        conn, json=data)
 
         if response.ok:
-            dataset_version = _utils.json_to_proto(response.json(),
+            dataset_version = _utils.json_to_proto(_utils.body_to_json(response),
                                                    _DatasetVersionService.CreateDatasetVersion.Response).dataset_version
             return dataset_version
         else:
@@ -867,7 +867,7 @@ class AtlasHiveDatasetVersionInfo(QueryDatasetVersionInfo):
         response = requests.get(atlas_url + atlas_entity_endpoint,
                                 auth=(atlas_user_name, atlas_password),
                                 params={'guid': guid})
-        return response.json()
+        return _utils.body_to_json(response)
 
     @staticmethod
     def generate_query(table_obj):

--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -329,13 +329,14 @@ def body_to_json(response):
     try:
         return response.json()
     except ValueError:  # not JSON response
-        e = ValueError('\n'.join([
+        msg = '\n'.join([
             "expected JSON response from {}, but instead got:".format(response.url),
             response.text or "<empty response>",
             "",
             "Please notify the Verta development team.",
-        ]))
-        six.raise_from(e, None)
+        ])
+        msg = six.ensure_str(msg)
+        six.raise_from(ValueError(msg), None)
 
 
 def is_hidden(path):  # to avoid "./".startswith('.')

--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -212,7 +212,7 @@ class LazyList(object):
             )
         raise_for_http_error(response)
 
-        response_msg = json_to_proto(response.json(), msg.Response)
+        response_msg = json_to_proto(body_to_json(response), msg.Response)
         return response_msg
 
     def _get_ids(self, response_msg):
@@ -290,7 +290,7 @@ def raise_for_http_error(response):
         response.raise_for_status()
     except requests.HTTPError as e:
         try:
-            reason = response.json()['message']
+            reason = body_to_json(response)['message']
         except (ValueError,  # not JSON response
                 KeyError):  # no 'message' from back end
             six.raise_from(e, None)  # use default reason
@@ -929,7 +929,7 @@ def get_notebook_filepath():
             response = requests.get(urljoin(server['url'], 'api/sessions'),
                                     params={'token': server.get('token', '')})
             if response.ok:
-                for session in response.json():
+                for session in body_to_json(response):
                     if session['kernel']['id'] == kernel_id:
                         relative_path = session['notebook']['path']
                         return os.path.join(server['notebook_dir'], relative_path)

--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -306,6 +306,38 @@ def raise_for_http_error(response):
             six.raise_from(requests.HTTPError(message, response=response), None)
 
 
+def body_to_json(response):
+    """
+    Returns the JSON-encoded contents of `response`, raising a detailed error on failure.
+
+    Parameters
+    ----------
+    response : :class:`requests.Response`
+        HTTP response.
+
+    Returns
+    -------
+    contents : dict
+        JSON-encoded contents of `response`.
+
+    Raises
+    ------
+    ValueError
+        If `response`'s contents are not JSON-encoded.
+
+    """
+    try:
+        return response.json()
+    except ValueError:  # not JSON response
+        e = ValueError('\n'.join([
+            "expected JSON response from {}, but instead got:".format(response.url),
+            response.text or "<empty response>",
+            "",
+            "Please notify the Verta development team.",
+        ]))
+        six.raise_from(e, None)
+
+
 def is_hidden(path):  # to avoid "./".startswith('.')
     return os.path.basename(path.rstrip('/')).startswith('.') and path != "."
 

--- a/client/verta/verta/_repository/commit.py
+++ b/client/verta/verta/_repository/commit.py
@@ -113,7 +113,7 @@ class Commit(object):
         response = _utils.make_request("GET", endpoint, conn)
         _utils.raise_for_http_error(response)
 
-        response_msg = _utils.json_to_proto(response.json(),
+        response_msg = _utils.json_to_proto(_utils.body_to_json(response),
                                             _VersioningService.GetCommitRequest.Response)
         commit_msg = response_msg.commit
         return cls(conn, repo, commit_msg, **kwargs)
@@ -134,7 +134,7 @@ class Commit(object):
         response = _utils.make_request("GET", endpoint, self._conn)
         _utils.raise_for_http_error(response)
 
-        response_msg = _utils.json_to_proto(response.json(),
+        response_msg = _utils.json_to_proto(_utils.body_to_json(response),
                                             _VersioningService.ListCommitBlobsRequest.Response)
         self._blobs.update({
             '/'.join(blob_msg.location): blob_msg_to_object(blob_msg.blob)
@@ -235,7 +235,7 @@ class Commit(object):
             response = _utils.make_request("GET", endpoint, self._conn, params=data)
             _utils.raise_for_http_error(response)
 
-            response_msg = _utils.json_to_proto(response.json(), msg.Response)
+            response_msg = _utils.json_to_proto(_utils.body_to_json(response), msg.Response)
             folder_msg = response_msg.folder
 
             folder_path = '/'.join(location)
@@ -347,7 +347,7 @@ class Commit(object):
         )
         response = _utils.make_request("POST", endpoint, self._conn, json=data)
         _utils.raise_for_http_error(response)
-        response_msg = _utils.json_to_proto(response.json(), proto_message.Response)
+        response_msg = _utils.json_to_proto(_utils.body_to_json(response), proto_message.Response)
 
         self._become_saved_child(response_msg.commit.commit_sha)
 
@@ -401,7 +401,7 @@ class Commit(object):
         response = _utils.make_request("GET", endpoint, self._conn)
         _utils.raise_for_http_error(response)
 
-        response_msg = _utils.json_to_proto(response.json(),
+        response_msg = _utils.json_to_proto(_utils.body_to_json(response),
                                             _VersioningService.ListCommitsLogRequest.Response)
         commits = response_msg.commits
 
@@ -487,7 +487,7 @@ class Commit(object):
         response = _utils.make_request("GET", endpoint, self._conn)
         _utils.raise_for_http_error(response)
 
-        response_msg = _utils.json_to_proto(response.json(),
+        response_msg = _utils.json_to_proto(_utils.body_to_json(response),
                                             _VersioningService.ComputeRepositoryDiffRequest.Response)
         return diff_module.Diff(response_msg.diffs)
 
@@ -571,7 +571,7 @@ class Commit(object):
         )
         response = _utils.make_request("POST", endpoint, self._conn, json=data)
         _utils.raise_for_http_error(response)
-        response_msg = _utils.json_to_proto(response.json(), msg.Response)
+        response_msg = _utils.json_to_proto(_utils.body_to_json(response), msg.Response)
 
         self._become_saved_child(response_msg.commit.commit_sha)
 
@@ -674,7 +674,7 @@ class Commit(object):
         )
         response = _utils.make_request("POST", endpoint, self._conn, json=data)
         _utils.raise_for_http_error(response)
-        response_msg = _utils.json_to_proto(response.json(), msg.Response)
+        response_msg = _utils.json_to_proto(_utils.body_to_json(response), msg.Response)
 
         # raise for conflict
         if response_msg.conflicts:

--- a/client/verta/verta/_repository/repository.py
+++ b/client/verta/verta/_repository/repository.py
@@ -44,7 +44,7 @@ class Repository(object):
         response = _utils.make_request("GET", self._endpoint_prefix, self._conn)
         _utils.raise_for_http_error(response)
 
-        response_msg = _utils.json_to_proto(response.json(),
+        response_msg = _utils.json_to_proto(_utils.body_to_json(response),
                                             _VersioningService.GetRepositoryRequest.Response)
         return response_msg.repository.name
 
@@ -66,7 +66,7 @@ class Repository(object):
         response = _utils.make_request("POST", endpoint, conn, json=data)
         _utils.raise_for_http_error(response)
 
-        response_msg = _utils.json_to_proto(response.json(),
+        response_msg = _utils.json_to_proto(_utils.body_to_json(response),
                                             _VersioningService.SetRepository.Response)
         return cls(conn, response_msg.repository.id)
 
@@ -91,13 +91,13 @@ class Repository(object):
         response = _utils.make_request("GET", endpoint, conn)
 
         if not response.ok:
-            if ((response.status_code == 403 and response.json()['code'] == 7)
-                    or (response.status_code == 404 and response.json()['code'] == 5)):
+            if ((response.status_code == 403 and _utils.body_to_json(response)['code'] == 7)
+                    or (response.status_code == 404 and _utils.body_to_json(response)['code'] == 5)):
                 return None
             else:
                 _utils.raise_for_http_error(response)
 
-        response_msg = _utils.json_to_proto(response.json(),
+        response_msg = _utils.json_to_proto(_utils.body_to_json(response),
                                             _VersioningService.GetRepositoryRequest.Response)
         return cls(conn, response_msg.repository.id)
 
@@ -155,5 +155,5 @@ class Repository(object):
         response = _utils.make_request("GET", endpoint, self._conn)
         _utils.raise_for_http_error(response)
 
-        response_msg = _utils.json_to_proto(response.json(), msg.Response)
+        response_msg = _utils.json_to_proto(_utils.body_to_json(response), msg.Response)
         return commit.Commit._from_id(self._conn, self, response_msg.commit.commit_sha, branch_name=branch)

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -244,7 +244,7 @@ class Client(object):
 
             if response.ok:
                 try:
-                    response_json = response.json()
+                    response_json = _utils.body_to_json(response)
                 except ValueError:  # not JSON response
                     pass
                 else:
@@ -806,7 +806,7 @@ class _ModelDBEntity(object):
                                        self._conn, json=data)
         _utils.raise_for_http_error(response)
 
-        response_msg = _utils.json_to_proto(response.json(), Message.Response)
+        response_msg = _utils.json_to_proto(_utils.body_to_json(response), Message.Response)
 
         url = response_msg.url
         # accommodate port-forwarded NFS store
@@ -1141,7 +1141,7 @@ class _ModelDBEntity(object):
                                        self._conn, params=data)
         _utils.raise_for_http_error(response)
 
-        response_msg = _utils.json_to_proto(response.json(), Message.Response)
+        response_msg = _utils.json_to_proto(_utils.body_to_json(response), Message.Response)
         code_ver_msg = response_msg.code_version
         which_code = code_ver_msg.WhichOneof('code')
         if which_code == 'git_snapshot':
@@ -1253,7 +1253,7 @@ class Project(_ModelDBEntity):
                                        self._conn, params=data)
         _utils.raise_for_http_error(response)
 
-        response_msg = _utils.json_to_proto(response.json(), Message.Response)
+        response_msg = _utils.json_to_proto(_utils.body_to_json(response), Message.Response)
         return response_msg.project.name
 
     @property
@@ -1278,11 +1278,11 @@ class Project(_ModelDBEntity):
                                            conn, params=data)
 
             if response.ok:
-                response_msg = _utils.json_to_proto(response.json(), Message.Response)
+                response_msg = _utils.json_to_proto(_utils.body_to_json(response), Message.Response)
                 return response_msg.project
             else:
-                if ((response.status_code == 403 and response.json()['code'] == 7)
-                        or (response.status_code == 404 and response.json()['code'] == 5)):
+                if ((response.status_code == 403 and _utils.body_to_json(response)['code'] == 7)
+                        or (response.status_code == 404 and _utils.body_to_json(response)['code'] == 5)):
                     return None
                 else:
                     _utils.raise_for_http_error(response)
@@ -1295,7 +1295,7 @@ class Project(_ModelDBEntity):
                                            conn, params=data)
 
             if response.ok:
-                response_json = response.json()
+                response_json = _utils.body_to_json(response)
                 response_msg = _utils.json_to_proto(response_json, Message.Response)
                 if workspace is None or response_json.get('project_by_user'):
                     # user's personal workspace
@@ -1309,8 +1309,8 @@ class Project(_ModelDBEntity):
 
                 return proj
             else:
-                if ((response.status_code == 403 and response.json()['code'] == 7)
-                        or (response.status_code == 404 and response.json()['code'] == 5)):
+                if ((response.status_code == 403 and _utils.body_to_json(response)['code'] == 7)
+                        or (response.status_code == 404 and _utils.body_to_json(response)['code'] == 5)):
                     return None
                 else:
                     _utils.raise_for_http_error(response)
@@ -1343,7 +1343,7 @@ class Project(_ModelDBEntity):
                                        conn, json=data)
 
         if response.ok:
-            response_msg = _utils.json_to_proto(response.json(), Message.Response)
+            response_msg = _utils.json_to_proto(_utils.body_to_json(response), Message.Response)
             return response_msg.project
         else:
             _utils.raise_for_http_error(response)
@@ -1420,7 +1420,7 @@ class Experiment(_ModelDBEntity):
                                        self._conn, params=data)
         _utils.raise_for_http_error(response)
 
-        response_msg = _utils.json_to_proto(response.json(), Message.Response)
+        response_msg = _utils.json_to_proto(_utils.body_to_json(response), Message.Response)
         return response_msg.experiment.name
 
     @property
@@ -1454,7 +1454,7 @@ class Experiment(_ModelDBEntity):
             raise ValueError("insufficient arguments")
 
         if response.ok:
-            response_msg = _utils.json_to_proto(response.json(), Message.Response)
+            response_msg = _utils.json_to_proto(_utils.body_to_json(response), Message.Response)
             expt = response_msg.experiment
 
             if not expt.id:  # 200, but empty message
@@ -1463,8 +1463,8 @@ class Experiment(_ModelDBEntity):
 
             return expt
         else:
-            if ((response.status_code == 403 and response.json()['code'] == 7)
-                    or (response.status_code == 404 and response.json()['code'] == 5)):
+            if ((response.status_code == 403 and _utils.body_to_json(response)['code'] == 7)
+                    or (response.status_code == 404 and _utils.body_to_json(response)['code'] == 5)):
                 return None
             else:
                 _utils.raise_for_http_error(response)
@@ -1486,7 +1486,7 @@ class Experiment(_ModelDBEntity):
                                        conn, json=data)
 
         if response.ok:
-            response_msg = _utils.json_to_proto(response.json(), Message.Response)
+            response_msg = _utils.json_to_proto(_utils.body_to_json(response), Message.Response)
             return response_msg.experiment
         else:
             _utils.raise_for_http_error(response)
@@ -1874,7 +1874,7 @@ class ExperimentRun(_ModelDBEntity):
                                        self._conn, params=data)
         _utils.raise_for_http_error(response)
 
-        response_msg = _utils.json_to_proto(response.json(), Message.Response)
+        response_msg = _utils.json_to_proto(_utils.body_to_json(response), Message.Response)
         run_msg = response_msg.experiment_run
         return '\n'.join((
             "name: {}".format(run_msg.name),
@@ -1900,7 +1900,7 @@ class ExperimentRun(_ModelDBEntity):
         )
         _utils.raise_for_http_error(response)
 
-        proj_id = response.json()['experiment_run']['project_id']
+        proj_id = _utils.body_to_json(response)['experiment_run']['project_id']
         response = _utils.make_request(
             "GET",
             "{}://{}/api/v1/modeldb/project/getProjectById".format(self._conn.scheme, self._conn.socket),
@@ -1908,7 +1908,7 @@ class ExperimentRun(_ModelDBEntity):
         )
         _utils.raise_for_http_error(response)
 
-        project_json = response.json()['project']
+        project_json = _utils.body_to_json(response)['project']
         if 'workspace_id' not in project_json:
             # workspace is OSS default
             return _OSS_DEFAULT_WORKSPACE
@@ -1932,10 +1932,10 @@ class ExperimentRun(_ModelDBEntity):
             _utils.raise_for_http_error(response)
 
             # workspace is user
-            return response.json()['verta_info']['username']
+            return _utils.body_to_json(response)['verta_info']['username']
         else:
             # workspace is organization
-            return response.json()['organization']['name']
+            return _utils.body_to_json(response)['organization']['name']
 
     @property
     def name(self):
@@ -1947,7 +1947,7 @@ class ExperimentRun(_ModelDBEntity):
                                        self._conn, params=data)
         _utils.raise_for_http_error(response)
 
-        response_msg = _utils.json_to_proto(response.json(), Message.Response)
+        response_msg = _utils.json_to_proto(_utils.body_to_json(response), Message.Response)
         return response_msg.experiment_run.name
 
     @staticmethod
@@ -1974,7 +1974,7 @@ class ExperimentRun(_ModelDBEntity):
             raise ValueError("insufficient arguments")
 
         if response.ok:
-            response_msg = _utils.json_to_proto(response.json(), Message.Response)
+            response_msg = _utils.json_to_proto(_utils.body_to_json(response), Message.Response)
             expt_run = response_msg.experiment_run
 
             if not expt_run.id:  # 200, but empty message
@@ -1983,8 +1983,8 @@ class ExperimentRun(_ModelDBEntity):
 
             return expt_run
         else:
-            if ((response.status_code == 403 and response.json()['code'] == 7)
-                    or (response.status_code == 404 and response.json()['code'] == 5)):
+            if ((response.status_code == 403 and _utils.body_to_json(response)['code'] == 7)
+                    or (response.status_code == 404 and _utils.body_to_json(response)['code'] == 5)):
                 return None
             else:
                 _utils.raise_for_http_error(response)
@@ -2007,7 +2007,7 @@ class ExperimentRun(_ModelDBEntity):
                                        conn, json=data)
 
         if response.ok:
-            response_msg = _utils.json_to_proto(response.json(), Message.Response)
+            response_msg = _utils.json_to_proto(_utils.body_to_json(response), Message.Response)
             return response_msg.experiment_run
         else:
             _utils.raise_for_http_error(response)
@@ -2231,7 +2231,7 @@ class ExperimentRun(_ModelDBEntity):
                                        self._conn, params=data)
         _utils.raise_for_http_error(response)
 
-        response_msg = _utils.json_to_proto(response.json(), Message.Response)
+        response_msg = _utils.json_to_proto(_utils.body_to_json(response), Message.Response)
         artifact = {artifact.key: artifact for artifact in response_msg.artifacts}.get(key)
         if artifact is None:
             raise KeyError("no artifact found with key {}".format(key))
@@ -2277,7 +2277,7 @@ class ExperimentRun(_ModelDBEntity):
                                        self._conn, params=data)
         _utils.raise_for_http_error(response)
 
-        response_msg = _utils.json_to_proto(response.json(), Message.Response)
+        response_msg = _utils.json_to_proto(_utils.body_to_json(response), Message.Response)
         dataset = {dataset.key: dataset for dataset in response_msg.datasets}.get(key)
         if dataset is None:
             # may be old artifact-based dataset
@@ -2357,7 +2357,7 @@ class ExperimentRun(_ModelDBEntity):
                                            self._conn.scheme, self._conn.socket), self._conn, json=data)
         _utils.raise_for_http_error(response)
 
-        response_msg = _utils.json_to_proto(response.json(), Message.Response)
+        response_msg = _utils.json_to_proto(_utils.body_to_json(response), Message.Response)
         new_run_msg = response_msg.experiment_run
         print("created new ExperimentRun: {}".format(new_run_msg.name))
         new_run = ExperimentRun(self._conn, self._conf, _expt_run_id=new_run_msg.id)
@@ -2423,7 +2423,7 @@ class ExperimentRun(_ModelDBEntity):
                                        self._conn, params=data)
         _utils.raise_for_http_error(response)
 
-        response_msg = _utils.json_to_proto(response.json(), Message.Response)
+        response_msg = _utils.json_to_proto(_utils.body_to_json(response), Message.Response)
         return response_msg.tags
 
     def log_attribute(self, key, value):
@@ -2509,7 +2509,7 @@ class ExperimentRun(_ModelDBEntity):
                                        self._conn, params=data)
         _utils.raise_for_http_error(response)
 
-        response_msg = _utils.json_to_proto(response.json(), Message.Response)
+        response_msg = _utils.json_to_proto(_utils.body_to_json(response), Message.Response)
         attributes = _utils.unravel_key_values(response_msg.attributes)
         try:
             return attributes[key]
@@ -2534,7 +2534,7 @@ class ExperimentRun(_ModelDBEntity):
                                        self._conn, params=data)
         _utils.raise_for_http_error(response)
 
-        response_msg = _utils.json_to_proto(response.json(), Message.Response)
+        response_msg = _utils.json_to_proto(_utils.body_to_json(response), Message.Response)
         return _utils.unravel_key_values(response_msg.attributes)
 
     def log_metric(self, key, value):
@@ -2622,7 +2622,7 @@ class ExperimentRun(_ModelDBEntity):
                                        self._conn, params=data)
         _utils.raise_for_http_error(response)
 
-        response_msg = _utils.json_to_proto(response.json(), Message.Response)
+        response_msg = _utils.json_to_proto(_utils.body_to_json(response), Message.Response)
         metrics = _utils.unravel_key_values(response_msg.metrics)
         try:
             return metrics[key]
@@ -2647,7 +2647,7 @@ class ExperimentRun(_ModelDBEntity):
                                        self._conn, params=data)
         _utils.raise_for_http_error(response)
 
-        response_msg = _utils.json_to_proto(response.json(), Message.Response)
+        response_msg = _utils.json_to_proto(_utils.body_to_json(response), Message.Response)
         return _utils.unravel_key_values(response_msg.metrics)
 
     def log_hyperparameter(self, key, value):
@@ -2733,7 +2733,7 @@ class ExperimentRun(_ModelDBEntity):
                                        self._conn, params=data)
         _utils.raise_for_http_error(response)
 
-        response_msg = _utils.json_to_proto(response.json(), Message.Response)
+        response_msg = _utils.json_to_proto(_utils.body_to_json(response), Message.Response)
         hyperparameters = _utils.unravel_key_values(response_msg.hyperparameters)
         try:
             return hyperparameters[key]
@@ -2758,7 +2758,7 @@ class ExperimentRun(_ModelDBEntity):
                                        self._conn, params=data)
         _utils.raise_for_http_error(response)
 
-        response_msg = _utils.json_to_proto(response.json(), Message.Response)
+        response_msg = _utils.json_to_proto(_utils.body_to_json(response), Message.Response)
         return _utils.unravel_key_values(response_msg.hyperparameters)
 
     def log_dataset(self, key, dataset, overwrite=False):
@@ -3080,7 +3080,7 @@ class ExperimentRun(_ModelDBEntity):
                                            "{}://{}/api/v1/modeldb/experiment-run/getExperimentRunById".format(self._conn.scheme, self._conn.socket),
                                            self._conn, params={'id': self.id})
             _utils.raise_for_http_error(response)
-            existing_artifact_keys = {artifact['key'] for artifact in response.json()['experiment_run'].get('artifacts', [])}
+            existing_artifact_keys = {artifact['key'] for artifact in _utils.body_to_json(response)['experiment_run'].get('artifacts', [])}
             unlogged_artifact_keys = set(artifacts) - existing_artifact_keys
             if unlogged_artifact_keys:
                 raise ValueError("`artifacts` contains keys that have not been logged: {}".format(sorted(unlogged_artifact_keys)))
@@ -3392,7 +3392,7 @@ class ExperimentRun(_ModelDBEntity):
                                        self._conn, params=data)
         _utils.raise_for_http_error(response)
 
-        response_msg = _utils.json_to_proto(response.json(), Message.Response)
+        response_msg = _utils.json_to_proto(_utils.body_to_json(response), Message.Response)
         if len(response_msg.observations) == 0:
             raise KeyError("no observation found with key {}".format(key))
         else:
@@ -3417,7 +3417,7 @@ class ExperimentRun(_ModelDBEntity):
                                        self._conn, params=data)
         _utils.raise_for_http_error(response)
 
-        response_msg = _utils.json_to_proto(response.json(), Message.Response)
+        response_msg = _utils.json_to_proto(_utils.body_to_json(response), Message.Response)
         return _utils.unravel_observations(response_msg.experiment_run.observations)
 
     def log_requirements(self, requirements, overwrite=False):
@@ -3747,7 +3747,7 @@ class ExperimentRun(_ModelDBEntity):
                                        "{}://{}/api/v1/modeldb/experiment-run/getExperimentRunById".format(self._conn.scheme, self._conn.socket),
                                        self._conn, params={'id': self.id})
         _utils.raise_for_http_error(response)
-        existing_artifact_keys = {artifact['key'] for artifact in response.json()['experiment_run'].get('artifacts', [])}
+        existing_artifact_keys = {artifact['key'] for artifact in _utils.body_to_json(response)['experiment_run'].get('artifacts', [])}
         unlogged_artifact_keys = set(keys) - existing_artifact_keys
         if unlogged_artifact_keys:
             raise ValueError("`keys` contains keys that have not been logged: {}".format(sorted(unlogged_artifact_keys)))
@@ -3758,7 +3758,7 @@ class ExperimentRun(_ModelDBEntity):
                                        self._conn, params={'id': self.id})
         _utils.raise_for_http_error(response)
         paths = {artifact['key']: artifact['path']
-                 for artifact in response.json()['artifacts']}
+                 for artifact in _utils.body_to_json(response)['artifacts']}
 
         artifacts = dict()
         for key in keys:
@@ -3799,7 +3799,7 @@ class ExperimentRun(_ModelDBEntity):
         )
         _utils.raise_for_http_error(response)
 
-        status = response.json()
+        status = _utils.body_to_json(response)
         if 'api' in status:
             status.update({'url': "{}://{}{}".format(self._conn.scheme, self._conn.socket, status.pop('api'))})
             status.update({'token': status.pop('token', None)})
@@ -3858,7 +3858,7 @@ class ExperimentRun(_ModelDBEntity):
                 self._conn, params={'id': self.id})
             _utils.raise_for_http_error(response)
 
-            data.update({'url_path': "{}/{}".format(response.json()['experiment_run']['project_id'], path)})
+            data.update({'url_path': "{}/{}".format(_utils.body_to_json(response)['experiment_run']['project_id'], path)})
         if no_token:
             data.update({'token': ""})
         elif token is not None:
@@ -4018,7 +4018,7 @@ class ExperimentRun(_ModelDBEntity):
         response = _utils.make_request("GET", endpoint, self._conn, params=data)
         _utils.raise_for_http_error(response)
 
-        response_msg = _utils.json_to_proto(response.json(), msg.Response)
+        response_msg = _utils.json_to_proto(_utils.body_to_json(response), msg.Response)
         repo = _repository.Repository(self._conn, response_msg.versioned_inputs.repository_id)
         commit_id = response_msg.versioned_inputs.commit
         commit = commit_module.Commit._from_id(self._conn, repo, commit_id)

--- a/client/verta/verta/deployment.py
+++ b/client/verta/verta/deployment.py
@@ -140,7 +140,7 @@ class DeployedModel:
     def _set_token_and_url(self):
         response = self._session.get(self._status_url)
         _utils.raise_for_http_error(response)
-        status = response.json()
+        status = _utils.body_to_json(response)
         if status['status'] == 'error':
             raise RuntimeError(status['message'])
         elif status['status'] != 'deployed':
@@ -212,10 +212,10 @@ class DeployedModel:
             response = self._predict(x, compress)
 
             if response.ok:
-                return response.json()
+                return _utils.body_to_json(response)
             elif response.status_code == 502:  # bad gateway; possibly error from the model back end
                 try:
-                    data = response.json()
+                    data = _utils.body_to_json(response)
                 except ValueError:  # not JSON response; 502 not from model back end
                     pass
                 else:  # from model back end; contains message (maybe)


### PR DESCRIPTION
Most of this PR is a find-and-replace of `response.json()` with `_utils.body_to_json(response)` except for my two comments.