### PR TITLE
Add model overwriting check for CLI ModelVersion update/create

### DIFF
--- a/client/verta/tests/test_cli/test_registry.py
+++ b/client/verta/tests/test_cli/test_registry.py
@@ -279,3 +279,28 @@ class TestUpdate:
 
         os.remove(filename)
         os.remove(classifier_name)
+
+    def test_model_overwrite(self, registered_model):
+        model_name = registered_model.name
+        version_name = "my version"
+
+        classifier_name = "tiny2.pth"
+        CLASSIFIER_CONTENTS = os.urandom(2**16)
+        with open(classifier_name, 'wb') as f:
+            f.write(CLASSIFIER_CONTENTS)
+
+        runner = CliRunner()
+        runner.invoke(
+            cli,
+            ['registry', 'create', 'registeredmodelversion', model_name, version_name, "--model", classifier_name],
+        )
+
+        result = runner.invoke(
+            cli,
+            ['registry', 'update', 'registeredmodelversion', model_name, version_name, "--model", classifier_name],
+        )
+        assert result.exception
+        assert "a model has already been associated with the version" in result.output
+
+        os.remove(classifier_name)
+

--- a/client/verta/tests/test_cli/test_registry.py
+++ b/client/verta/tests/test_cli/test_registry.py
@@ -280,7 +280,7 @@ class TestUpdate:
         os.remove(filename)
         os.remove(classifier_name)
 
-    def test_model_overwrite(self, registered_model):
+    def test_model_already_logged_error(self, registered_model):
         model_name = registered_model.name
         version_name = "my version"
 

--- a/client/verta/verta/_cli/registry/create.py
+++ b/client/verta/verta/_cli/registry/create.py
@@ -59,6 +59,9 @@ def create_model_version(model_name, version_name, label, model, artifact, works
 
     model_version = registered_model.get_or_create_version(name=version_name, labels=list(label))
 
+    if model and model_version.has_model:
+        raise click.BadParameter("a model has already been associated with the version")
+
     if artifact:
         artifact_keys = model_version.get_artifact_keys()
 
@@ -70,7 +73,7 @@ def create_model_version(model_name, version_name, label, model, artifact, works
                 raise click.BadParameter("key \"{}\" already exists".format(key))
 
         for (key, path) in artifact:
-            model_version.log_artifact(key, path, True)
+            model_version.log_artifact(key, path)
 
-    if model is not None:
-        model_version.log_model(model, True)
+    if model:
+        model_version.log_model(model)

--- a/client/verta/verta/_cli/registry/update.py
+++ b/client/verta/verta/_cli/registry/update.py
@@ -47,6 +47,9 @@ def update_model_version(model_name, version_name, label, model, artifact, works
     except ValueError:
         raise click.BadParameter("version {} not found".format(version_name))
 
+    if model and model_version.has_model:
+        raise click.BadParameter("a model has already been associated with the version")
+
     if artifact:
         artifact_keys = model_version.get_artifact_keys()
 
@@ -58,11 +61,11 @@ def update_model_version(model_name, version_name, label, model, artifact, works
                 raise click.BadParameter("key \"{}\" already exists".format(key))
 
         for (key, path) in artifact:
-            model_version.log_artifact(key, path, True)
+            model_version.log_artifact(key, path)
 
     if label:
         for l in label:
             model_version.add_label(l)
 
-    if model is not None:
-        model_version.log_model(model, True)
+    if model:
+        model_version.log_model(model)


### PR DESCRIPTION
Current implementation automatically overwrites the model. This is inconsistent with artifacts. A small fix, plus a test to demonstrate the new behavior.