### PR TITLE
No more protobuf-as-attr in dataset blobs

### DIFF
--- a/client/verta/verta/_repository/commit.py
+++ b/client/verta/verta/_repository/commit.py
@@ -488,7 +488,7 @@ class Commit(object):
 
         """
         # prepare ModelDB-versioned blobs, and track for upload after commit save
-        mdb_versioned_blobs = dict()
+        mdb_versioned_blobs = dict()  # avoid duplicates
         for blob_path, blob in self._blobs.items():
             if isinstance(blob, dataset._Dataset) and blob._mdb_versioned:
                 blob._prepare_components_to_upload()

--- a/client/verta/verta/_repository/commit.py
+++ b/client/verta/verta/_repository/commit.py
@@ -488,7 +488,7 @@ class Commit(object):
 
         """
         # prepare ModelDB-versioned blobs, and track for upload after commit save
-        mdb_versioned_blobs = dict()  # avoid duplicates
+        mdb_versioned_blobs = dict()
         for blob_path, blob in self._blobs.items():
             if isinstance(blob, dataset._Dataset) and blob._mdb_versioned:
                 blob._prepare_components_to_upload()

--- a/client/verta/verta/_repository/commit.py
+++ b/client/verta/verta/_repository/commit.py
@@ -499,12 +499,10 @@ class Commit(object):
 
         # upload ModelDB-versioned blobs
         for blob_path, blob in mdb_versioned_blobs.items():
-            for component_blob in blob._path_component_blobs:
-                if component_blob.internal_versioned_path:
-                    component_path = component_blob.path
-                    downloaded_filepath = blob._components_to_upload[component_path]
-                    with open(downloaded_filepath, 'rb') as f:
-                        self._upload_artifact(blob_path, component_path, f)
+            for component in blob._components_map.values():
+                if component._internal_versioned_path:
+                    with open(component._local_path, 'rb') as f:
+                        self._upload_artifact(blob_path, component.path, f)
 
             blob._clean_up_uploaded_components()
 

--- a/client/verta/verta/dataset/_dataset.py
+++ b/client/verta/verta/dataset/_dataset.py
@@ -271,7 +271,7 @@ class _Dataset(blob.Blob):
 class Component(object):
     def __init__(
             self,
-            path=None, size=None, last_modified=None,
+            path, size=None, last_modified=None,
             sha256=None, md5=None,
             base_path=None,
             internal_versioned_path=None, local_path=None):
@@ -309,21 +309,21 @@ class Component(object):
     def _from_proto(cls, component_msg):
         return cls(
             path=component_msg.path,
-            size=component_msg.size,
-            last_modified=component_msg.last_modified_at_source,
-            sha256=component_msg.sha256,
-            md5=component_msg.md5,
-            internal_versioned_path=component_msg.internal_versioned_path,
+            size=component_msg.size or None,
+            last_modified=component_msg.last_modified_at_source or None,
+            sha256=component_msg.sha256 or None,
+            md5=component_msg.md5 or None,
+            internal_versioned_path=component_msg.internal_versioned_path or None,
         )
 
     def _as_proto(self):
         return _DatasetService.PathDatasetComponentBlob(
-            path=self.path,
-            size=self.size,
-            last_modified_at_source=self.last_modified,
-            sha256=self.sha256,
-            md5=self.md5,
-            internal_versioned_path=self._internal_versioned_path,
+            path=self.path or "",
+            size=self.size or 0,
+            last_modified_at_source=self.last_modified or 0,
+            sha256=self.sha256 or "",
+            md5=self.md5 or "",
+            internal_versioned_path=self._internal_versioned_path or "",
         )
 
 
@@ -354,6 +354,6 @@ class S3Component(Component):
     def _as_proto(self):
         s3_component_msg = _DatasetService.S3DatasetComponentBlob()
         s3_component_msg.path.CopyFrom(super(S3Component, self)._as_proto())
-        s3_component_msg.s3_version_id = self.s3_version_id
+        s3_component_msg.s3_version_id = self.s3_version_id or ""
 
         return s3_component_msg

