### PR TITLE
Clear cache at the end of run._log_artifact()

### DIFF
--- a/client/verta/verta/_tracking/experimentrun.py
+++ b/client/verta/verta/_tracking/experimentrun.py
@@ -398,6 +398,8 @@ class ExperimentRun(_ModelDBEntity):
             else:
                 _utils.raise_for_http_error(response)
 
+        self._clear_cache()
+
     def _get_artifact(self, key):
         """
         Gets the artifact with name `key` from this Experiment Run.
@@ -607,6 +609,8 @@ class ExperimentRun(_ModelDBEntity):
                                        self._conn, json=data)
         _utils.raise_for_http_error(response)
 
+        self._clear_cache()
+
     def log_tags(self, tags):
         """
         Logs multiple tags to this Experiment Run.
@@ -626,6 +630,8 @@ class ExperimentRun(_ModelDBEntity):
                                        "{}://{}/api/v1/modeldb/experiment-run/addExperimentRunTags".format(self._conn.scheme, self._conn.socket),
                                        self._conn, json=data)
         _utils.raise_for_http_error(response)
+
+        self._clear_cache()
 
     def get_tags(self):
         """
@@ -675,6 +681,8 @@ class ExperimentRun(_ModelDBEntity):
             else:
                 _utils.raise_for_http_error(response)
 
+        self._clear_cache()
+
     def log_attributes(self, attributes):
         """
         Logs potentially multiple attributes to this Experiment Run.
@@ -705,6 +713,8 @@ class ExperimentRun(_ModelDBEntity):
                                  " consider using observations instead")
             else:
                 _utils.raise_for_http_error(response)
+
+        self._clear_cache()
 
     def get_attribute(self, key):
         """
@@ -1012,6 +1022,8 @@ class ExperimentRun(_ModelDBEntity):
                                  " consider setting overwrite=True".format(key))
             else:
                 _utils.raise_for_http_error(response)
+
+        self._clear_cache()
 
     def log_dataset_path(self, key, path):
         """
@@ -1665,6 +1677,8 @@ class ExperimentRun(_ModelDBEntity):
                                        "{}://{}/api/v1/modeldb/experiment-run/logObservation".format(self._conn.scheme, self._conn.socket),
                                        self._conn, json=data)
         _utils.raise_for_http_error(response)
+
+        self._clear_cache()
 
     def get_observation(self, key):
         """
@@ -2371,6 +2385,8 @@ class ExperimentRun(_ModelDBEntity):
         )
         response = _utils.make_request("POST", endpoint, self._conn, json=data)
         _utils.raise_for_http_error(response)
+
+        self._clear_cache()
 
     def get_commit(self):
         """

--- a/client/verta/verta/_tracking/experimentrun.py
+++ b/client/verta/verta/_tracking/experimentrun.py
@@ -276,6 +276,8 @@ class ExperimentRun(_ModelDBEntity):
         else:
             self._upload_artifact(key, artifact_stream)
 
+        self._clear_cache()
+
     def _upload_artifact(self, key, artifact_stream, part_size=64*(10**6)):
         """
         Uploads `artifact_stream` to ModelDB artifact store.

--- a/client/verta/verta/integrations/tensorflow/__init__.py
+++ b/client/verta/verta/integrations/tensorflow/__init__.py
@@ -200,6 +200,7 @@ def log_tensorboard_events(run, log_dir):
                 event_observations = _collect_observations(events_filepath, prefix=subdir)
                 observations.extend(event_observations)
 
+    # TODO: implement `run.log_observations()` instead of this
     _utils.make_request(
         "POST",
         "{}://{}/api/v1/modeldb/experiment-run/logObservations".format(run._conn.scheme, run._conn.socket),
@@ -209,3 +210,4 @@ def log_tensorboard_events(run, log_dir):
             'observations': observations,
         },
     )
+    run._clear_cache()


### PR DESCRIPTION
Tests involving `run.fetch_artifacts()` were failing because
1. `run.fetch_artifacts()` directly accesses `run._msg` to check what artifact keys have been logged
1. Unlike several other `log_*()` calls, `log_artifact()` doesn't clear the cache
1. So `run.fetch_artifacts()` could (and does, in tests) check an outdated `self._msg`

Now, logging artifacts clears the cache, so `run.fetch_artifacts()` will get an up-to-date record of artifact keys.