### PR TITLE
Remove None checks for options with multiple=True

### DIFF
--- a/client/verta/verta/_cli/registry/create.py
+++ b/client/verta/verta/_cli/registry/create.py
@@ -72,5 +72,5 @@ def create_model_version(model_name, version_name, label, model, artifact, works
         for (key, path) in artifact:
             model_version.log_artifact(key, path, True)
 
-    if model:
+    if model is not None:
         model_version.log_model(model, True)

--- a/client/verta/verta/_cli/registry/create.py
+++ b/client/verta/verta/_cli/registry/create.py
@@ -47,7 +47,7 @@ def create_model(model_name, label, visibility, workspace):
 def create_model_version(model_name, version_name, label, model, artifact, workspace, from_run):
     """Create a new registeredmodelversion entry.
     """
-    if artifact is not None and len(artifact) > len(set(map(lambda pair: pair[0], artifact))):
+    if artifact and len(artifact) > len(set(map(lambda pair: pair[0], artifact))):
         raise click.BadParameter("cannot have duplicate artifact keys")
 
     client = Client()
@@ -59,7 +59,7 @@ def create_model_version(model_name, version_name, label, model, artifact, works
 
     model_version = registered_model.get_or_create_version(name=version_name, labels=list(label))
 
-    if artifact is not None:
+    if artifact:
         artifact_keys = model_version.get_artifact_keys()
 
         for (key, _) in artifact:
@@ -72,6 +72,5 @@ def create_model_version(model_name, version_name, label, model, artifact, works
         for (key, path) in artifact:
             model_version.log_artifact(key, path, True)
 
-    if model is not None:
+    if model:
         model_version.log_model(model, True)
-

--- a/client/verta/verta/_cli/registry/get.py
+++ b/client/verta/verta/_cli/registry/get.py
@@ -68,9 +68,6 @@ def get_model_version(model_name, version_name, output, workspace):
     except ValueError:
         raise click.BadParameter("version {} not found".format(version_name))
 
-    if version is None:
-        raise click.BadParameter("version {} not found".format(version_name))
-
     if output == "json":
         version_repr = json.dumps(_utils.proto_to_json(version._msg))
     else:

--- a/client/verta/verta/_cli/registry/update.py
+++ b/client/verta/verta/_cli/registry/update.py
@@ -64,5 +64,5 @@ def update_model_version(model_name, version_name, label, model, artifact, works
         for l in label:
             model_version.add_label(l)
 
-    if model:
+    if model is not None:
         model_version.log_model(model, True)

--- a/client/verta/verta/_cli/registry/update.py
+++ b/client/verta/verta/_cli/registry/update.py
@@ -34,7 +34,7 @@ def update_model_version(model_name, version_name, label, model, artifact, works
     """
     client = Client()
 
-    if artifact is not None and len(artifact) > len(set(map(lambda pair: pair[0], artifact))):
+    if artifact and len(artifact) > len(set(map(lambda pair: pair[0], artifact))):
         raise click.BadParameter("cannot have duplicate artifact keys")
 
     try:
@@ -47,10 +47,7 @@ def update_model_version(model_name, version_name, label, model, artifact, works
     except ValueError:
         raise click.BadParameter("version {} not found".format(version_name))
 
-    if model_version is None:
-        raise click.BadParameter("version {} not found".format(version_name))
-
-    if artifact is not None:
+    if artifact:
         artifact_keys = model_version.get_artifact_keys()
 
         for (key, _) in artifact:
@@ -63,12 +60,9 @@ def update_model_version(model_name, version_name, label, model, artifact, works
         for (key, path) in artifact:
             model_version.log_artifact(key, path, True)
 
-    if label is not None:
+    if label:
         for l in label:
             model_version.add_label(l)
 
-    if model is not None:
+    if model:
         model_version.log_model(model, True)
-
-
-


### PR DESCRIPTION
`multiple`able `option`s are actually `tuple`s, rather than `None`, when not provided.