### PR TITLE
Check if key is "model" in del_artifact

### DIFF
--- a/client/verta/tests/test_model_registry/test_model_version.py
+++ b/client/verta/tests/test_model_registry/test_model_version.py
@@ -141,7 +141,7 @@ class TestModelVersion:
         with pytest.raises(ValueError) as excinfo:
             model_version.del_artifact("model")
 
-        assert "the key \"model\" is reserved for model; consider using del_model() instead" in str(excinfo.value)
+        assert "model can't be deleted through del_artifact(); consider using del_model() instead" in str(excinfo.value)
 
     def test_del_artifact(self, registered_model):
         np = pytest.importorskip("numpy")

--- a/client/verta/tests/test_model_registry/test_model_version.py
+++ b/client/verta/tests/test_model_registry/test_model_version.py
@@ -138,6 +138,11 @@ class TestModelVersion:
 
         assert "the key \"model\" is reserved for model; consider using log_model() instead" in str(excinfo.value)
 
+        with pytest.raises(ValueError) as excinfo:
+            model_version.del_artifact("model")
+
+        assert "the key \"model\" is reserved for model; consider using del_model() instead" in str(excinfo.value)
+
     def test_del_artifact(self, registered_model):
         np = pytest.importorskip("numpy")
         sklearn = pytest.importorskip("sklearn")

--- a/client/verta/verta/_registry/modelversion.py
+++ b/client/verta/verta/_registry/modelversion.py
@@ -209,7 +209,7 @@ class RegisteredModelVersion(_ModelDBEntity):
 
     def del_artifact(self, key):
         if key == "model":
-            raise ValueError("the key \"model\" is reserved for model; consider using del_model() instead")
+            raise ValueError("model can't be deleted through del_artifact(); consider using del_model() instead")
 
         self._fetch_with_no_cache()
 

--- a/client/verta/verta/_registry/modelversion.py
+++ b/client/verta/verta/_registry/modelversion.py
@@ -208,6 +208,9 @@ class RegisteredModelVersion(_ModelDBEntity):
         return artifact_stream
 
     def del_artifact(self, key):
+        if key == "model":
+            raise ValueError("the key \"model\" is reserved for model; consider using del_model() instead")
+
         self._fetch_with_no_cache()
 
         ind = -1


### PR DESCRIPTION
Forgot to check this... User might accidentally delete model via del_artifact.