### PR TITLE
Check status code first to help debug test failure

### DIFF
--- a/client/verta/tests/test_utils.py
+++ b/client/verta/tests/test_utils.py
@@ -28,8 +28,8 @@ class TestMakeRequest:
             client._conn,
         )
 
-        assert not response.history
         assert response.status_code == 200
+        assert not response.history
 
     def test_301_continue(self, client):
         response = _utils.make_request(
@@ -42,9 +42,9 @@ class TestMakeRequest:
             },
         )
 
+        assert response.status_code == 200
         assert len(response.history) == 1
         assert response.history[0].status_code == 301
-        assert response.status_code == 200
 
     def test_302_stop(self, client):
         with pytest.raises(RuntimeError) as excinfo:


### PR DESCRIPTION
These tests are failing because of [an issue with httpbin](https://github.com/postmanlabs/httpbin/issues/617).

If the status check happened first, it would've given a better indication as to what happened (a `404`).