### PR TITLE
Skip CLI tests

### DIFF
--- a/client/verta/tests/test_cli/test_registry.py
+++ b/client/verta/tests/test_cli/test_registry.py
@@ -6,6 +6,9 @@ from click.testing import CliRunner
 from verta._cli import cli
 
 
+pytest.skip("registry in Client not yet implemented", allow_module_level=True)
+
+
 class TestCreate:
     pass
 

--- a/client/verta/tests/test_cli/test_repository.py
+++ b/client/verta/tests/test_cli/test_repository.py
@@ -7,6 +7,9 @@ from verta._cli import cli
 from verta._internal_utils import _config_utils
 
 
+pytest.skip("repository sub-CLI has been disabled", allow_module_level=True)
+
+
 class TestInit:
     def test_init(self):
         runner = CliRunner()


### PR DESCRIPTION
`verta repository` has been disabled for the time being
`verta registry` is blocked on merging Client registry PRs