### PR TITLE
Update helm subcharts

### DIFF
--- a/chart/modeldb/charts/backend/Chart.yaml
+++ b/chart/modeldb/charts/backend/Chart.yaml
@@ -1,1 +1,2 @@
 name: backend
+version: 0.2.0

--- a/chart/modeldb/charts/backend/templates/deployment.yaml
+++ b/chart/modeldb/charts/backend/templates/deployment.yaml
@@ -9,7 +9,6 @@ metadata:
 {{toYaml .Values.labels | indent 4 -}}
 {{- end}}
   name: {{ .Release.Name }}
-  namespace: {{ .Release.Namespace | quote }}
 spec:
   selector:
     matchLabels:
@@ -27,6 +26,15 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         verta.ai/disable_anti_affinity: "true"
     spec:
+{{- if .Values.securityContext.enabled }}
+      securityContext:
+        {{- if .Values.securityContext.runAsUser }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        {{- end}}
+        {{- if .Values.securityContext.fsGroup }}
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+        {{- end}}
+{{- end}}
       containers:
         - image: {{ .Values.image }}:{{ .Values.imageTag }}
           env:

--- a/chart/modeldb/charts/backend/templates/service.yaml
+++ b/chart/modeldb/charts/backend/templates/service.yaml
@@ -5,7 +5,6 @@ metadata:
     app: {{ .Release.Name }}
     component: backend
   name: {{ .Release.Name }}-backend
-  namespace: {{ .Release.Namespace | quote }}
   {{- if .Values.service.annotations }}
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}

--- a/chart/modeldb/charts/backend/templates/statefulset.yaml
+++ b/chart/modeldb/charts/backend/templates/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
 {{toYaml .Values.labels | indent 4 -}}
 {{- end}}
   name: {{ .Release.Name }}-backend
-  namespace: {{ .Release.Namespace | quote }}
 spec:
   selector:
     matchLabels:
@@ -28,6 +27,15 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         verta.ai/disable_anti_affinity: "true"
     spec:
+{{- if .Values.securityContext.enabled }}
+      securityContext:
+        {{- if .Values.securityContext.runAsUser }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        {{- end}}
+        {{- if .Values.securityContext.fsGroup }}
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+        {{- end}}
+{{- end}}
       containers:
         - image: {{ .Values.image }}:{{ .Values.imageTag }}
           env:
@@ -70,6 +78,7 @@ spec:
               readOnly: true
             - mountPath: "{{ .Values.artifactStore.path }}"
               name: {{ .Release.Name }}
+              subPath: {{ .Values.artifactStore.subPath }}
         - image: {{ .Values.proxy.image }}:{{ .Values.proxy.imageTag }}
           imagePullPolicy: Always
           name: proxy
@@ -99,6 +108,14 @@ spec:
         - name: {{ .Release.Name }}-secret-volume
           secret:
             secretName: {{ .Release.Name }}-backend-config-secret
+{{- if .Values.artifactStore.existingClaim }}
+        - name: {{ .Release.Name }}
+          persistentVolumeClaim:
+{{- with .Values.artifactStore.existingClaim }}
+            claimName: {{ tpl . $ }}
+{{- end }}
+{{- end }}
+{{- if not .Values.artifactStore.existingClaim }}
   volumeClaimTemplates:
   - metadata:
       labels:
@@ -111,4 +128,5 @@ spec:
       resources:
         requests:
           storage: "{{ .Values.artifactStore.storage }}"
+{{- end }}
 {{- end -}}

--- a/chart/modeldb/charts/graphql/Chart.yaml
+++ b/chart/modeldb/charts/graphql/Chart.yaml
@@ -1,1 +1,2 @@
 name: graphql
+version: 0.2.0

--- a/chart/modeldb/charts/graphql/templates/deployment.yaml
+++ b/chart/modeldb/charts/graphql/templates/deployment.yaml
@@ -8,7 +8,6 @@ metadata:
 {{toYaml .Values.labels | indent 4 -}}
 {{- end}}
   name: {{ .Release.Name }}-graphql
-  namespace: {{ .Release.Namespace | quote }}
 spec:
   selector:
     matchLabels:

--- a/chart/modeldb/charts/graphql/templates/service.yaml
+++ b/chart/modeldb/charts/graphql/templates/service.yaml
@@ -5,7 +5,6 @@ metadata:
     app: {{ .Release.Name }}
     component: graphql
   name: {{ .Release.Name }}-graphql
-  namespace: {{ .Release.Namespace | quote }}
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}
 spec:

--- a/chart/modeldb/charts/webapp/Chart.yaml
+++ b/chart/modeldb/charts/webapp/Chart.yaml
@@ -1,1 +1,2 @@
 name: webapp
+version: 0.2.0

--- a/chart/modeldb/charts/webapp/templates/deployment.yaml
+++ b/chart/modeldb/charts/webapp/templates/deployment.yaml
@@ -8,7 +8,6 @@ metadata:
 {{toYaml .Values.labels | indent 4 -}}
 {{- end}}
   name: {{ .Release.Name }}-webapp
-  namespace: {{ .Release.Namespace | quote }}
 spec:
   selector:
     matchLabels:

--- a/chart/modeldb/charts/webapp/templates/service.yaml
+++ b/chart/modeldb/charts/webapp/templates/service.yaml
@@ -5,7 +5,6 @@ metadata:
     app: {{ .Release.Name }}
     component: webapp
   name: {{ .Release.Name }}-webapp
-  namespace: {{ .Release.Namespace | quote }}
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}
 spec:


### PR DESCRIPTION
Mostly minor updates. The version value is required in all subcharts in Helm 3. For our use-case it is nice to not have the namespace specified since we are generating files that will then be applied using `kubectl apply`. This is my first time working with helm, and I'm open to any suggested changes!

Changes:
- Add version strings to subcharts
- Remove namespace specification from all specs (useful for creating namespace-agnostic specs using helm template)
- Add artifact volume options and securityContext options for backend