### PR TITLE
Clean up RegisteredModel and Endpoint created in tests

### DIFF
--- a/client/verta/tests/conftest.py
+++ b/client/verta/tests/conftest.py
@@ -364,3 +364,13 @@ def created_registered_models(client):
 @pytest.fixture
 def model_version(registered_model):
     yield registered_model.get_or_create_version()
+
+
+@pytest.fixture
+def created_endpoints(client):
+    to_delete = []
+
+    yield to_delete
+
+    for endpoint in to_delete:
+        utils.delete_endpoint(endpoint.id, endpoint.workspace, client._conn)

--- a/client/verta/tests/conftest.py
+++ b/client/verta/tests/conftest.py
@@ -348,5 +348,19 @@ def registered_model(client):
 
 
 @pytest.fixture
+def created_registered_models(client):
+    """Container to track and clean up `RegisteredModel`s created during tests."""
+    to_delete = []
+
+    yield to_delete
+
+    for registered_model in to_delete:
+        if client._ctx.registered_model and registered_model.id == client._ctx.registered_model.id:
+            client._ctx.registered_model = None
+
+        utils.delete_registered_model(registered_model.id, client._conn)
+
+
+@pytest.fixture
 def model_version(registered_model):
     yield registered_model.get_or_create_version()

--- a/client/verta/tests/test_cli/test_endpoint.py
+++ b/client/verta/tests/test_cli/test_endpoint.py
@@ -5,7 +5,7 @@ from verta._internal_utils import _utils
 
 
 class TestCreate:
-    def test_create_endpoint(self):
+    def test_create_endpoint(self, client, created_endpoints):
         endpoint_name = _utils.generate_default_name()
 
         runner = CliRunner()
@@ -16,10 +16,7 @@ class TestCreate:
 
         assert not result.exception
 
-        result = runner.invoke(
-            cli,
-            ['deployment', 'get', 'endpoint', endpoint_name],
-        )
+        endpoint = client.get_endpoint(endpoint_name)
+        assert endpoint
 
-        assert not result.exception
-        assert endpoint_name in result.output
+        created_endpoints.append(endpoint)

--- a/client/verta/tests/test_endpoint/test_endpoint.py
+++ b/client/verta/tests/test_endpoint/test_endpoint.py
@@ -11,42 +11,51 @@ def get_build_ids(status):
     return set(map(lambda comp: comp["build_id"], status["components"]))
 
 class TestEndpoint:
-    def test_create(self, client):
+    def test_create(self, client, created_endpoints):
         name = _utils.generate_default_name()
-        assert client.set_endpoint(name)
+        endpoint = client.set_endpoint(name)
+        created_endpoints.append(endpoint)
 
-    def test_get(self, client):
+        assert endpoint
+
+    def test_get(self, client, created_endpoints):
         name = _utils.generate_default_name()
 
         with pytest.raises(ValueError):
             client.get_endpoint(name)
 
         endpoint = client.set_endpoint(name)
+        created_endpoints.append(endpoint)
 
         assert endpoint.id == client.get_endpoint(endpoint.path).id
         assert endpoint.id == client.get_endpoint(id=endpoint.id).id
 
-    def test_get_by_name(self, client):
+    def test_get_by_name(self, client, created_endpoints):
         path = _utils.generate_default_name()
         path2 = _utils.generate_default_name()
         endpoint = client.set_endpoint(path)
+        created_endpoints.append(endpoint)
 
-        client.set_endpoint(path2)  # in case get erroneously fetches latest
+        dummy_endpoint = client.set_endpoint(path2)  # in case get erroneously fetches latest
+        created_endpoints.append(dummy_endpoint)
 
         assert endpoint.id == client.set_endpoint(endpoint.path).id
-        
-    def test_get_by_id(self, client):
+
+    def test_get_by_id(self, client, created_endpoints):
         path = _utils.generate_default_name()
         path2 = _utils.generate_default_name()
         endpoint = client.set_endpoint(path)
+        created_endpoints.append(endpoint)
 
-        client.set_endpoint(path2)  # in case get erroneously fetches latest
+        dummy_endpoint = client.set_endpoint(path2)  # in case get erroneously fetches latest
+        created_endpoints.append(dummy_endpoint)
 
         assert endpoint.id == client.set_endpoint(id=endpoint.id).id
 
-    def test_list(self, client):
+    def test_list(self, client, created_endpoints):
         name = _utils.generate_default_name()
         endpoint = client.set_endpoint(name)
+        created_endpoints.append(endpoint)
 
         endpoints = client.endpoints()
         assert len(endpoints) >= 1
@@ -58,9 +67,10 @@ class TestEndpoint:
         assert has_new_id
 
 
-    def test_get_status(self, client):
+    def test_get_status(self, client, created_endpoints):
         path = verta._internal_utils._utils.generate_default_name()
         endpoint = client.set_endpoint(path)
