### PR TITLE
Update date query keys for datasets

### DIFF
--- a/client/verta/tests/test_datasets.py
+++ b/client/verta/tests/test_datasets.py
@@ -239,13 +239,13 @@ class TestClientDatasetFunctions:
         # test sorting ascending
         datasets = client.find_datasets(
             dataset_ids=[dataset1.id, dataset2.id],
-            sort_key="time_created", ascending=True,
+            sort_key="date_created", ascending=True,
         )
         assert [dataset.id for dataset in datasets] == [dataset1.id, dataset2.id]
         # and descending
         datasets = client.find_datasets(
             dataset_ids=[dataset1.id, dataset2.id],
-            sort_key="time_created", ascending=False,
+            sort_key="date_created", ascending=False,
         )
         assert [dataset.id for dataset in datasets] == [dataset2.id, dataset1.id]
 

--- a/client/verta/verta/_dataset_versioning/datasets.py
+++ b/client/verta/verta/_dataset_versioning/datasets.py
@@ -13,7 +13,8 @@ class Datasets(_utils.LazyList):
         'id',
         'name',
         'tags',
-        'time_created',
+        'date_created',
+        'date_updated',
     }
 
     def __init__(self, conn, conf):

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -702,6 +702,8 @@ class Client(object):
         if dataset_ids:
             datasets = datasets.with_ids(_utils.as_list_of_str(dataset_ids))
         if sort_key:
+            if sort_key.startswith("time_"):
+                sort_key = "date_" + sort_key[len("time_"):]
             datasets = datasets.sort(sort_key, not ascending)
         if workspace:
             datasets = datasets.with_workspace(workspace)
@@ -1151,8 +1153,7 @@ class Client(object):
         if workspace is None:
             workspace = self._get_personal_workspace()
         return Endpoint._create(self._conn, self._conf, workspace, path, description)
-      
-      
+
     @property
     def endpoints(self):
         return Endpoints(self._conn, self._conf, self._get_personal_workspace())


### PR DESCRIPTION
I was having the Client accept `time_created` as a sort key for Datasets (based on [Dataset proto](https://github.com/VertaAI/modeldb/blob/1db93d6/protos/protos/public/modeldb/DatasetService.proto#L23-L24)), but the backend actually wants `date_created` as defined in [Repository proto](https://github.com/VertaAI/modeldb/blob/1db93d6/protos/protos/public/modeldb/versioning/VersioningService.proto#L103-L104).