### PR TITLE
Add Blob._from_proto() and Blob._as_proto()

### DIFF
--- a/client/verta/verta/_repository/blob.py
+++ b/client/verta/verta/_repository/blob.py
@@ -2,6 +2,38 @@
 
 from __future__ import print_function
 
+import abc
 
+from ..external import six
+
+
+@six.add_metaclass(abc.ABCMeta)
 class Blob(object):
-    pass
+    @classmethod
+    @abc.abstractmethod
+    def _from_proto(cls, blob_msg):
+        """
+        Returns a blob from `blob_msg`.
+
+        Parameters
+        ----------
+        blob_msg : _VersioningService.Blob
+
+        Returns
+        -------
+        blob : class instance
+
+        """
+        pass
+
+    @abc.abstractmethod
+    def _as_proto(self):
+        """
+        Returns this blob as a protobuf message.
+
+        Returns
+        -------
+        blob_msg : _VersioningService.Blob
+
+        """
+        pass

--- a/client/verta/verta/_repository/commit.py
+++ b/client/verta/verta/_repository/commit.py
@@ -328,10 +328,10 @@ class Commit(object):
         msg.commit.message = commit_message
 
         for path, blob in six.viewitems(self._blobs):
-            blob_expanded_msg = _VersioningService.BlobExpanded()
-            blob_expanded_msg.location.extend(path_to_location(path))  # pylint: disable=no-member
-            blob_expanded_msg.blob.CopyFrom(blob._as_proto())
-            msg.blobs.append(blob_expanded_msg)  # pylint: disable=no-member
+            blob_msg = _VersioningService.BlobExpanded()
+            blob_msg.location.extend(path_to_location(path))  # pylint: disable=no-member
+            blob_msg.blob.CopyFrom(blob._as_proto())
+            msg.blobs.append(blob_msg)  # pylint: disable=no-member
 
         return msg
 

--- a/client/verta/verta/_repository/commit.py
+++ b/client/verta/verta/_repository/commit.py
@@ -328,21 +328,10 @@ class Commit(object):
         msg.commit.message = commit_message
 
         for path, blob in six.viewitems(self._blobs):
-            blob_msg = _VersioningService.BlobExpanded()
-            blob_msg.location.extend(path_to_location(path))  # pylint: disable=no-member
-            # TODO: move typecheck & CopyFrom to root blob base class
-            if isinstance(blob, code._Code):
-                blob_msg.blob.code.CopyFrom(blob._msg)  # pylint: disable=no-member
-            elif isinstance(blob, configuration._Configuration):
-                blob_msg.blob.config.CopyFrom(blob._msg)  # pylint: disable=no-member
-            elif isinstance(blob, dataset._Dataset):
-                blob_msg.blob.dataset.CopyFrom(blob._msg)  # pylint: disable=no-member
-            elif isinstance(blob, environment._Environment):
-                blob_msg.blob.environment.CopyFrom(blob._msg)  # pylint: disable=no-member
-            else:
-                raise RuntimeError("Commit contains an unexpected item {};"
-                                   " please notify the Verta development team".format(type(blob)))
-            msg.blobs.append(blob_msg)  # pylint: disable=no-member
+            blob_expanded_msg = _VersioningService.BlobExpanded()
+            blob_expanded_msg.location.extend(path_to_location(path))  # pylint: disable=no-member
+            blob_expanded_msg.blob.CopyFrom(blob._as_proto())
+            msg.blobs.append(blob_expanded_msg)  # pylint: disable=no-member
 
         return msg
 
@@ -873,29 +862,29 @@ def blob_msg_to_object(blob_msg):
     # TODO: make this more concise
     content_type = blob_msg.WhichOneof('content')
     content_subtype = None
-    obj = None
+    blob_cls = None
     if content_type == 'code':
         content_subtype = blob_msg.code.WhichOneof('content')
         if content_subtype == 'git':
-            obj = code.Git(_autocapture=False)
+            blob_cls = code.Git
         elif content_subtype == 'notebook':
-            obj = code.Notebook(_autocapture=False)
+            blob_cls = code.Notebook
     elif content_type == 'config':
-        obj = configuration.Hyperparameters()
+        blob_cls = configuration.Hyperparameters
     elif content_type == 'dataset':
         content_subtype = blob_msg.dataset.WhichOneof('content')
         if content_subtype == 's3':
-            obj = dataset.S3(paths=[])
+            blob_cls = dataset.S3
         elif content_subtype == 'path':
-            obj = dataset.Path(paths=[])
+            blob_cls = dataset.Path
     elif content_type == 'environment':
         content_subtype = blob_msg.environment.WhichOneof('content')
         if content_subtype == 'python':
-            obj = environment.Python(_autocapture=False)
+            blob_cls = environment.Python
         elif content_subtype == 'docker':
             raise NotImplementedError
 