+        created_endpoints.append(endpoint)
         status = endpoint.get_status()
 
         # Check that some fields exist:
@@ -68,11 +78,12 @@ class TestEndpoint:
         assert "date_created" in status
         assert "id" in status
 
-    def test_direct_update(self, client, experiment_run, model_for_deployment):
+    def test_direct_update(self, client, created_endpoints, experiment_run, model_for_deployment):
         experiment_run.log_model_for_deployment(**model_for_deployment)
 
         path = verta._internal_utils._utils.generate_default_name()
         endpoint = client.set_endpoint(path)
+        created_endpoints.append(endpoint)
 
         original_status = endpoint.get_status()
         original_build_ids = get_build_ids(original_status)
@@ -82,17 +93,18 @@ class TestEndpoint:
         new_build_ids = get_build_ids(endpoint.get_status())
         assert len(new_build_ids) - len(new_build_ids.intersection(original_build_ids)) > 0
 
-    def test_canary_update(self, client, experiment_run, model_for_deployment):
+    def test_canary_update(self, client, created_endpoints, experiment_run, model_for_deployment):
         experiment_run.log_model_for_deployment(**model_for_deployment)
 
         path = verta._internal_utils._utils.generate_default_name()
         endpoint = client.set_endpoint(path)
+        created_endpoints.append(endpoint)
 
         original_status = endpoint.get_status()
         original_build_ids = get_build_ids(original_status)
 
         strategy = CanaryUpdateStrategy(interval=1, step=0.5)
-        
+
         with pytest.raises(RuntimeError) as excinfo:
             endpoint.update(experiment_run, strategy)
 

--- a/client/verta/tests/test_model_registry/test_model.py
+++ b/client/verta/tests/test_model_registry/test_model.py
@@ -19,23 +19,28 @@ class TestModel:
         assert registered_model.id == client.get_registered_model(registered_model.name).id
         assert registered_model.id == client.get_registered_model(id=registered_model.id).id
 
-    def test_get_by_name(self, client):
+    def test_get_by_name(self, client, created_registered_models):
         registered_model = client.set_registered_model()
+        created_registered_models.append(registered_model)
 
-        client.set_registered_model()  # in case get erroneously fetches latest
+        dummy_model = client.set_registered_model()  # in case get erroneously fetches latest
+        created_registered_models.append(dummy_model)
 
         assert registered_model.id == client.set_registered_model(registered_model.name).id
 
-    def test_get_by_id(self, client):
+    def test_get_by_id(self, client, created_registered_models):
         registered_model = client.set_registered_model()
+        created_registered_models.append(registered_model)
 
-        client.set_registered_model()  # in case get erroneously fetches latest
+        dummy_model = client.set_registered_model()  # in case get erroneously fetches latest
+        created_registered_models.append(dummy_model)
 
         assert registered_model.id == client.set_registered_model(id=registered_model.id).id
 
-    def test_find(self, client):
+    def test_find(self, client, created_registered_models):
         name = "registered_model_new_test"
         registered_model = client.set_registered_model(name)
+        created_registered_models.append(registered_model)
 
         find = client.registered_models.find(["name == '{}'".format(name)])
         assert len(find) == 1
@@ -43,12 +48,13 @@ class TestModel:
             assert item._msg == registered_model._msg
 
         tag_name = name + "_new_tag"
-        registered_model = {name + "1": client.set_registered_model(name + "1", labels=[tag_name, "tag2"]),
-                            name + "2": client.set_registered_model(name + "2", labels=[tag_name])}
+        registered_models = {name + "1": client.set_registered_model(name + "1", labels=[tag_name, "tag2"]),
+                             name + "2": client.set_registered_model(name + "2", labels=[tag_name])}
+        created_registered_models.extend(registered_models.values())
         find = client.registered_models.find(["labels == \"{}\"".format(tag_name)])
         assert len(find) == 2
         for item in find:
-            assert item._msg == registered_model[item._msg.name]._msg
+            assert item._msg == registered_models[item._msg.name]._msg
 
     def test_labels(self, client):
         assert client.set_registered_model(labels=["tag1", "tag2"])

--- a/client/verta/tests/utils.py
+++ b/client/verta/tests/utils.py
@@ -134,3 +134,8 @@ def delete_registered_model(id_, conn):
     request_url = "{}://{}/api/v1/registry/registered_models/{}".format(conn.scheme, conn.socket, id_)
     response = requests.delete(request_url, headers=conn.auth)
     _utils.raise_for_http_error(response)
+
+def delete_endpoint(id_, workspace, conn):
+    request_url = "{}://{}/api/v1/deployment/workspace/{}/endpoints/{}".format(conn.scheme, conn.socket, workspace, id_)
+    response = requests.delete(request_url, headers=conn.auth)
+    _utils.raise_for_http_error(response)


### PR DESCRIPTION
I don't know of an easy, hassle-free way to do this.
We'll have to manually collect the entities we create, and the fixture will delete them after the test.