### PR TITLE
Use shutil.move() instead of os.rename()

### DIFF
--- a/client/verta/tests/test_config.py
+++ b/client/verta/tests/test_config.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import tempfile
 
 import yaml
@@ -40,7 +41,7 @@ def expected_config(in_tempdir):
         os.mkdir(_config_utils.HOME_VERTA_DIR)
     else:
         if os.path.exists(home_config_filepath):
-            os.rename(home_config_filepath, os.path.join(backup_dir, config_filename))
+            shutil.move(home_config_filepath, os.path.join(backup_dir, config_filename))
     try:
         # create home config
         with open(home_config_filepath, 'w') as f:
@@ -95,7 +96,7 @@ def expected_config(in_tempdir):
 
         # restore home config
         if os.path.exists(os.path.join(backup_dir, config_filename)):
-            os.rename(os.path.join(backup_dir, config_filename), home_config_filepath)
+            shutil.move(os.path.join(backup_dir, config_filename), home_config_filepath)
 
 
 class TestRead:
@@ -189,7 +190,7 @@ class TestWrite:
         # backup home config
         backup_dir = tempfile.mkdtemp(dir=".")
         if os.path.exists(os.path.join(home_verta_dir, config_filename)):
-            os.rename(
+            shutil.move(
                 os.path.join(home_verta_dir, config_filename),
                 os.path.join(backup_dir, config_filename),
             )
@@ -218,7 +219,7 @@ class TestWrite:
 
             # restore home config
             if os.path.exists(os.path.join(backup_dir, config_filename)):
-                os.rename(
+                shutil.move(
                     os.path.join(backup_dir, config_filename),
                     os.path.join(home_verta_dir, config_filename),
                 )

--- a/client/verta/tests/test_versioning/test_dataset.py
+++ b/client/verta/tests/test_versioning/test_dataset.py
@@ -679,7 +679,7 @@ class TestPathManagedVersioning:
         dataset = verta.dataset.Path(dirname, enable_mdb_versioning=True)
         commit.update(blob_path, dataset)
         commit.save("Version data.")
-        os.rename(dirname, reference_dir)  # move sources to avoid collision
+        shutil.move(dirname, reference_dir)  # move sources to avoid collision
         dataset = commit.get(blob_path)
 
         # download to implicit path

--- a/client/verta/verta/_internal_utils/_request_utils.py
+++ b/client/verta/verta/_internal_utils/_request_utils.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import os
+import shutil
 import tempfile
 
 from . import _file_utils
@@ -43,7 +44,7 @@ def download(response, filepath, chunk_size=32*(10**6), overwrite_ok=False):
             filepath = _file_utils.without_collision(filepath)
 
         # move written contents to `filepath`
-        os.rename(tempf.name, filepath)
+        shutil.move(tempf.name, filepath)
     except Exception as e:
         # delete partially-downloaded file
         if tempf is not None and os.path.isfile(tempf.name):

--- a/client/verta/verta/_tracking/experimentrun.py
+++ b/client/verta/verta/_tracking/experimentrun.py
@@ -10,6 +10,7 @@ import pathlib2
 import pprint
 import shutil
 import sys
+import shutil
 import tarfile
 import tempfile
 import time
@@ -2544,7 +2545,7 @@ class ExperimentRun(_ModelDBEntity):
             pass
 
         # move written contents to cache location
-        os.rename(temp_path, path)
+        shutil.move(temp_path, path)
 
         return path
 


### PR DESCRIPTION
If a direct `os.rename()` fails, `shutil.move()` [falls back](https://github.com/python/cpython/blob/2.7/Lib/shutil.py#L316-L326) to copying the file then deleting the original.
This is [supposed to](https://docs.python.org/2/library/shutil.html#shutil.move) have better support for moving files across filesystems.