### PR TITLE
Use ~= for CONTAIN

### DIFF
--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -138,7 +138,7 @@ class LazyList(object):
     # number of items to fetch per back end call in __iter__()
     _ITER_PAGE_LIMIT = 100
 
-    _OP_MAP = {'in': _CommonCommonService.OperatorEnum.CONTAIN,
+    _OP_MAP = {'~=': _CommonCommonService.OperatorEnum.CONTAIN,
                '==': _CommonCommonService.OperatorEnum.EQ,
                '!=': _CommonCommonService.OperatorEnum.NE,
                '>':  _CommonCommonService.OperatorEnum.GT,

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -702,7 +702,7 @@ class Client(object):
         if name is not None:
             if not isinstance(name, six.string_types):
                 raise TypeError("`name` must be str, not {}".format(type(name)))
-            predicates.append("name in \"{}\"".format(name))
+            predicates.append("name ~= \"{}\"".format(name))
         if predicates:
             datasets = datasets.find(predicates)
 


### PR DESCRIPTION
We were using `in`, which makes more semantic sense, but didn't make syntactic sense because users would end up typing
```
name in "Proj "
```
since the field name comes before the operator in the Client's query language.