### PR TITLE
Catch 400s as prediction errors

### DIFF
--- a/client/verta/verta/deployment/_deployedmodel.py
+++ b/client/verta/verta/deployment/_deployedmodel.py
@@ -220,7 +220,7 @@ class DeployedModel:
                     pass
                 else:  # from model back end; contains message (maybe)
                     # try to directly print message, otherwise line breaks appear as '\n'
-                    msg = data.get('message', json.dumps(data))
+                    msg = data.get('message') or json.dumps(data)
                     raise RuntimeError("deployed model encountered an error: {}".format(msg))
             elif not (response.status_code >= 500 or response.status_code in (404, 429)):  # clientside error
                 break

--- a/client/verta/verta/deployment/_deployedmodel.py
+++ b/client/verta/verta/deployment/_deployedmodel.py
@@ -213,13 +213,14 @@ class DeployedModel:
 
             if response.ok:
                 return _utils.body_to_json(response)
-            elif response.status_code == 502:  # bad gateway; possibly error from the model back end
+            elif response.status_code in (400, 502):  # possibly error from the model back end
                 try:
                     data = _utils.body_to_json(response)
                 except ValueError:  # not JSON response; 502 not from model back end
                     pass
                 else:  # from model back end; contains message (maybe)
-                    msg = data.get('message', "(no specific error message found)")
+                    # try to directly print message, otherwise line breaks appear as '\n'
+                    msg = data.get('message', json.dumps(data))
                     raise RuntimeError("deployed model encountered an error: {}".format(msg))
             elif not (response.status_code >= 500 or response.status_code in (404, 429)):  # clientside error
                 break


### PR DESCRIPTION
Deployment API is apparently now returning `400`s instead of `502`s.

**Before:**
```python
HTTPError: 400 Client Error: {"message": "Traceback (most recent call last):\n  File \"<ipython-input-1-8fee06dacb9f>\", line 6, in predict\nRuntimeError: I don't want to\n"} for url: https://dev.verta.ai/api/v1/predict/d2270ced-ba8e-475b-b6fd-a7561a2275c3 at 2020-07-29 01:01:08.830000 UTC
```

**After:** (which is what the Client used to do on `502`s)
```python
RuntimeError: deployed model encountered an error: Traceback (most recent call last):
  File "<ipython-input-1-8fee06dacb9f>", line 6, in predict
RuntimeError: I don't want to

```