### PR TITLE
VR-5185 Commit reuploads versioned blobs everytime it is saved

### DIFF
--- a/client/scala/src/main/scala/ai/verta/blobs/dataset/FileMetadata.scala
+++ b/client/scala/src/main/scala/ai/verta/blobs/dataset/FileMetadata.scala
@@ -12,11 +12,11 @@ case class FileMetadata(
   val md5: String,
   val path: String,
   val size: BigInt,
-  val versionId: Option[String] = None
+  val versionId: Option[String] = None,
+  private[verta] var internalVersionedPath: Option[String] = None // MDB internal versioned path
 ) {
   // mutable fields, which are updated when preparing for uploading:
   /** TODO: remove these mutable fields to make FileMetadata immutable again */
-  private[verta] var internalVersionedPath: Option[String] = None // MDB internal versioned path
   private[verta] var localPath: Option[String] = None // path to file in local system
 
   override def equals(other: Any) = other match {

--- a/client/scala/src/main/scala/ai/verta/blobs/dataset/PathBlob.scala
+++ b/client/scala/src/main/scala/ai/verta/blobs/dataset/PathBlob.scala
@@ -20,7 +20,8 @@ import scala.annotation.tailrec
  */
 case class PathBlob(
   protected val contents: HashMap[String, FileMetadata],
-  val enableMDBVersioning: Boolean = false
+  val enableMDBVersioning: Boolean = false,
+  val downloadable: Boolean = false
 ) extends Dataset {
   /** Prepare the PathBlob for uploading
    *  @return whether the attempt succeeds
@@ -112,9 +113,9 @@ object PathBlob {
       comp => comp.path.get -> Dataset.toMetadata(comp)
     )
 
-    // if internal versioned path of a component is defined, then the blob enables MDB Versioning
-    val enableMDBVersioning = pathVersioningBlob.components.get.head.internal_versioned_path.isDefined
-    new PathBlob(HashMap(metadataList: _*), enableMDBVersioning)
+    // if internal versioned path of a component is defined, then the blob is downloadable
+    val downloadable = pathVersioningBlob.components.get.head.internal_versioned_path.isDefined
+    new PathBlob(HashMap(metadataList: _*), downloadable = downloadable)
   }
 
   /** Convert a PathBlob instance to a VersioningBlob

--- a/client/scala/src/main/scala/ai/verta/blobs/dataset/S3.scala
+++ b/client/scala/src/main/scala/ai/verta/blobs/dataset/S3.scala
@@ -25,7 +25,8 @@ import java.io.{File, FileOutputStream}
  */
 case class S3(
   protected val contents: HashMap[String, FileMetadata],
-  val enableMDBVersioning: Boolean = false
+  val enableMDBVersioning: Boolean = false,
+  val downloadable: Boolean = false
 ) extends Dataset {
   /** Get the version id of a file
    *  @param path: S3 URL of a file in the form "s3://<bucketName>/<key>"
@@ -162,9 +163,9 @@ object S3 {
       comp => comp.path.get.path.get -> Dataset.toMetadata(comp.path.get, comp.s3_version_id)
     )
 
-    // if internal versioned path of a component is defined, then the blob enables MDB Versioning
-    val enableMDBVersioning = componentList.head.path.get.internal_versioned_path.isDefined
-    new S3(HashMap(metadataList: _*), enableMDBVersioning)
+    // if internal versioned path of a component is defined, then the blob is downloadble
+    val downloadable = componentList.head.path.get.internal_versioned_path.isDefined
+    new S3(HashMap(metadataList: _*), downloadable = downloadable)
   }
 
   /** Combine two S3 instances

--- a/client/scala/src/main/scala/ai/verta/repository/Commit.scala
+++ b/client/scala/src/main/scala/ai/verta/repository/Commit.scala
@@ -602,7 +602,7 @@ class Commit(
               Await.result(clientSet.client.requestRaw("PUT", url, null, Map("Content-Length" -> readLen.toString), filepart), Duration.Inf)
                 .flatMap(resp => clientSet.versioningService.commitVersionedBlobArtifactPart(
                   VersioningCommitVersionedBlobArtifactPart(
-                    artifact_part = Some(ModeldbArtifactPart(
+                    artifact_part = Some(CommonArtifactPart(
                       etag = Some(resp.headers("ETag").get),
                       part_number = Some(BigInt(partNum))
                     )),

--- a/client/scala/src/main/scala/ai/verta/repository/Commit.scala
+++ b/client/scala/src/main/scala/ai/verta/repository/Commit.scala
@@ -500,8 +500,8 @@ class Commit(
    *  @return Some dataset, if the blob is a dataset; otherwise None
    */
   private def toMDBVersioningDataset(blob: Blob): Option[Dataset] = blob match {
-    case PathBlob(contents, enableMDBVersioning) => Some(PathBlob(contents, enableMDBVersioning))
-    case S3(contents, enableMDBVersioning) => Some(S3(contents, enableMDBVersioning))
+    case path: PathBlob => Some(path)
+    case s3: S3 => Some(s3)
     case _ => None
   }
 

--- a/client/scala/src/test/scala/ai/verta/repository/TestCommitDataVersioning.scala
+++ b/client/scala/src/test/scala/ai/verta/repository/TestCommitDataVersioning.scala
@@ -210,8 +210,15 @@ class TestCommitDataVersioning extends FunSuite {
       // check that the content is now different:
       assert(!Files.readAllBytes((new File("somefile")).toPath).sameElements(originalContent))
 
+      // upload another file to commit:
+      val updatedContent = generateRandomFile("somefile2").get
+      val pathBlob2 = PathBlob("somefile2", true).get
+      val newCommit = commit
+        .update("file2", pathBlob2)
+        .flatMap(_.save("some-msg-2")).get
+
       // recover the old versioned file:
-      val retrievedBlob: Dataset = commit.get("file").get match {
+      val retrievedBlob: Dataset = newCommit.get("file").get match {
         case path: PathBlob => path
       }
       retrievedBlob.download(Some("somefile"), Some("somefile"))

--- a/client/scala/src/test/scala/ai/verta/repository/TestCommitDataVersioning.scala
+++ b/client/scala/src/test/scala/ai/verta/repository/TestCommitDataVersioning.scala
@@ -211,7 +211,7 @@ class TestCommitDataVersioning extends FunSuite {
       assert(!Files.readAllBytes((new File("somefile")).toPath).sameElements(originalContent))
 
       // upload another file to commit:
-      val updatedContent = generateRandomFile("somefile2").get
+      generateRandomFile("somefile2").get
       val pathBlob2 = PathBlob("somefile2", true).get
       val newCommit = commit
         .update("file2", pathBlob2)
@@ -356,7 +356,7 @@ class TestCommitDataVersioning extends FunSuite {
       }
       val downloadAttempt3 = retrievedPathBlob2.download(downloadToPath = Some("some-path"))
       assert(downloadAttempt3.isFailure)
-      assert(downloadAttempt3 match {case Failure(e) => e.getMessage contains "This blob did not allow for versioning"})
+      assert(downloadAttempt3 match {case Failure(e) => e.getMessage contains "This dataset cannot be used for downloads"})
     } finally {
       cleanup(f)
     }


### PR DESCRIPTION
On top of https://github.com/VertaAI/modeldb/pull/962.

@conradoverta I found a new bug that I didn't think of before: Every time the commit saves, it attempts to reupload the blobs that were previously designated to enableMDBVersioning, even though user does not update that blob. 

This is because unlike the Python client, I used the flag enableMDBVersioning for both upload-able and download-able check. 
This is wrong; a blob might be downloadable, but no need to be uploaded when the commit is saved (as it has been uploaded before, and there is no update since).

The solution is to decouple these two states. I add another (immutable) field called downloadable, which is a user-friendly name for internal_versioned_path.isDefined. 

I've also updated one of the tests, which would now fail under my old implementation, but pass under my new implementation.