### PR TITLE
Remove kwarg for Python2

### DIFF
--- a/client/verta/tests/test_utils.py
+++ b/client/verta/tests/test_utils.py
@@ -286,7 +286,7 @@ class TestPipRequirementsUtils:
         ))
 
 
-class TestIncrementFilepath:
+class TestIncrementPath:
     @pytest.mark.parametrize(
         "input_filepath, expected_filepath",
         [

--- a/client/verta/verta/_internal_utils/_file_utils.py
+++ b/client/verta/verta/_internal_utils/_file_utils.py
@@ -42,7 +42,7 @@ def increment_path(path):
 
     # check if name already has number
     if ' ' in base:
-        original_base, number_str = base.rsplit(' ', maxsplit=1)
+        original_base, number_str = base.rsplit(' ', 1)
         if number_str.isdigit():
             # increment number
             number = int(number_str) + 1


### PR DESCRIPTION
```python
>           original_base, number_str = base.rsplit(' ', maxsplit=1)
E           TypeError: rsplit() takes no keyword arguments
```