### PR TITLE
Reduces the size of docker context by ~900mb. Speeds up docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+**/node_modules


### PR DESCRIPTION
If you have webapp node_modules, all docker builds become much slower because of sending ~900MB of node_modules to the docker context for builds.