### PR TITLE
VR-5428, VR-5429 Improving test quality

### DIFF
--- a/client/verta/tests/test_cli/test_registry.py
+++ b/client/verta/tests/test_cli/test_registry.py
@@ -29,7 +29,7 @@ class TestCreate:
         assert not result.exception
         assert "name: \"{}\"".format(model_name) in result.output
 
-    def test_create_version(self, registered_model):
+    def test_create_version(self, registered_model, in_tempdir):
         model_name = registered_model.name
         version_name = "my version"
 
@@ -49,8 +49,6 @@ class TestCreate:
             cli,
             ['registry', 'create', 'registeredmodelversion', model_name, version_name, '-l', 'label1', '-l', 'label2', "--artifact", "file", filename, "--model", classifier_name],
         )
-        os.remove(filename)
-        os.remove(classifier_name)
         assert not result.exception
 
         model_version = registered_model.get_version(name=version_name)
@@ -59,7 +57,7 @@ class TestCreate:
         assert model_version.get_labels() == ["label1", "label2"]
         assert model_version.get_model().getvalue() == CLASSIFIER_CONTENTS
 
-    def test_create_version_invalid_key(self, registered_model):
+    def test_create_version_invalid_key(self, registered_model, in_tempdir):
         model_name = registered_model.name
         version_name = "my version"
 
@@ -103,9 +101,6 @@ class TestCreate:
         assert result.exception
         assert "key \"file\" already exists" in result.output
 
-        os.remove(filename)
-        os.remove(classifier_name)
-
     def test_create_version_wrong_model_name(self, strs):
         version_name = "my version"
 
@@ -144,12 +139,12 @@ class TestCreate:
         assert 'Python' in env_str
 
         assert model_for_deployment['model'].get_params() == model_version.get_model().get_params()
-        assert (model_version.get_artifact("some-artifact") == artifact).all()
+        assert np.array_equal(model_version.get_artifact("some-artifact"), artifact)
 
-    def test_create_from_run_with_model_artifact_error(self, experiment_run, registered_model):
+    def test_create_from_run_with_model_artifact_error(self, experiment_run, registered_model, in_tempdir):
         model_name = registered_model.name
         version_name = "from_run"
-        error_message = "--from_run cannot be provided alongside other options, except for --workspace"
+        error_message = "--from-run cannot be provided alongside other options, except for --workspace"
 
         filename = "tiny1.bin"
         FILE_CONTENTS = os.urandom(2**16)
@@ -180,8 +175,6 @@ class TestCreate:
         )
         assert result.exception
         assert error_message in result.output
-
-        os.remove(filename)
 
 
 class TestGet:
@@ -296,7 +289,7 @@ class TestList:
         assert str(model2._msg.name) in result.output
 
 class TestUpdate:
-    def test_update_version(self, registered_model):
+    def test_update_version(self, registered_model, in_tempdir):
         model_name = registered_model.name
         version_name = "my version"
         registered_model.get_or_create_version(version_name)
@@ -317,8 +310,6 @@ class TestUpdate:
             cli,
             ['registry', 'update', 'registeredmodelversion', model_name, version_name, '-l', 'label1', '-l', 'label2', "--artifact", "file", filename, "--model", classifier_name],
         )
-        os.remove(filename)
-        os.remove(classifier_name)
         assert not result.exception
 
         model_version = registered_model.get_version(name=version_name)
@@ -326,7 +317,7 @@ class TestUpdate:
         assert model_version.get_labels() == ["label1", "label2"]
         assert model_version.get_model().getvalue() == CLASSIFIER_CONTENTS
 
-    def test_update_version_invalid_key(self, registered_model):
+    def test_update_version_invalid_key(self, registered_model, in_tempdir):
         model_name = registered_model.name
         version_name = "my version"
         registered_model.get_or_create_version(version_name)
@@ -367,10 +358,7 @@ class TestUpdate:
         assert result.exception
         assert "key \"file\" already exists" in result.output
 
-        os.remove(filename)
-        os.remove(classifier_name)
-
-    def test_model_already_logged_error(self, registered_model):
+    def test_model_already_logged_error(self, registered_model, in_tempdir):
         model_name = registered_model.name
         version_name = "my version"
 
@@ -391,6 +379,4 @@ class TestUpdate:
         )
         assert result.exception
         assert "a model has already been associated with the version" in result.output
-
-        os.remove(classifier_name)
 

--- a/client/verta/tests/test_model_registry/test_model_version.py
+++ b/client/verta/tests/test_model_registry/test_model_version.py
@@ -28,7 +28,7 @@ class TestMDBIntegration:
         assert 'Python' in env_str
 
         assert model_for_deployment['model'].get_params() == model_version.get_model().get_params()
-        assert (model_version.get_artifact("some-artifact") == artifact).all()
+        assert np.array_equal(model_version.get_artifact("some-artifact"), artifact)
 
 
 class TestModelVersion:
@@ -67,14 +67,14 @@ class TestModelVersion:
 
         # retrieve the classifier:
         retrieved_classfier = model_version.get_model()
-        assert (retrieved_classfier.coef_ == original_coef).all()
+        assert np.array_equal(retrieved_classfier.coef_, original_coef)
 
         # overwrite should work:
         new_classifier = LogisticRegression()
         new_classifier.fit(np.random.random((36, 12)), np.random.random(36).round())
         model_version.log_model(new_classifier, True)
         retrieved_classfier = model_version.get_model()
-        assert (retrieved_classfier.coef_ == new_classifier.coef_).all()
+        assert np.array_equal(retrieved_classfier.coef_, new_classifier.coef_)
 
         # when overwrite = false, overwriting should fail
         with pytest.raises(ValueError) as excinfo:
@@ -94,14 +94,14 @@ class TestModelVersion:
 
         # retrieve the artifact:
         retrieved_coef = model_version.get_artifact("coef")
-        assert (retrieved_coef == original_coef).all()
+        assert np.array_equal(retrieved_coef, original_coef)
 
         # Overwrite should work:
         new_classifier = LogisticRegression()
         new_classifier.fit(np.random.random((36, 12)), np.random.random(36).round())
         model_version.log_artifact("coef", new_classifier.coef_, True)
         retrieved_coef = model_version.get_artifact("coef")
-        assert (retrieved_coef == new_classifier.coef_).all()
+        assert np.array_equal(retrieved_coef, new_classifier.coef_)
 
         # when overwrite = false, overwriting should fail
         with pytest.raises(ValueError) as excinfo:
@@ -109,13 +109,12 @@ class TestModelVersion:
 
         assert "The key has been set" in str(excinfo.value)
 
-    def test_add_artifact_file(self, model_version):
+    def test_add_artifact_file(self, model_version, in_tempdir):
         filename = "tiny1.bin"
         FILE_CONTENTS = os.urandom(2**16)
         with open(filename, 'wb') as f:
             f.write(FILE_CONTENTS)
         model_version.log_artifact("file", filename)
-        os.remove(filename)
 
         # retrieve the artifact:
         retrieved_file = model_version.get_artifact("file")


### PR DESCRIPTION
Small changes:
- In artifact tests comparing NumPy arrays, use np.array_equal() instead of (x == y).all()
- Run tests that create test artifact files using in_tempdir fixture