--- a/client/verta/verta/dataset/_dataset.py
+++ b/client/verta/verta/dataset/_dataset.py
@@ -255,22 +255,17 @@ class _Dataset(blob.Blob):
         """
         Returns the paths of all components in this dataset.
 
-        .. note::
-
-            In Python 2.7, this method returns ``str`` rather than ``unicode``.  Unicode filenames
-            can be restored by calling ``.decode('utf-8')`` on the returned strings.
-
         Returns
         -------
         component_paths : list of str
             Paths of all components.
 
         """
-        return [
-            six.ensure_str(component.path)  # in Py2, protobuf had converted this to unicode str
+        return list(sorted(
+            component.path
             for component
-            in self._path_component_blobs
-        ]
+            in self._components_map.values()
+        ))
 
 
 class Component(object):

--- a/client/verta/verta/dataset/_dataset.py
+++ b/client/verta/verta/dataset/_dataset.py
@@ -297,7 +297,7 @@ class Component(object):
         if self.size:
             lines.append("{} bytes".format(self.size))
         if self.last_modified:
-            lines.append("last modified: {}".format(_utils.timestamp_to_str(self.last_modified_at_source)))
+            lines.append("last modified: {}".format(_utils.timestamp_to_str(self.last_modified)))
         if self.sha256:
             lines.append("SHA-256 checksum: {}".format(self.sha256))
         if self.md5:
@@ -353,7 +353,7 @@ class S3Component(Component):
 
     def _as_proto(self):
         s3_component_msg = _DatasetService.S3DatasetComponentBlob()
-        s3_component_msg.path = super(S3Component, self)._as_proto()
+        s3_component_msg.path.CopyFrom(super(S3Component, self)._as_proto())
         s3_component_msg.s3_version_id = self.s3_version_id
 
         return s3_component_msg

--- a/client/verta/verta/dataset/_dataset.py
+++ b/client/verta/verta/dataset/_dataset.py
@@ -310,3 +310,24 @@ class Component(object):
             lines.append("S3 version ID: {}".format(self.s3_version_id))
 
         return "\n    ".join(lines)
+
+    @classmethod
+    def _from_proto(cls, component_msg):
+        return cls(
+            path=component_msg.path,
+            size=component_msg.size,
+            last_modified=component_msg.last_modified_at_source,
+            sha256=component_msg.sha256,
+            md5=component_msg.md5,
+            internal_versioned_path=component_msg.internal_versioned_path,
+        )
+
+    def _as_proto(self):
+        return _DatasetService.PathDatasetComponentBlob(
+            path=self.path,
+            size=self.size,
+            last_modified_at_source=self.last_modified,
+            sha256=self.sha256,
+            md5=self.md5,
+            internal_versioned_path=self._internal_versioned_path,
+        )

--- a/client/verta/verta/dataset/_dataset.py
+++ b/client/verta/verta/dataset/_dataset.py
@@ -302,3 +302,43 @@ class _Dataset(blob.Blob):
             for component
             in self._path_component_blobs
         ]
+
+
+class Component(object):
+    def __init__(
+            self,
+            path, size=None, last_modified_at_source=None,
+            sha256=None, md5=None,
+            s3_version_id=None,
+            internal_versioned_path=None, local_path=None):
+        # metadata
+        self.path = path
+        self.size = size
+        self.last_modified_at_source = last_modified_at_source
+
+        # checksums
+        self.sha256 = sha256
+        self.md5 = md5
+
+        # S3 versioning
+        self.s3_version_id = s3_version_id
+
+        # ModelDB versioning
+        self._internal_versioned_path = internal_versioned_path
+        self._local_path = local_path
+
+    def __repr__(self):
+        lines = [self.path]
+
+        if self.size:
+            lines.append("{} bytes".format(self.size))
+        if self.last_modified_at_source:
+            lines.append("last modified: {}".format(_utils.timestamp_to_str(self.last_modified_at_source)))
+        if self.sha256:
+            lines.append("SHA-256 checksum: {}".format(self.sha256))
+        if self.md5:
+            lines.append("MD5 checksum: {}".format(self.md5))
+        if self.s3_version_id:
+            lines.append("S3 version ID: {}".format(self.s3_version_id))
+
+        return "\n    ".join(lines)

--- a/client/verta/verta/dataset/_dataset.py
+++ b/client/verta/verta/dataset/_dataset.py
@@ -300,7 +300,7 @@ class Component(object):
 
         if self.size:
             lines.append("{} bytes".format(self.size))
