### PR TITLE
Fix parent_order crashes code when there are old commits with null parent_order

### DIFF
--- a/backend/src/main/java/ai/verta/modeldb/entities/versioning/CommitEntity.java
+++ b/backend/src/main/java/ai/verta/modeldb/entities/versioning/CommitEntity.java
@@ -1,6 +1,7 @@
 package ai.verta.modeldb.entities.versioning;
 
 import ai.verta.modeldb.versioning.Commit;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -110,6 +111,9 @@ public class CommitEntity {
   }
 
   private List<String> getParentCommitIds() {
+    if (parent_commits == null || parent_commits.isEmpty()) {
+      return Collections.emptyList();
+    }
     return parent_commits.values().stream()
         .map(CommitEntity::getCommit_hash)
         .collect(Collectors.toList());


### PR DESCRIPTION
**Jira Ticket:** https://vertaai.atlassian.net/browse/VR-5050