### PR TITLE
Convert client.endpoints into property, properly

### DIFF
--- a/client/verta/tests/test_endpoint/test_endpoint.py
+++ b/client/verta/tests/test_endpoint/test_endpoint.py
@@ -56,7 +56,7 @@ class TestEndpoint:
         endpoint = client.set_endpoint(name)
         created_endpoints.append(endpoint)
 
-        endpoints = client.endpoints()
+        endpoints = client.endpoints
         assert len(endpoints) >= 1
         has_new_id = False
         for item in endpoints:

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -923,4 +923,4 @@ class Client(object):
 
     @property
     def endpoints(self):
-        return Endpoints(self._conn, self._conf)
+        return Endpoints(self._conn, self._conf, self._get_personal_workspace())

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -921,8 +921,6 @@ class Client(object):
     def set_endpoint(self, *args, **kwargs):
         return self.get_or_create_endpoint(*args, **kwargs)
 
-    def endpoints(self, workspace = None):
-        workspace = self._set_from_config_if_none(workspace, "workspace")
-        if workspace is None:
-            workspace = self._get_personal_workspace()
-        return Endpoints(self._conn, self._conf, workspace)
+    @property
+    def endpoints(self):
+        return Endpoints(self._conn, self._conf)


### PR DESCRIPTION
Reverts VertaAI/modeldb#1158 with a proper implementation.

`client.endpoints` will set the user's personal workspace.
The user can then change the workspace with `.with_workspace()`.

I have verified the test passes 😄 
```
pytest test_endpoint/test_endpoint.py::TestEndpoint::test_list
```