### PR TITLE
VR-4873 loadBlobs should be synchronized

### DIFF
--- a/client/scala/src/main/scala/ai/verta/repository/Commit.scala
+++ b/client/scala/src/main/scala/ai/verta/repository/Commit.scala
@@ -145,7 +145,7 @@ class Commit(
   /** Retrieve commit's blobs from remote
    *  This is only called when user perform operations involving blobs.
    */
-  private def loadBlobs()(implicit ec: ExecutionContext): Try[Unit] = {
+  private def loadBlobs()(implicit ec: ExecutionContext): Try[Unit] = this.synchronized {
     if (!loadedFromRemote) {
       // if the commit is not saved, get the blobs of its parent(s)
       val ids: List[String] = commit.commit_sha match {


### PR DESCRIPTION
Interestingly, Scala does not have synchronized keyword for method signature. Instead, we can just use object.synchronized (using object as the lock). 

Also I'm not sure how to test this though. Since our commit is immutable (well other than the blobs loading mechanism), data races won't lead to result being wrong. It's just going to load the blobs  multiple times right? (Inefficient, but still correct). Anyway, let me know if there's anything I should do.