### PR TITLE
VR-5522 Use run.log_model() instead of run.log_model_for_deployment() in tests

### DIFF
--- a/client/verta/tests/test_endpoint/test_endpoint.py
+++ b/client/verta/tests/test_endpoint/test_endpoint.py
@@ -69,7 +69,7 @@ class TestEndpoint:
         assert "id" in status
 
     def test_direct_update(self, client, experiment_run, model_for_deployment):
-        experiment_run.log_model_for_deployment(**model_for_deployment)
+        experiment_run.log_model(model_for_deployment['model'])
 
         path = verta._internal_utils._utils.generate_default_name()
         endpoint = client.set_endpoint(path)
@@ -83,7 +83,7 @@ class TestEndpoint:
         assert len(new_build_ids) - len(new_build_ids.intersection(original_build_ids)) > 0
 
     def test_canary_update(self, client, experiment_run, model_for_deployment):
-        experiment_run.log_model_for_deployment(**model_for_deployment)
+        experiment_run.log_model(model_for_deployment['model'])
 
         path = verta._internal_utils._utils.generate_default_name()
         endpoint = client.set_endpoint(path)

--- a/client/verta/tests/test_endpoint/test_endpoint.py
+++ b/client/verta/tests/test_endpoint/test_endpoint.py
@@ -69,7 +69,8 @@ class TestEndpoint:
         assert "id" in status
 
     def test_direct_update(self, client, experiment_run, model_for_deployment):
-        experiment_run.log_model(model_for_deployment['model'])
+        experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
+        experiment_run.log_requirements(['scikit-learn'])
 
         path = verta._internal_utils._utils.generate_default_name()
         endpoint = client.set_endpoint(path)
@@ -83,7 +84,8 @@ class TestEndpoint:
         assert len(new_build_ids) - len(new_build_ids.intersection(original_build_ids)) > 0
 
     def test_canary_update(self, client, experiment_run, model_for_deployment):
-        experiment_run.log_model(model_for_deployment['model'])
+        experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
+        experiment_run.log_requirements(['scikit-learn'])
 
         path = verta._internal_utils._utils.generate_default_name()
         endpoint = client.set_endpoint(path)


### PR DESCRIPTION
A search through repository shows that I only use it in two places. I have no idea why; I used the correct version everywhere else.