-        if self.last_modified_at_source:
+        if self.last_modified:
             lines.append("last modified: {}".format(_utils.timestamp_to_str(self.last_modified_at_source)))
         if self.sha256:
             lines.append("SHA-256 checksum: {}".format(self.sha256))

--- a/client/verta/verta/dataset/_dataset.py
+++ b/client/verta/verta/dataset/_dataset.py
@@ -271,7 +271,7 @@ class _Dataset(blob.Blob):
 class Component(object):
     def __init__(
             self,
-            path, size=None, last_modified_at_source=None,
+            path, size=None, last_modified=None,
             sha256=None, md5=None,
             s3_version_id=None,
             base_path=None,
@@ -279,7 +279,7 @@ class Component(object):
         # metadata
         self.path = path
         self.size = size
-        self.last_modified_at_source = last_modified_at_source
+        self.last_modified = last_modified
 
         # checksums
         self.sha256 = sha256

--- a/client/verta/verta/dataset/_path.py
+++ b/client/verta/verta/dataset/_path.py
@@ -57,10 +57,9 @@ class Path(_dataset._Dataset):
         super(Path, self).__init__(enable_mdb_versioning=enable_mdb_versioning)
 
         filepaths = _file_utils.flatten_file_trees(paths)
-        components = list(map(self._get_file_metadata, filepaths))
+        components = list(map(self._file_to_component, filepaths))
 
         # remove `base_path` from the beginning of component paths
-        base_path_to_component_paths = collections.defaultdict(set)
         if base_path is not None:
             for component in components:
                 path = _file_utils.remove_prefix_dir(component.path, prefix_dir=base_path)
@@ -73,27 +72,14 @@ class Path(_dataset._Dataset):
                 # update component with modified path
                 component.path = path
 
-                # keep track of which paths correspond to which `base_path`
-                #     `base_path` needs to be tracked to reconstruct the original filepath in
-                #     _prepare_components_to_upload() so that the file can actually be located for
-                #     upload. This is a mapping because more paths could be added to this blob
-                #     using different base paths.
-                base_path_to_component_paths[base_path].add(component.path)
+                # track base path
+                component._base_path = base_path
 
-        self._msg.path.components.extend(components)
-        self._base_path_to_component_paths = base_path_to_component_paths
-
-    def __repr__(self):
-        # TODO: consolidate with S3 since they're almost identical now
-        lines = ["Path Version"]
-        components = sorted(
-            self._path_component_blobs,
-            key=lambda component_msg: component_msg.path,
-        )
-        for component in components:
-            lines.extend(self._path_component_to_repr_lines(component))
-
-        return "\n    ".join(lines)
+        self._components_map.update({
+            component.path: component
+            for component
+            in components
+        })
 
     @classmethod
     def _from_proto(cls, blob_msg):
@@ -108,23 +94,14 @@ class Path(_dataset._Dataset):
 
         return blob_msg
 
-    @property
-    def _path_component_blobs(self):
-        return [
-            component
-            for component
-            in self._msg.path.components
-        ]
-
     @classmethod
-    def _get_file_metadata(cls, filepath):
-        msg = _DatasetService.PathDatasetComponentBlob()
-        msg.path = filepath
-        msg.size = os.stat(filepath).st_size
-        msg.last_modified_at_source = _utils.timestamp_to_ms(os.stat(filepath).st_mtime)
-        msg.md5 = cls._hash_file(filepath)
-
-        return msg
+    def _file_to_component(cls, filepath):
+        return _dataset.Component(
+            path=filepath,
+            size=os.stat(filepath).st_size,
+            last_modified_at_source=_utils.timestamp_to_ms(os.stat(filepath).st_mtime),
+            md5=cls._hash_file(filepath),
+        )
 
     @staticmethod
     def _hash_file(filepath):
@@ -157,12 +134,12 @@ class Path(_dataset._Dataset):
             component_path = component_blob.path
 
             # reconstruct original filepaths with removed `base_path`s
-            for base_path, component_paths in self._base_path_to_component_paths.items():
-                if component_path in component_paths:
-                    filepath = os.path.join(base_path, component_path)
+            for component in self._components.values():
+                if component._base_path:
+                    filepath = os.path.join(component._base_path, component.path)
                     break
             else:
-                filepath = component_path
+                filepath = component.path
             filepath = os.path.abspath(filepath)
 
             # track which file this component corresponds to

--- a/client/verta/verta/dataset/_path.py
+++ b/client/verta/verta/dataset/_path.py
@@ -85,14 +85,7 @@ class Path(_dataset._Dataset):
         obj = cls(paths=[])
 
         for component_msg in blob_msg.dataset.path.components:
-            component = _dataset.Component(
-                path=component_msg.path,
-                size=component_msg.size,
-                last_modified=component_msg.last_modified_at_source,
-                sha256=component_msg.sha256,
-                md5=component_msg.md5,
-                internal_versioned_path=component_msg.internal_versioned_path,
-            )
+            component = _dataset.Component._from_proto(component_msg)
             obj._components_map[component.path] = component
 
         return obj
@@ -101,14 +94,7 @@ class Path(_dataset._Dataset):
         blob_msg = _VersioningService.Blob()
 
         for component in self._components_map.values():
-            component_msg = _DatasetService.PathDatasetComponentBlob(
-                path=component.path,
-                size=component.size,
-                last_modified_at_source=component.last_modified,
-                sha256=component.sha256,
-                md5=component.md5,
-                internal_versioned_path=component._internal_versioned_path,
-            )
+            component_msg = component._as_proto()
             blob_msg.dataset.path.components.append(component_msg)
 
         return blob_msg

--- a/client/verta/verta/dataset/_path.py
+++ b/client/verta/verta/dataset/_path.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 import hashlib
 import os
 
+from .._protos.public.modeldb.versioning import Dataset_pb2 as _DatasetService
 from .._protos.public.modeldb.versioning import VersioningService_pb2 as _VersioningService
 
 from ..external import six
@@ -82,13 +83,23 @@ class Path(_dataset._Dataset):
     @classmethod
     def _from_proto(cls, blob_msg):
         obj = cls(paths=[])
-        obj._msg.CopyFrom(blob_msg.dataset)
+        # obj._msg.CopyFrom(blob_msg.dataset)
 
         return obj
 
     def _as_proto(self):
         blob_msg = _VersioningService.Blob()
-        blob_msg.dataset.CopyFrom(self._msg)
+
+        for component in self._components_map.values():
+            component_msg = _DatasetService.PathDatasetComponentBlob(
+                path=component.path,
+                size=component.size,
+                last_modified_at_source=component.last_modified,
+                sha256=component.sha256,
+                md5=component.md5,
+                internal_versioned_path=component._internal_versioned_path,
+            )
+            blob_msg.dataset.path.components.append(component_msg)
 
         return blob_msg
 
@@ -97,7 +108,7 @@ class Path(_dataset._Dataset):
         return _dataset.Component(
             path=filepath,
             size=os.stat(filepath).st_size,
-            last_modified_at_source=_utils.timestamp_to_ms(os.stat(filepath).st_mtime),
+            last_modified=_utils.timestamp_to_ms(os.stat(filepath).st_mtime),
             md5=cls._hash_file(filepath),
         )
 

--- a/client/verta/verta/dataset/_path.py
+++ b/client/verta/verta/dataset/_path.py
@@ -83,7 +83,17 @@ class Path(_dataset._Dataset):
     @classmethod
     def _from_proto(cls, blob_msg):
         obj = cls(paths=[])
-        # obj._msg.CopyFrom(blob_msg.dataset)
+
+        for component_msg in blob_msg.dataset.path.components:
+            component = _dataset.Component(
+                path=component_msg.path,
+                size=component_msg.size,
+                last_modified=component_msg.last_modified_at_source,
+                sha256=component_msg.sha256,
+                md5=component_msg.md5,
+                internal_versioned_path=component_msg.internal_versioned_path,
+            )
+            obj._components_map[component.path] = component
 
         return obj
 

--- a/client/verta/verta/dataset/_s3.py
+++ b/client/verta/verta/dataset/_s3.py
@@ -222,7 +222,7 @@ class S3(_dataset._Dataset):
             return
 
         for component in self._components_map.values():
-            if component._local_path:
+            if component._local_path and os.path.isfile(component._local_path):
                 os.remove(component._local_path)
 
 

--- a/client/verta/verta/dataset/_s3.py
+++ b/client/verta/verta/dataset/_s3.py
@@ -82,7 +82,7 @@ class S3(_dataset._Dataset):
         obj = cls(paths=[])
 
         for component_msg in blob_msg.dataset.s3.components:
-            component = _dataset.Component._from_proto(component_msg)
+            component = _dataset.S3Component._from_proto(component_msg)
             obj._components_map[component.path] = component
 
         return obj
@@ -136,7 +136,7 @@ class S3(_dataset._Dataset):
         component = _dataset.S3Component(
             path=cls._S3_PATH.format(bucket_name, key),
             size=obj.get('Size') or obj.get('ContentLength') or 0,
-            last_modified_at_source=_utils.timestamp_to_ms(_utils.ensure_timestamp(obj['LastModified'])),
+            last_modified=_utils.timestamp_to_ms(_utils.ensure_timestamp(obj['LastModified'])),
             md5=obj['ETag'].strip('"'),
         )
         if obj.get('VersionId', 'null') != 'null':  # S3's API returns 'null' when there's no version ID

--- a/client/verta/verta/dataset/_s3.py
+++ b/client/verta/verta/dataset/_s3.py
@@ -59,7 +59,6 @@ class S3(_dataset._Dataset):
 
         super(S3, self).__init__(enable_mdb_versioning=enable_mdb_versioning)
 
-        obj_paths_to_metadata = dict()  # prevent duplicate objects
         for path in paths:
             # convert paths to S3Location
             if isinstance(path, six.string_types):
@@ -72,30 +71,33 @@ class S3(_dataset._Dataset):
                     " not {} ({})".format(type(path), path)
                 )
 