-    if obj is None:
+    if blob_cls is None:
         if content_subtype is None:
             raise NotImplementedError("found unexpected content type {};"
                                       " please notify the Verta development team".format(content_type))
@@ -903,8 +892,7 @@ def blob_msg_to_object(blob_msg):
             raise NotImplementedError("found unexpected {} type {};"
                                       " please notify the Verta development team".format(content_type, content_subtype))
 
-    obj._msg.CopyFrom(getattr(blob_msg, content_type))
-    return obj
+    return blob_cls._from_proto(blob_msg)
 
 
 def path_to_location(path):

--- a/client/verta/verta/code/_code.py
+++ b/client/verta/verta/code/_code.py
@@ -15,4 +15,5 @@ class _Code(blob.Blob):
         """
         super(_Code, self).__init__()
 
+        # TODO: don't use proto to store data
         self._msg = _CodeService.CodeBlob()

--- a/client/verta/verta/code/_git.py
+++ b/client/verta/verta/code/_git.py
@@ -2,7 +2,7 @@
 
 from __future__ import print_function
 
-from .._protos.public.modeldb.versioning import Code_pb2 as _CodeService
+from .._protos.public.modeldb.versioning import VersioningService_pb2 as _VersioningService
 
 from .._internal_utils import _git_utils
 from . import _code
@@ -80,3 +80,16 @@ class Git(_code._Code):
             lines.append("in repo {}".format(self._msg.git.repo))
 
         return "\n    ".join(lines)
+
+    @classmethod
+    def _from_proto(cls, blob_msg):
+        obj = cls(_autocapture=False)
+        obj._msg.CopyFrom(blob_msg.code)
+
+        return obj
+
+    def _as_proto(self):
+        blob_msg = _VersioningService.Blob()
+        blob_msg.code.CopyFrom(self._msg)
+
+        return blob_msg

--- a/client/verta/verta/code/_notebook.py
+++ b/client/verta/verta/code/_notebook.py
@@ -4,6 +4,8 @@ from __future__ import print_function
 
 import os
 
+from .._protos.public.modeldb.versioning import VersioningService_pb2 as _VersioningService
+
 from .._internal_utils import _git_utils
 from .._internal_utils import _utils
 from ..dataset import _path
@@ -83,3 +85,16 @@ class Notebook(_code._Code):
             )
 
         return "\n    ".join(lines)
+
+    @classmethod
+    def _from_proto(cls, blob_msg):
+        obj = cls(_autocapture=False)
+        obj._msg.CopyFrom(blob_msg.code)
+
+        return obj
+
+    def _as_proto(self):
+        blob_msg = _VersioningService.Blob()
+        blob_msg.code.CopyFrom(self._msg)
+
+        return blob_msg

--- a/client/verta/verta/configuration/_configuration.py
+++ b/client/verta/verta/configuration/_configuration.py
@@ -15,4 +15,5 @@ class _Configuration(blob.Blob):
     def __init__(self):
         super(_Configuration, self).__init__()
 
+        # TODO: don't use proto to store data
         self._msg = _ConfigService.ConfigBlob()

--- a/client/verta/verta/configuration/_hyperparameters.py
+++ b/client/verta/verta/configuration/_hyperparameters.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 
 from ..external import six
 
+from .._protos.public.modeldb.versioning import VersioningService_pb2 as _VersioningService
 from .._protos.public.modeldb.versioning import Config_pb2 as _ConfigService
 
 from . import _configuration
@@ -104,6 +105,19 @@ class Hyperparameters(_configuration._Configuration):
         )
 
         return "\n    ".join(lines)
+
+    @classmethod
+    def _from_proto(cls, blob_msg):
+        obj = cls()
+        obj._msg.CopyFrom(blob_msg.config)
+
+        return obj
+
+    def _as_proto(self):
+        blob_msg = _VersioningService.Blob()
+        blob_msg.config.CopyFrom(self._msg)
+
+        return blob_msg
 
     @staticmethod
     def _value_to_msg(value):

--- a/client/verta/verta/dataset/_dataset.py
+++ b/client/verta/verta/dataset/_dataset.py
@@ -27,6 +27,7 @@ class _Dataset(blob.Blob):
     def __init__(self, enable_mdb_versioning=False):
         super(_Dataset, self).__init__()
 
+        # TODO: don't use proto to store data
         self._msg = _DatasetService.DatasetBlob()
 
         self._mdb_versioned = enable_mdb_versioning

--- a/client/verta/verta/dataset/_dataset.py
+++ b/client/verta/verta/dataset/_dataset.py
@@ -2,6 +2,7 @@
 
 from __future__ import print_function
 
+import abc
 import os
 import pathlib2
 import tempfile
@@ -38,6 +39,7 @@ class _Dataset(blob.Blob):
         self._blob_path = None
 
     @property
+    @abc.abstractmethod
     def _path_component_blobs(self):
         """
         Returns path components of this dataset.
