### PR TITLE
Implement backbone for CanaryUpdateStrategy.add_rule()

### DIFF
--- a/client/verta/verta/deployment/strategies.py
+++ b/client/verta/verta/deployment/strategies.py
@@ -1,14 +1,76 @@
 # -*- coding: utf-8 -*-
 
+import abc
 
+from ..external import six
+
+
+@six.add_metaclass(abc.ABCMeta)
 class _UpdateStrategy(object):
     _STRATEGY = ""
+
+    @abc.abstractmethod
+    def _as_build_update_req_body(self, build_id):
+        """
+        Returns
+        -------
+        dict
+            JSON to be passed as the body for an Endpoint update request.
+
+        """
+        pass
 
 class DirectUpdateStrategy(_UpdateStrategy):
     _STRATEGY = "rollout"
 
+    def _as_build_update_req_body(self, build_id):
+        return {
+            'build_id': build_id,
+            'strategy': self._STRATEGY,
+        }
+
 class CanaryUpdateStrategy(_UpdateStrategy):
     _STRATEGY = "canary"
 
-    def __init__(self):
+    def __init__(self, interval, step):
+        """
+        Parameters
+        ----------
+        interval : int
+            Rollout interval, in seconds.
+        step : float in (0, 1]
+            Ratio of deployment to roll out per `interval`.
+
+        """
+        interval_err_msg = "`interval` must be int greater than 0"
+        if not isinstance(interval, int):
+            raise TypeError(interval_err_msg)
+        if not interval > 0:
+            raise ValueError(interval_err_msg)
+
+        step_err_msg = "`step` must be float in (0, 1]"
+        if not isinstance(step, float):
+            raise TypeError(step_err_msg)
+        if not 0 < step <= 1:
+            raise ValueError(step_err_msg)
+
+        self._progress_interval_seconds = interval
+        self._progress_step = step
+        self._rules = []
+
+    def _as_build_update_req_body(self, build_id):
+        raise NotImplementedError
+        return {
+            'build_id': build_id,
+            'strategy': self._STRATEGY,
+            'canary_strategy': {
+                'progress_interval_seconds': self._progress_interval_seconds,
+                'progress_step': self._progress_step,
+                'rules': [
+                    # TODO
+                ],
+            },
+        }
+
+    def add_rule(self, rule):
         raise NotImplementedError

--- a/client/verta/verta/deployment/update_rules.py
+++ b/client/verta/verta/deployment/update_rules.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+import abc
+
+from ..external import six
+
+
+@six.add_metaclass(abc.ABCMeta)
+class _UpdateRule(object):
+    _RULE_ID = 0
+    _NAME = ""
+
+    def __init__(self, value):
+        self._value = value
+
+    def _as_json(self):
+        return {
+            'rule_id': self._RULE_ID,
+            'rule_parameters': [
+                {
+                    'name': self._NAME,
+                    'value': self._value,
+                },
+            ],
+        }
+
+class AverageLatencyThreshold(_UpdateRule):
+    _RULE_ID = 1001
+    _NAME = "latency_avg"
+
+class P90LatencyThreshold(_UpdateRule):
+    _RULE_ID = 1001
+    _NAME = "latency_p90"
+
+class ErrorRate(_UpdateRule):
+    _RULE_ID = 1002
+    _NAME = "error_rate"


### PR DESCRIPTION
```python
from verta.deployment.strategies import CanaryUpdateStrategy
update_strategy = CanaryUpdateStrategy(
    interval=15,  # seconds
    step=0.2,  # rollout ratio
)

from verta.deployment.update_rules import AverageLatencyThreshold
update_strategy.add_rule(
    AverageLatencyThreshold(value=0.1),
)

```
---
I ended up implementing a solid chunk of the logic for this while figuring out how exactly endpoint updates work.
The remaining steps for the lucky assignee of VR-5411 are:

- finish `CanaryUpdateStrategy._as_build_update_req_body()` to call `._as_json()` on `self._rules`
- implement `CanaryUpdateStrategy.add_rule()`
- call `_UpdateStrategy._as_build_update_req_body()` to generate a request body in `Endpoint.update()`