### PR TITLE
Revert "Convert client.endpoints into property"

### DIFF
--- a/client/verta/tests/test_endpoint/test_endpoint.py
+++ b/client/verta/tests/test_endpoint/test_endpoint.py
@@ -56,7 +56,7 @@ class TestEndpoint:
         endpoint = client.set_endpoint(name)
         created_endpoints.append(endpoint)
 
-        endpoints = client.endpoints
+        endpoints = client.endpoints()
         assert len(endpoints) >= 1
         has_new_id = False
         for item in endpoints:

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -921,6 +921,8 @@ class Client(object):
     def set_endpoint(self, *args, **kwargs):
         return self.get_or_create_endpoint(*args, **kwargs)
 
-    @property
-    def endpoints(self):
-        return Endpoints(self._conn, self._conf)
+    def endpoints(self, workspace = None):
+        workspace = self._set_from_config_if_none(workspace, "workspace")
+        if workspace is None:
+            workspace = self._get_personal_workspace()
+        return Endpoints(self._conn, self._conf, workspace)


### PR DESCRIPTION
Reverts VertaAI/modeldb#1148 to revisit
Apparently breaks `Endpoints` because `workspace` is needed for it to work