@@ -48,8 +50,7 @@ class _Dataset(blob.Blob):
             Path components of this dataset.
 
         """
-        # This shall be implemented by subclasses, but shouldn't halt execution if called.
-        return []
+        pass
 
     @staticmethod
     def _path_component_to_repr_lines(path_component_msg):
@@ -76,13 +77,13 @@ class _Dataset(blob.Blob):
 
         return lines
 
+    @abc.abstractmethod
     def _prepare_components_to_upload(self):
-        # This shall be implemented by subclasses, but shouldn't halt execution if called.
-        return
+        pass
 
+    @abc.abstractmethod
     def _clean_up_uploaded_components(self):
-        # This shall be implemented by subclasses, but shouldn't halt execution if called.
-        return
+        pass
 
     def _set_commit_and_blob_path(self, commit, blob_path):
         """

--- a/client/verta/verta/dataset/_path.py
+++ b/client/verta/verta/dataset/_path.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 import hashlib
 import os
 
+from .._protos.public.modeldb.versioning import VersioningService_pb2 as _VersioningService
 from .._protos.public.modeldb.versioning import Dataset_pb2 as _DatasetService
 
 from ..external import six
@@ -68,6 +69,19 @@ class Path(_dataset._Dataset):
             lines.extend(self._path_component_to_repr_lines(component))
 
         return "\n    ".join(lines)
+
+    @classmethod
+    def _from_proto(cls, blob_msg):
+        obj = cls(paths=[])
+        obj._msg.CopyFrom(blob_msg.dataset)
+
+        return obj
+
+    def _as_proto(self):
+        blob_msg = _VersioningService.Blob()
+        blob_msg.dataset.CopyFrom(self._msg)
+
+        return blob_msg
 
     @property
     def _path_component_blobs(self):

--- a/client/verta/verta/dataset/_s3.py
+++ b/client/verta/verta/dataset/_s3.py
@@ -9,6 +9,7 @@ import tempfile
 from ..external import six
 from ..external.six.moves.urllib.parse import urlparse  # pylint: disable=import-error, no-name-in-module
 
+from .._protos.public.modeldb.versioning import VersioningService_pb2 as _VersioningService
 from .._protos.public.modeldb.versioning import Dataset_pb2 as _DatasetService
 
 from .._internal_utils import _artifact_utils
@@ -91,6 +92,19 @@ class S3(_dataset._Dataset):
             lines.extend(self._path_component_to_repr_lines(component))
 
         return "\n    ".join(lines)
+
+    @classmethod
+    def _from_proto(cls, blob_msg):
+        obj = cls(paths=[])
+        obj._msg.CopyFrom(blob_msg.dataset)
+
+        return obj
+
+    def _as_proto(self):
+        blob_msg = _VersioningService.Blob()
+        blob_msg.dataset.CopyFrom(self._msg)
+
+        return blob_msg
 
     @property
     def _path_component_blobs(self):

--- a/client/verta/verta/environment/_environment.py
+++ b/client/verta/verta/environment/_environment.py
@@ -22,6 +22,7 @@ class _Environment(blob.Blob):
     def __init__(self, env_vars, autocapture):
         super(_Environment, self).__init__()
 
+        # TODO: don't use proto to store data
         self._msg = _EnvironmentService.EnvironmentBlob()
 
         if env_vars is not None:

--- a/client/verta/verta/environment/_python.py
+++ b/client/verta/verta/environment/_python.py
@@ -8,6 +8,7 @@ import sys
 
 from ..external import six
 
+from .._protos.public.modeldb.versioning import VersioningService_pb2 as _VersioningService
 from .._protos.public.modeldb.versioning import Environment_pb2 as _EnvironmentService
 
 from .._internal_utils import _pip_requirements_utils
@@ -101,6 +102,19 @@ class Python(_environment._Environment):
             )
 
         return "\n    ".join(lines)
+
+    @classmethod
+    def _from_proto(cls, blob_msg):
+        obj = cls(_autocapture=False)
+        obj._msg.CopyFrom(blob_msg.environment)
+
+        return obj
+
+    def _as_proto(self):
+        blob_msg = _VersioningService.Blob()
+        blob_msg.environment.CopyFrom(self._msg)
+
+        return blob_msg
 
     @staticmethod
     def _req_spec_to_msg(req_spec):


### PR DESCRIPTION
Until now, interacting with a blob's `_msg` attribute was the way to translate between these Python objects and protobuf messages.

This PR begins the shift away from that practice by implementing a `_from_proto()` and `_as_proto()` interface for blobs. This is only a start, as these methods still rely on the `_msg` attribute.