### PR TITLE
VR-5007 Getting a PathBlob with empty component fails

### DIFF
--- a/client/scala/src/main/scala/ai/verta/blobs/dataset/Dataset.scala
+++ b/client/scala/src/main/scala/ai/verta/blobs/dataset/Dataset.scala
@@ -61,9 +61,9 @@ object Dataset {
      component: VersioningPathDatasetComponentBlob,
      versionId: Option[String] = None
    ) = new FileMetadata(
-     component.last_modified_at_source.get,
-     component.md5.get,
-     component.path.get,
+     component.last_modified_at_source.getOrElse(0),
+     component.md5.getOrElse(""),
+     component.path.getOrElse(""),
      component.size.getOrElse(0),
      versionId
    )

--- a/client/scala/src/main/scala/ai/verta/blobs/dataset/Dataset.scala
+++ b/client/scala/src/main/scala/ai/verta/blobs/dataset/Dataset.scala
@@ -64,7 +64,7 @@ object Dataset {
      component.last_modified_at_source.get,
      component.md5.get,
      component.path.get,
-     component.size.get,
+     component.size.getOrElse(0),
      versionId
    )
 

--- a/client/scala/src/test/scala/ai/verta/repository/TestCommit.scala
+++ b/client/scala/src/test/scala/ai/verta/repository/TestCommit.scala
@@ -68,7 +68,7 @@ class TestCommit extends FunSuite {
     }
   }
 
-  test("Update empty pathblob should work") {
+  test("Getting pathblob with empty component should succeed") {
     val f = fixture
     val emptyFile = new File("emptyfile")
 

--- a/client/scala/src/test/scala/ai/verta/repository/TestCommit.scala
+++ b/client/scala/src/test/scala/ai/verta/repository/TestCommit.scala
@@ -68,6 +68,21 @@ class TestCommit extends FunSuite {
     }
   }
 
+  test("Update empty pathblob should work") {
+    val f = fixture
+    val emptyFile = new File("emptyfile")
+
+    try {
+      emptyFile.createNewFile()
+      val newCommit =
+        f.commit.update("emptyfile", PathBlob("emptyfile").get).flatMap(_.save("save empty blob")).get
+      assert(newCommit.get("emptyfile").isSuccess)
+    } finally {
+      emptyFile.delete()
+      cleanup(f)
+    }
+  }
+
   test("Tagging unsaved commit should fail") {
     val f = fixture
 


### PR DESCRIPTION
Small bug: When the size of a component is none, my current implementation fails when I attempt to get that blob back. I also provided a test that actually failed when I ran against my old code, and passed when I ran against my new implementation.