### PR TITLE
Fix the design for preparing to upload

### DIFF
--- a/client/scala/src/main/scala/ai/verta/blobs/dataset/Dataset.scala
+++ b/client/scala/src/main/scala/ai/verta/blobs/dataset/Dataset.scala
@@ -25,8 +25,7 @@ trait Dataset extends Blob {
     )
 
   /** Prepare the components and data for upload.
-   *  @return a map of paths (in the blob) to instances of UploadComponent
-   *  which contains the path to the object in local file system and the versioning component
+   *  @return whether the attempt succeeds.
    */
   private[verta] def prepareForUpload(): Try[Unit]
 

--- a/client/scala/src/main/scala/ai/verta/blobs/dataset/Dataset.scala
+++ b/client/scala/src/main/scala/ai/verta/blobs/dataset/Dataset.scala
@@ -15,9 +15,9 @@ trait Dataset extends Blob {
 
   /** Helper to convert VersioningPathDatasetComponentBlob to FileMetadata
    */
-  protected def toComponent(metadata: FileMetadata, internalVersionedPath: Option[String] = None) =
+  protected def toComponent(metadata: FileMetadata) =
     VersioningPathDatasetComponentBlob(
-      internal_versioned_path = internalVersionedPath,
+      internal_versioned_path = metadata.internalVersionedPath,
       last_modified_at_source = Some(metadata.lastModified),
       md5 = Some(metadata.md5),
       path = Some(metadata.path),
@@ -28,7 +28,7 @@ trait Dataset extends Blob {
    *  @return a map of paths (in the blob) to instances of UploadComponent
    *  which contains the path to the object in local file system and the versioning component
    */
-  private[verta] def prepareForUpload(): Try[Map[String, UploadComponent]]
+  private[verta] def prepareForUpload(): Try[Unit]
 
   /** Get the metadata of a certain file stored in the dataset blob
    *  @param path path to the file
@@ -37,7 +37,7 @@ trait Dataset extends Blob {
   def getMetadata(path: String) = contents.get(path)
 
   /** Get all the Dataset blob's corresponding list of components */
-  protected def components = getAllMetadata.map(toComponent(_)).toList
+  protected def components = getAllMetadata.map(toComponent).toList
 
   /** Get the set of all the files' metadata managed by the Dataset blob  */
   def getAllMetadata = contents.values
@@ -52,7 +52,7 @@ trait Dataset extends Blob {
   }
 
   /** Clean up the uploaded components */
-  protected def cleanUpUploadedComponents(uploadMap: Map[String, UploadComponent]): Try[Unit] = Success(())
+  protected def cleanUpUploadedComponents(): Try[Unit] = Success(())
 }
 
 object Dataset {

--- a/client/scala/src/main/scala/ai/verta/blobs/dataset/FileMetadata.scala
+++ b/client/scala/src/main/scala/ai/verta/blobs/dataset/FileMetadata.scala
@@ -15,6 +15,7 @@ case class FileMetadata(
   val versionId: Option[String] = None
 ) {
   // mutable fields, which are updated when preparing for uploading:
+  /** TODO: remove these mutable fields to make FileMetadata immutable again */
   private[verta] var internalVersionedPath: Option[String] = None // MDB internal versioned path
   private[verta] var localPath: Option[String] = None // path to file in local system
 

--- a/client/scala/src/main/scala/ai/verta/blobs/dataset/FileMetadata.scala
+++ b/client/scala/src/main/scala/ai/verta/blobs/dataset/FileMetadata.scala
@@ -14,6 +14,10 @@ case class FileMetadata(
   val size: BigInt,
   val versionId: Option[String] = None
 ) {
+  // mutable fields, which are updated when preparing for uploading:
+  private[verta] var internalVersionedPath: Option[String] = None
+  private[verta] var localPath: Option[String] = None
+
   override def equals(other: Any) = other match {
     case other: FileMetadata => lastModified == other.lastModified &&
       md5 == other.md5 && path == other.path && size == other.size &&

--- a/client/scala/src/main/scala/ai/verta/blobs/dataset/FileMetadata.scala
+++ b/client/scala/src/main/scala/ai/verta/blobs/dataset/FileMetadata.scala
@@ -15,8 +15,8 @@ case class FileMetadata(
   val versionId: Option[String] = None
 ) {
   // mutable fields, which are updated when preparing for uploading:
-  private[verta] var internalVersionedPath: Option[String] = None
-  private[verta] var localPath: Option[String] = None
+  private[verta] var internalVersionedPath: Option[String] = None // MDB internal versioned path
+  private[verta] var localPath: Option[String] = None // path to file in local system
 
   override def equals(other: Any) = other match {
     case other: FileMetadata => lastModified == other.lastModified &&

--- a/client/scala/src/main/scala/ai/verta/blobs/dataset/S3.scala
+++ b/client/scala/src/main/scala/ai/verta/blobs/dataset/S3.scala
@@ -83,6 +83,7 @@ case class S3(
 
       val internalVersionedPath = f"${Dataset.hash(file, "SHA-256").get}/${location.key.get}"
 
+      /** TODO: remove these  */
       // mutating internal field:
       metadata.internalVersionedPath = Some(internalVersionedPath)
       metadata.localPath = Some(file.getPath)

--- a/client/scala/src/main/scala/ai/verta/blobs/dataset/UploadComponent.scala
+++ b/client/scala/src/main/scala/ai/verta/blobs/dataset/UploadComponent.scala
@@ -1,6 +1,0 @@
-package ai.verta.blobs.dataset
-
-import ai.verta.swagger._public.modeldb.versioning.model._
-
-/** The versioning path dataset component to be uploaded, along with the path to the file in the local file system */
-case class UploadComponent(val filePath: String, val component: VersioningPathDatasetComponentBlob)

--- a/client/scala/src/main/scala/ai/verta/repository/Commit.scala
+++ b/client/scala/src/main/scala/ai/verta/repository/Commit.scala
@@ -40,21 +40,12 @@ class Commit(
    *  @return The blob. If not existed, or retrieving blobs from backend fails, return a failure.
    */
   def get(path: String)(implicit ec: ExecutionContext): Try[Blob] =
-    getBlob(path)
-
-  /** Retrieve the versioning blob stored at the path
-   *  Helper function for get and remove operations
-   *  @param path location of the blob
-   *  @return ModelDB versioning blob. If not existed, fails.
-   */
-  private def getBlob(path: String)(implicit ec: ExecutionContext): Try[Blob] =
     loadBlobs().flatMap(_ =>
       blobs.get(path) match {
         case None => Failure(new NoSuchElementException("No blob was stored at this path."))
         case Some(blob) => Success(blob)
       }
     )
-
 
   /** Adds blob to this commit at path
    *  If path is already in this Commit, it will be updated to the new blob
@@ -71,7 +62,7 @@ class Commit(
    *  @return The new commit with the blob removed, if succeeds.
    */
   def remove(path: String)(implicit ec: ExecutionContext) =
-    getBlob(path).map(_ => getChild(blobs - path))
+    get(path).map(_ => getChild(blobs - path))
 
   /** Saves this commit to ModelDB
    *  @param message description of this commit


### PR DESCRIPTION
Changes:
- blobs of Commit now takes Blob as value
- prepareForUpload now mutates FileMetadata. The components, which are computed based on FileMetadata, will automatically contain internalVersionedPath (after prepareForUpload is invoked)