### PR TITLE
Require boto3 for S3 test

### DIFF
--- a/client/verta/tests/test_versioning/test_dataset.py
+++ b/client/verta/tests/test_versioning/test_dataset.py
@@ -344,6 +344,8 @@ class TestS3ManagedVersioning:
 
     def test_not_to_s3_dir(self, commit, in_tempdir):
         """If the user specifies "s3://", things shouldn't go into an "s3:" dir."""
+        pytest.importorskip("boto3")
+
         bucket = "verta-versioned-bucket"
         dirname = "tiny-files/"
         s3_folder = "s3://{}/{}".format(bucket, dirname)

--- a/client/verta/tests/test_versioning/test_dataset.py
+++ b/client/verta/tests/test_versioning/test_dataset.py
@@ -338,8 +338,6 @@ class TestS3ManagedVersioning:
 
     def test_not_to_s3_dir(self, commit):
         """If the user specifies "s3://", things shouldn't go into an "s3:" dir."""
-        pytest.importorskip("boto3")
-
         bucket = "verta-versioned-bucket"
         dirname = "tiny-files/"
         s3_folder = "s3://{}/{}".format(bucket, dirname)


### PR DESCRIPTION
EDIT: discovered I could apply this `boto3` check to entire test classes, so I don't need to remember it when writing future tests. Also applied the `in_tempdir` fixture class-wide with this newfound power.