-            obj_paths_to_metadata.update({
-                obj_metadata.path.path: obj_metadata
-                for obj_metadata
-                in self._get_s3_loc_metadata(s3_loc)
+            self._components_map.update({
+                component.path: component
+                for component
+                in self._get_s3_components(s3_loc)
             })
-
-        s3_metadata = six.viewvalues(obj_paths_to_metadata)
-        self._msg.s3.components.extend(s3_metadata)
 
     @classmethod
     def _from_proto(cls, blob_msg):
         obj = cls(paths=[])
-        obj._msg.CopyFrom(blob_msg.dataset)
+
+        for component_msg in blob_msg.dataset.s3.components:
+            component = _dataset.Component._from_proto(component_msg)
+            obj._components_map[component.path] = component
 
         return obj
 
     def _as_proto(self):
         blob_msg = _VersioningService.Blob()
-        blob_msg.dataset.CopyFrom(self._msg)
+
+        for component in self._components_map.values():
+            component_msg = component._as_proto()
+            blob_msg.dataset.s3.components.append(component_msg)
 
         return blob_msg
 
     @classmethod
-    def _get_s3_loc_metadata(cls, s3_loc):
+    def _get_s3_components(cls, s3_loc):
         try:
             import boto3
         except ImportError:
@@ -119,7 +121,7 @@ class S3(_dataset._Dataset):
                     continue
                 if not obj['IsLatest']:
                     continue
-                yield cls._get_s3_obj_metadata(obj, s3_loc.bucket, obj['Key'])
+                yield cls._s3_obj_to_component(obj, s3_loc.bucket, obj['Key'])
         else:
             # TODO: handle `key` not found
             if s3_loc.version_id is not None:
@@ -127,20 +129,20 @@ class S3(_dataset._Dataset):
                 obj = s3.head_object(Bucket=s3_loc.bucket, Key=s3_loc.key, VersionId=s3_loc.version_id)
             else:
                 obj = s3.head_object(Bucket=s3_loc.bucket, Key=s3_loc.key)
-            yield cls._get_s3_obj_metadata(obj, s3_loc.bucket, s3_loc.key)
+            yield cls._s3_obj_to_component(obj, s3_loc.bucket, s3_loc.key)
 
     @classmethod
-    def _get_s3_obj_metadata(cls, obj, bucket_name, key):
-        # pylint: disable=no-member
-        msg = _DatasetService.S3DatasetComponentBlob()
-        msg.path.path = cls._S3_PATH.format(bucket_name, key)
-        msg.path.size = obj.get('Size') or obj.get('ContentLength') or 0
-        msg.path.last_modified_at_source = _utils.timestamp_to_ms(_utils.ensure_timestamp(obj['LastModified']))
-        msg.path.md5 = obj['ETag'].strip('"')
+    def _s3_obj_to_component(cls, obj, bucket_name, key):
+        component = _dataset.S3Component(
+            path=cls._S3_PATH.format(bucket_name, key),
+            size=obj.get('Size') or obj.get('ContentLength') or 0,
+            last_modified_at_source=_utils.timestamp_to_ms(_utils.ensure_timestamp(obj['LastModified'])),
+            md5=obj['ETag'].strip('"'),
+        )
         if obj.get('VersionId', 'null') != 'null':  # S3's API returns 'null' when there's no version ID
-            msg.s3_version_id = obj['VersionId']
+            component.s3_version_id = obj['VersionId']
 
-        return msg
+        return component
 
     @staticmethod
     def location(path, version_id=None):
@@ -185,14 +187,13 @@ class S3(_dataset._Dataset):
         s3 = boto3.client('s3')
 
         # download files to local disk
-        for s3_obj in self._msg.s3.components:
-            s3_path = s3_obj.path.path
-            s3_loc = S3Location(s3_path, s3_obj.s3_version_id)
+        for component in self._components_map.values():
+            s3_loc = S3Location(component.path, component.s3_version_id)
 
             # download to file in ~/.verta/temp/
             tempdir = os.path.join(_utils.HOME_VERTA_DIR, "temp")
             pathlib2.Path(tempdir).mkdir(parents=True, exist_ok=True)
-            print("downloading {} from S3".format(s3_path))
+            print("downloading {} from S3".format(component.path))
             with tempfile.NamedTemporaryFile('w+b', dir=tempdir, delete=False) as tempf:
                 s3.download_fileobj(
                     Bucket=s3_loc.bucket,
@@ -203,12 +204,12 @@ class S3(_dataset._Dataset):
             print("download complete")
 
             # track which downloaded file this component corresponds to
-            self._components_to_upload[s3_path] = tempf.name
+            component._local_path = tempf.name
 
             # add MDB path to component blob
             with open(tempf.name, 'rb') as f:
                 artifact_hash = _artifact_utils.calc_sha256(f)
-            s3_obj.path.internal_versioned_path = artifact_hash + '/' + s3_loc.key
+            component._internal_versioned_path = artifact_hash + '/' + s3_loc.key
 
     def _clean_up_uploaded_components(self):
         """
@@ -220,8 +221,9 @@ class S3(_dataset._Dataset):
         if not self._mdb_versioned:
             return
 
-        for filepath in self._components_to_upload.values():
-            os.remove(filepath)
+        for component in self._components_map.values():
+            if component._local_path:
+                os.remove(component._local_path)
 
 
 class S3Location(object):

--- a/client/verta/verta/dataset/_s3.py
+++ b/client/verta/verta/dataset/_s3.py
@@ -81,18 +81,6 @@ class S3(_dataset._Dataset):
         s3_metadata = six.viewvalues(obj_paths_to_metadata)
         self._msg.s3.components.extend(s3_metadata)
 
-    def __repr__(self):
-        # TODO: consolidate with Path since they're almost identical now
-        lines = ["S3 Version"]
-        components = sorted(
-            self._path_component_blobs,
-            key=lambda component_msg: component_msg.path,
-        )
-        for component in components:
-            lines.extend(self._path_component_to_repr_lines(component))
-
-        return "\n    ".join(lines)
-
     @classmethod
     def _from_proto(cls, blob_msg):
         obj = cls(paths=[])
@@ -105,15 +93,6 @@ class S3(_dataset._Dataset):
         blob_msg.dataset.CopyFrom(self._msg)
 
         return blob_msg
-
-    @property
-    def _path_component_blobs(self):
-        # S3 has its PathDatasetComponentBlob nested one lever deeper than Path
-        return [
-            component.path
-            for component
-            in self._msg.s3.components
-        ]
 
     @classmethod
     def _get_s3_loc_metadata(cls, s3_loc):


### PR DESCRIPTION
On top of #891

`S3` and `Path` dataset blobs no longer have a protobuf `_msg` attribute, and instead have a collection of `Component` objects.

This accomplishes the primary goal of this refactor which was to have `_base_path` (and as a bonus, the `_local_path` used for MDB versioning upload!) grouped together with the components' information.

I chose to make this a class instead of a `namedtuple` for these reasons:
- optional fields (though this turned out to not be that important)
- control over `__repr__`
- ability to define `_from_proto()` and `_as_proto()`