### PR TITLE
Fix data_blob.list_paths() tests for Py2

### DIFF
--- a/client/verta/docs/api/api/versioning.rst
+++ b/client/verta/docs/api/api/versioning.rst
@@ -30,8 +30,10 @@ Dataset
 ^^^^^^^
 .. autoclass:: verta.dataset.Path
     :members:
+    :inherited-members:
 .. autoclass:: verta.dataset.S3
     :members:
+    :inherited-members:
 
 Environment
 ^^^^^^^^^^^

--- a/client/verta/tests/test_versioning/test_dataset.py
+++ b/client/verta/tests/test_versioning/test_dataset.py
@@ -175,15 +175,15 @@ class TestS3:
         s3 = pytest.importorskip("boto3").client('s3')
 
         bucket = "verta-starter"
-        expected_paths = [
+        expected_paths = set(
             "s3://{}/{}".format(bucket, s3_obj['Key'])
             for s3_obj
             in s3.list_objects_v2(Bucket=bucket)['Contents']
             if not s3_obj['Key'].endswith('/')  # folder, not object
-        ]
+        )
 
         dataset = verta.dataset.S3("s3://{}".format(bucket))
-        assert dataset.list_paths() == expected_paths
+        assert set(dataset.list_paths()) == expected_paths
 
 
 class TestPath:
@@ -238,13 +238,13 @@ class TestPath:
     def test_list_paths(self):
         data_dir = "modelapi_hypothesis/"
 
-        expected_paths = []
+        expected_paths = set()
         for root, _, filenames in os.walk(data_dir):
             for filename in filenames:
-                expected_paths.append(os.path.join(root, filename))
+                expected_paths.add(os.path.join(root, filename))
 
         dataset = verta.dataset.Path(data_dir)
-        assert dataset.list_paths() == expected_paths
+        assert set(dataset.list_paths()) == expected_paths
 
 
 class TestS3ManagedVersioning:

--- a/client/verta/verta/dataset/_dataset.py
+++ b/client/verta/verta/dataset/_dataset.py
@@ -8,6 +8,8 @@ import tempfile
 
 from .._protos.public.modeldb.versioning import Dataset_pb2 as _DatasetService
 
+from ..external import six
+
 from .._internal_utils import _utils
 from .._internal_utils import _file_utils
 
@@ -264,4 +266,8 @@ class _Dataset(blob.Blob):
             Paths of all components.
 
         """
-        return [component.path for component in self._path_component_blobs]
+        return [
+            six.ensure_str(component.path)  # in Py2, protobuf had converted this to unicode str
+            for component
+            in self._path_component_blobs
+        ]

--- a/client/verta/verta/dataset/_dataset.py
+++ b/client/verta/verta/dataset/_dataset.py
@@ -260,6 +260,11 @@ class _Dataset(blob.Blob):
         """
         Returns the paths of all components in this dataset.
 
+        .. note::
+
+            In Python 2.7, this method returns ``str`` rather than ``unicode``.  Unicode filenames
+            can be restored by calling ``.decode('utf-8')`` on the returned strings.
+
         Returns
         -------
         component_paths : list of str


### PR DESCRIPTION
- change `Dataset.list_blobs()` to return `str` rather than `unicode`
- change test to compare sets rather than lists
- add `Dataset` methods to its subclasses' docs