### PR TITLE
Coerce HTTP response body from unicode to str for Py2

### DIFF
--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -451,7 +451,7 @@ def raise_for_http_error(response):
         curr_time = timestamp_to_str(now(), utc=True)
         time_str = " at {} UTC".format(curr_time)
 
-        reason = response.text.strip()
+        reason = six.ensure_str(response.text.strip())
         if not reason:
             e.args = (e.args[0] + time_str,) + e.args[1:]  # attach time to error message
             six.raise_from(e, None)  # use default reason


### PR DESCRIPTION
response.text returns a unicode object, which is fine in Python 3,
but problematic in Python 2 because the format string near the end
of this function is str, not unicode. So the object has to be cast
from unicode to str here to about an ascii-decode-error later.