### PR TITLE
VR-4843 Add test + doc for ExperimentRun's get/log observation

### DIFF
--- a/client/scala/src/main/scala/ai/verta/client/entities/ExperimentRun.scala
+++ b/client/scala/src/main/scala/ai/verta/client/entities/ExperimentRun.scala
@@ -168,6 +168,11 @@ class ExperimentRun(val clientSet: ClientSet, val expt: Experiment, val run: Mod
   def getAttribute(key: String)(implicit ec: ExecutionContext) =
     getAttributes(List(key)).map(_.get(key))
 
+  /** Logs an observation to this Experiment Run
+   *  @param key Name of the observation
+   *  @param value Value of the observation
+   *  @param timestamp Unix timestamp. If not provided, the current time will be used.
+   */
   def logObservation(key: String, value: Any, timestamp: LocalDateTime = null)(implicit ec: ExecutionContext) = {
     val ts = if (timestamp == null) LocalDateTime.now() else timestamp
 
@@ -187,6 +192,10 @@ class ExperimentRun(val clientSet: ClientSet, val expt: Experiment, val run: Mod
       .map(_ => {})
   }
 
+  /** Gets the observation series with name key from this Experiment Run
+   *  @param key Name of observation series
+   *  @return Values of observation series
+   */
   def getObservation(key: String)(implicit ec: ExecutionContext) = {
     clientSet.experimentRunService.getObservations(id = run.id, observation_key = Some(key))
       .map(res => {
@@ -201,6 +210,9 @@ class ExperimentRun(val clientSet: ClientSet, val expt: Experiment, val run: Mod
       })
   }
 
+  /** Gets all observations from this Experiment Run.
+   *  @return Names and values of all observation series
+   */
   def getObservations()(implicit ec: ExecutionContext) = {
     clientSet.experimentRunService.getExperimentRunById(run.id)
       .map(runResp => {

--- a/client/scala/src/main/scala/ai/verta/client/entities/ExperimentRun.scala
+++ b/client/scala/src/main/scala/ai/verta/client/entities/ExperimentRun.scala
@@ -215,13 +215,13 @@ class ExperimentRun(val clientSet: ClientSet, val expt: Experiment, val run: Mod
    */
   def getObservations()(implicit ec: ExecutionContext) = {
     clientSet.experimentRunService.getExperimentRunById(run.id)
-      .map(runResp => {
+      .flatMap(runResp => Try {
         val observations = runResp.experiment_run.get.observations
         val obsMap = new mutable.HashMap[String, List[(LocalDateTime, Any)]]()
         observations.get.foreach(o => {
           val ts = LocalDateTime.ofInstant(Instant.ofEpochMilli(o.timestamp.get.toLong), TimeZone.getTimeZone("UTC").toZoneId)
           val key = o.attribute.get.key.get
-          val value = KVHandler.convertToAny(o.attribute.get.value.get, s"unknown type for observation $key: ${o.attribute.get.value.get.toString} (${o.attribute.get.value.get.getClass.toString})")
+          val value = KVHandler.convertToAny(o.attribute.get.value.get, s"unknown type for observation $key: ${o.attribute.get.value.get.toString} (${o.attribute.get.value.get.getClass.toString})").get
           obsMap.update(key, (ts, value) :: obsMap.getOrElse(key, Nil))
         })
         obsMap.map(el => {

--- a/client/scala/src/test/scala/ai/verta/client/entities/TestExperimentRun.scala
+++ b/client/scala/src/test/scala/ai/verta/client/entities/TestExperimentRun.scala
@@ -156,9 +156,7 @@ class TestExperimentRun extends FunSuite {
       assert(f.expRun.getObservation("non-existing-obs").get equals Nil)
 
       val allObservations = f.expRun.getObservations().get.mapValues(series => series.map(_._2))
-      assert(allObservations equals
-        Map("some-obs" -> List(Success(0.5), Success(0.4), Success(0.6)), "single-obs" -> List(Success(0.3)))
-      )
+      assert(allObservations equals Map("some-obs" -> List(0.5, 0.4, 0.6), "single-obs" -> List(0.3)))
     } finally {
       cleanup(f)
     }

--- a/client/scala/src/test/scala/ai/verta/client/entities/TestExperimentRun.scala
+++ b/client/scala/src/test/scala/ai/verta/client/entities/TestExperimentRun.scala
@@ -142,6 +142,28 @@ class TestExperimentRun extends FunSuite {
     }
   }
 
+  test("getObservation(s) should get the correct series of logged observation") {
+    val f = fixture
+
+    try {
+      f.expRun.logObservation("some-obs", 0.5)
+      f.expRun.logObservation("some-obs", 0.4)
+      f.expRun.logObservation("some-obs", 0.6)
+      f.expRun.logObservation("single-obs", 0.3)
+
+      assert(f.expRun.getObservation("some-obs").get.map(_._2) equals List(0.5, 0.4, 0.6))
+      assert(f.expRun.getObservation("single-obs").get.map(_._2) equals List(0.3))
+      assert(f.expRun.getObservation("non-existing-obs").get equals Nil)
+
+      val allObservations = f.expRun.getObservations().get.mapValues(series => series.map(_._2))
+      assert(allObservations equals
+        Map("some-obs" -> List(Success(0.5), Success(0.4), Success(0.6)), "single-obs" -> List(Success(0.3)))
+      )
+    } finally {
+      cleanup(f)
+    }
+  }
+
   test("get commit should retrieve the right commit that was logged") {
     val f = fixture
 


### PR DESCRIPTION
getObservations returns type is really weird. It's Try[Map[String, List[LocalDateTime, Any]]]. This "Any" is not the type of the observation logged, but actually "Try[Any]" (that's the return type of KVHandler's convertToAny method). For example, if I log:

```
expRun.logObservation("some-obs", 0.3)
expRun.logObservation("some-obs", 0.4)
expRun.logObservation("some-obs", 0.5)
```
getObservations would return:

```
allObs = getObservations()
allObs == Map(some-obs -> List((ts1, Success(0.3), (ts2, Success(0.4), (ts3, Success(0.5)))
```

And I can't do something like:

```
allObs.mapValues(series => series.map(_._2.get))
```

Because the type of Success(0.3) is actually not Try[Any], but just Any. It swallows the Try.
Should I do something about this?