### PR TITLE
Convert client.endpoints into property

### DIFF
--- a/client/verta/tests/test_endpoint/test_endpoint.py
+++ b/client/verta/tests/test_endpoint/test_endpoint.py
@@ -48,7 +48,7 @@ class TestEndpoint:
         name = _utils.generate_default_name()
         endpoint = client.set_endpoint(name)
 
-        endpoints = client.endpoints()
+        endpoints = client.endpoints
         assert len(endpoints) >= 1
         has_new_id = False
         for item in endpoints:

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -921,8 +921,6 @@ class Client(object):
     def set_endpoint(self, *args, **kwargs):
         return self.get_or_create_endpoint(*args, **kwargs)
 
-    def endpoints(self, workspace = None):
-        workspace = self._set_from_config_if_none(workspace, "workspace")
-        if workspace is None:
-            workspace = self._get_personal_workspace()
-        return Endpoints(self._conn, self._conf, workspace)
+    @property
+    def endpoints(self):
+        return Endpoints(self._conn, self._conf)


### PR DESCRIPTION
For API consistency with the other collection properties (`client.projects`, `client.registered_models`, etc.)