### PR TITLE
Use _utils.raise_for_http_error() everywhere

### DIFF
--- a/client/verta/tests/test_deployment.py
+++ b/client/verta/tests/test_deployment.py
@@ -892,12 +892,13 @@ class TestDeploy:
         experiment_run.log_requirements(['scikit-learn'])
 
         # delete model
-        _utils.make_request(
+        response = _utils.make_request(
             "DELETE",
             "{}://{}/api/v1/modeldb/experiment-run/deleteArtifact".format(experiment_run._conn.scheme,
                                                               experiment_run._conn.socket),
             experiment_run._conn, json={'id': experiment_run.id, 'key': "model.pkl"}
-        ).raise_for_status()
+        )
+        _utils.raise_for_http_error(response)
 
         with pytest.raises(RuntimeError) as excinfo:
             experiment_run.deploy()
@@ -914,12 +915,13 @@ class TestDeploy:
         experiment_run.log_requirements(['scikit-learn'])
 
         # delete model API
-        _utils.make_request(
+        response = _utils.make_request(
             "DELETE",
             "{}://{}/api/v1/modeldb/experiment-run/deleteArtifact".format(experiment_run._conn.scheme,
                                                               experiment_run._conn.socket),
             experiment_run._conn, json={'id': experiment_run.id, 'key': "model_api.json"}
-        ).raise_for_status()
+        )
+        _utils.raise_for_http_error(response)
 
         with pytest.raises(RuntimeError) as excinfo:
             experiment_run.deploy()

--- a/client/verta/tests/test_protos.py
+++ b/client/verta/tests/test_protos.py
@@ -2,6 +2,8 @@ import requests
 
 import pytest
 
+from verta._internal_utils import _utils
+
 
 class TestGetChildren:
     def test_get_experiments_in_project(self, client):
@@ -13,7 +15,7 @@ class TestGetChildren:
 
         response = requests.get("http://{}/api/v1/modeldb/experiment/getExperimentsInProject".format(client._conn.socket),
                                 params={'project_id': proj.id}, headers=client._conn.auth)
-        response.raise_for_status()
+        _utils.raise_for_http_error(response)
         assert set(expt_ids) == set(experiment['id'] for experiment in response.json()['experiments'])
 
     def test_get_experiment_runs_in_project(self, client):
@@ -29,7 +31,7 @@ class TestGetChildren:
 
         response = requests.get("http://{}/api/v1/modeldb/experiment-run/getExperimentRunsInProject".format(client._conn.socket),
                                 params={'project_id': proj.id}, headers=client._conn.auth)
-        response.raise_for_status()
+        _utils.raise_for_http_error(response)
         assert set(run_ids) == set(experiment_run['id'] for experiment_run in response.json()['experiment_runs'])
 
     def test_get_experiment_runs_in_experiment(self, client):
@@ -42,5 +44,5 @@ class TestGetChildren:
 
         response = requests.get("http://{}/api/v1/modeldb/experiment-run/getExperimentRunsInExperiment".format(client._conn.socket),
                                 params={'experiment_id': expt.id}, headers=client._conn.auth)
-        response.raise_for_status()
+        _utils.raise_for_http_error(response)
         assert set(run_ids) == set(experiment_run['id'] for experiment_run in response.json()['experiment_runs'])

--- a/client/verta/tests/utils.py
+++ b/client/verta/tests/utils.py
@@ -106,26 +106,26 @@ def chdir(new_dir):
 def delete_project(id_, conn):
     request_url = "{}://{}/api/v1/modeldb/project/deleteProject".format(conn.scheme, conn.socket)
     response = requests.delete(request_url, json={'id': id_}, headers=conn.auth)
-    response.raise_for_status()
+    _utils.raise_for_http_error(response)
 
 
 def delete_experiment(id_, conn):
     request_url = "{}://{}/api/v1/modeldb/experiment/deleteExperiment".format(conn.scheme, conn.socket)
     response = requests.delete(request_url, json={'id': id_}, headers=conn.auth)
-    response.raise_for_status()
+    _utils.raise_for_http_error(response)
 
 
 def delete_experiment_run(id_, conn):
     request_url = "{}://{}/api/v1/modeldb/experiment-run/deleteExperimentRun".format(conn.scheme, conn.socket)
     response = requests.delete(request_url, json={'id': id_}, headers=conn.auth)
-    response.raise_for_status()
+    _utils.raise_for_http_error(response)
 
 def delete_datasets(ids, conn):
     request_url = "{}://{}/api/v1/modeldb/dataset/deleteDatasets".format(conn.scheme, conn.socket)
     response = requests.delete(request_url, json={'ids': ids}, headers=conn.auth)
-    response.raise_for_status()
+    _utils.raise_for_http_error(response)
 
 def delete_repository(id_, conn):
     request_url = "{}://{}/api/v1/modeldb/versioning/repositories/{}".format(conn.scheme, conn.socket, id_)
     response = requests.delete(request_url, headers=conn.auth)
-    response.raise_for_status()
+    _utils.raise_for_http_error(response)

--- a/client/verta/verta/_repository/commit.py
+++ b/client/verta/verta/_repository/commit.py
@@ -233,7 +233,7 @@ class Commit(object):
                         continue  # try again
                     else:
                         break
-                response.raise_for_status()
+                _utils.raise_for_http_error(response)
 
                 # commit part
                 url = "{}://{}/api/v1/modeldb/versioning/commitVersionedBlobArtifactPart".format(

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -2157,7 +2157,7 @@ class ExperimentRun(_ModelDBEntity):
                         continue  # try again
                     else:
                         break
-                response.raise_for_status()
+                _utils.raise_for_http_error(response)
 
                 # commit part
                 url = "{}://{}/api/v1/modeldb/experiment-run/commitArtifactPart".format(


### PR DESCRIPTION
Followup to #909

The appended timestamp is helpful _anywhere_ we're making a request, so let's use this util everywhere!