### PR TITLE
VR-5392: Print full response body on HTTP error

### DIFF
--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -451,10 +451,8 @@ def raise_for_http_error(response):
         curr_time = timestamp_to_str(now(), utc=True)
         time_str = " at {} UTC".format(curr_time)
 
-        try:
-            reason = body_to_json(response)['message']
-        except (ValueError,  # not JSON response
-                KeyError):  # no 'message' from back end
+        reason = response.text.strip()
+        if not reason:
             e.args = (e.args[0] + time_str,) + e.args[1:]  # attach time to error message
             six.raise_from(e, None)  # use default reason
         else:


### PR DESCRIPTION
Helps with S3 errors because AWS puts XML error messages in the body.
Also, some of Deployment API seems to also return errors as simple strings.