### PR TITLE
VR-4885: date created & updated on ExperimentRun

### DIFF
--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -2383,6 +2383,30 @@ class ExperimentRun(_ModelDBEntity):
 
         return new_run
 
+    def get_date_created(self):
+        """
+        Gets a timestamp representing the time this Experiment Run was created.
+
+        Returns
+        -------
+        timestamp : int
+            Unix timestamp (in UTC).
+
+        """
+        pass
+
+    def get_date_updated(self):
+        """
+        Gets a timestamp representing the time this Experiment Run was updated.
+
+        Returns
+        -------
+        timestamp : int
+            Unix timestamp (in UTC).
+
+        """
+        pass
+
     def log_tag(self, tag):
         """
         Logs a tag to this Experiment Run.

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -2020,9 +2020,12 @@ class ExperimentRun(_ModelDBEntity):
         Message = _ExperimentRunService.GetExperimentRunById
         msg = Message(id=self.id)
         data = _utils.proto_to_json(msg)
-        response = _utils.make_request("GET",
-                                       "{}://{}/api/v1/modeldb/experiment-run/getExperimentRunById".format(self._conn.scheme, self._conn.socket),
-                                       self._conn, params=data)
+        url = "{}://{}/api/v1/modeldb/experiment-run/getExperimentRunById".format(
+            self._conn.scheme,
+            self._conn.socket,
+        )
+
+        response = _utils.make_request("GET", url, self._conn, params=data)
         _utils.raise_for_http_error(response)
 
         response_msg = _utils.json_to_proto(_utils.body_to_json(response), Message.Response)

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -1882,7 +1882,7 @@ class ExperimentRun(_ModelDBEntity):
             "name: {}".format(run_msg.name),
             "url: {}://{}/{}/projects/{}/exp-runs/{}".format(self._conn.scheme, self._conn.socket, self.workspace, run_msg.project_id, self.id),
             "date created: {}".format(_utils.timestamp_to_str(int(run_msg.date_created))),
-            "last updated: {}".format(_utils.timestamp_to_str(int(run_msg.date_updated))),
+            "date updated: {}".format(_utils.timestamp_to_str(int(run_msg.date_updated))),
             "description: {}".format(run_msg.description),
             "tags: {}".format(run_msg.tags),
             "attributes: {}".format(_utils.unravel_key_values(run_msg.attributes)),

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -1881,9 +1881,9 @@ class ExperimentRun(_ModelDBEntity):
         return '\n'.join((
             "name: {}".format(run_msg.name),
             "url: {}://{}/{}/projects/{}/exp-runs/{}".format(self._conn.scheme, self._conn.socket, self.workspace, run_msg.project_id, self.id),
-            "description: {}".format(run_msg.description),
             "date created: {}".format(_utils.timestamp_to_str(int(run_msg.date_created))),
             "last updated: {}".format(_utils.timestamp_to_str(int(run_msg.date_updated))),
+            "description: {}".format(run_msg.description),
             "tags: {}".format(run_msg.tags),
             "attributes: {}".format(_utils.unravel_key_values(run_msg.attributes)),
             "id: {}".format(run_msg.id),

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -1882,6 +1882,8 @@ class ExperimentRun(_ModelDBEntity):
             "name: {}".format(run_msg.name),
             "url: {}://{}/{}/projects/{}/exp-runs/{}".format(self._conn.scheme, self._conn.socket, self.workspace, run_msg.project_id, self.id),
             "description: {}".format(run_msg.description),
+            "date created: {}".format(_utils.timestamp_to_str(int(run_msg.date_created))),
+            "last updated: {}".format(_utils.timestamp_to_str(int(run_msg.date_updated))),
             "tags: {}".format(run_msg.tags),
             "attributes: {}".format(_utils.unravel_key_values(run_msg.attributes)),
             "id: {}".format(run_msg.id),


### PR DESCRIPTION
Note that the `__repr__` shows the time in the user's system's local time, like the WebApp does.
But the methods return the Unix timestamps in UTC for potentially programmatic applications.

<img width="1094" alt="Screen Shot 2020-06-22 at 2 36 03 PM" src="https://user-images.githubusercontent.com/7754936/85337915-3bd30280-b496-11ea-862f-8919d7c0b253.png">
