### PR TITLE
VR-5411 enable configuring CanaryUpdateStrategy for Endpoint.update()

### DIFF
--- a/client/verta/verta/deployment/strategies.py
+++ b/client/verta/verta/deployment/strategies.py
@@ -61,7 +61,7 @@ class CanaryUpdateStrategy(_UpdateStrategy):
 
     def _as_build_update_req_body(self, build_id):
         if not self._rules:
-            raise RuntimeError("canary update strategy must have at leaset one rule")
+            raise RuntimeError("canary update strategy must have at least one rule")
 
         return {
             'build_id': build_id,

--- a/client/verta/verta/deployment/strategies.py
+++ b/client/verta/verta/deployment/strategies.py
@@ -71,7 +71,7 @@ class CanaryUpdateStrategy(_UpdateStrategy):
         }
 
     def add_rule(self, rule):
-        if not issubclass(rule, _UpdateRule):
+        if not issubclass(type(rule), _UpdateRule):
             raise TypeError("strategy must be an object from verta.deployment.update_rules")
 
         self._rules.append(rule)

--- a/client/verta/verta/deployment/strategies.py
+++ b/client/verta/verta/deployment/strategies.py
@@ -3,6 +3,7 @@
 import abc
 
 from ..external import six
+from .update_rules import _UpdateRule
 
 
 @six.add_metaclass(abc.ABCMeta)
@@ -59,18 +60,18 @@ class CanaryUpdateStrategy(_UpdateStrategy):
         self._rules = []
 
     def _as_build_update_req_body(self, build_id):
-        raise NotImplementedError
         return {
             'build_id': build_id,
             'strategy': self._STRATEGY,
             'canary_strategy': {
                 'progress_interval_seconds': self._progress_interval_seconds,
                 'progress_step': self._progress_step,
-                'rules': [
-                    # TODO
-                ],
+                'rules': list(map(lambda rule: rule._as_json(), self._rules)),
             },
         }
 
     def add_rule(self, rule):
-        raise NotImplementedError
+        if not issubclass(rule, _UpdateRule):
+            raise TypeError("strategy must be an object from verta.deployment.update_rules")
+
+        self._rules.append(rule)

--- a/client/verta/verta/deployment/strategies.py
+++ b/client/verta/verta/deployment/strategies.py
@@ -60,6 +60,9 @@ class CanaryUpdateStrategy(_UpdateStrategy):
         self._rules = []
 
     def _as_build_update_req_body(self, build_id):
+        if not self._rules:
+            raise RuntimeError("canary update strategy must have at leaset one rule")
+
         return {
             'build_id': build_id,
             'strategy': self._STRATEGY,

--- a/client/verta/verta/deployment/strategies.py
+++ b/client/verta/verta/deployment/strategies.py
@@ -74,7 +74,7 @@ class CanaryUpdateStrategy(_UpdateStrategy):
         }
 
     def add_rule(self, rule):
-        if not issubclass(type(rule), _UpdateRule):
+        if not isinstance(rule, _UpdateRule):
             raise TypeError("strategy must be an object from verta.deployment.update_rules")
 
         self._rules.append(rule)


### PR DESCRIPTION
"call _UpdateStrategy._as_build_update_req_body() to generate a request body in Endpoint.update()" is done in https://github.com/VertaAI/modeldb/pull/1096
Testing is done in https://github.com/VertaAI/modeldb/pull/1100