### PR TITLE
Make sure stream is correctly passed

### DIFF
--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -231,7 +231,7 @@ class LazyList(object):
         raise NotImplementedError
 
 
-def make_request(method, url, conn, **kwargs):
+def make_request(method, url, conn, stream=False, **kwargs):
     """
     Makes a REST request.
 
@@ -243,8 +243,10 @@ def make_request(method, url, conn, **kwargs):
         URL.
     conn : Connection
         Connection authentication and configuration.
+    stream : bool, default False
+        Whether to stream the response contents.
     **kwargs
-        Parameters to requests.request().
+        Initialization parameters to requests.Request().
 
     Returns
     -------
@@ -261,7 +263,7 @@ def make_request(method, url, conn, **kwargs):
         s.mount(url, HTTPAdapter(max_retries=conn.retry))
         try:
             request = requests.Request(method, url, **kwargs).prepare()
-            response = s.send(request, allow_redirects=False)
+            response = s.send(request, allow_redirects=False, stream=stream)
 
             # manually inspect initial response and subsequent redirects to stop on 302s
             history = []  # track history because `requests` doesn't since we're redirecting manually

--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -263,7 +263,7 @@ def make_request(method, url, conn, stream=False, **kwargs):
         s.mount(url, HTTPAdapter(max_retries=conn.retry))
         try:
             request = requests.Request(method, url, **kwargs).prepare()
-            response = s.send(request, allow_redirects=False, stream=stream)
+            response = s.send(request, stream=stream, allow_redirects=False)
 
             # manually inspect initial response and subsequent redirects to stop on 302s
             history = []  # track history because `requests` doesn't since we're redirecting manually


### PR DESCRIPTION
#798 (don't follow `302`s) had split the logic in `make_request` into "build request" –> "send request", so the `stream` param needs to be specifically passed to the correct step.