### PR TITLE
Remove param restrictions on _ModelDBEntity._create_proto()

### DIFF
--- a/client/verta/verta/_tracking/entity.py
+++ b/client/verta/verta/_tracking/entity.py
@@ -137,17 +137,22 @@ class _ModelDBEntity(object):
             return None
 
     @classmethod
-    def _create_proto(cls, conn, ctx, name, desc=None, tags=None, attrs=None, date_created=None, **kwargs):
+    def _create_proto(cls, conn, *args, **kwargs):
+        tags = kwargs.pop('tags', None)
         if tags is not None:
-            tags = _utils.as_list_of_str(tags)
-        if attrs is not None:
-            attrs = [_CommonCommonService.KeyValue(key=key, value=_utils.python_to_val_proto(value, allow_collection=True))
-                     for key, value in six.viewitems(attrs)]
+            kwargs['tags'] = _utils.as_list_of_str(tags)
 
-        return cls._create_proto_internal(conn, ctx, name, desc=desc, tags=tags, attrs=attrs, date_created=date_created, **kwargs)
+        attrs = kwargs.pop('attrs', None)
+        if attrs is not None:
+            kwargs['attrs'] = [
+                _CommonCommonService.KeyValue(key=key, value=_utils.python_to_val_proto(value, allow_collection=True))
+                for key, value in six.viewitems(attrs)
+            ]
+
+        return cls._create_proto_internal(conn, *args, **kwargs)
 
     @classmethod
-    def _create_proto_internal(cls, conn, ctx, name, desc=None, tags=None, attrs=None, date_created=None, **kwargs):
+    def _create_proto_internal(cls, conn, ctx, name, desc=None, tags=None, attrs=None, date_created=None, **kwargs):  # recommended params
         raise NotImplementedError
 
     def log_code(self, exec_path=None, repo_url=None, commit_hash=None, overwrite=False):

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -925,7 +925,7 @@ class Client(object):
         else:
             return Endpoint._get_or_create_by_name(self._conn, path,
                                             lambda name: Endpoint._get_by_path(self._conn, self._conf, workspace, path),
-                                            lambda name: Endpoint._create( self._conn, self._conf, workspace, path, desc=description))
+                                            lambda name: Endpoint._create( self._conn, self._conf, workspace, path, description))
 
 
 
@@ -1151,7 +1151,8 @@ class Client(object):
         if workspace is None:
             workspace = self._get_personal_workspace()
         return Endpoint._create(self._conn, self._conf, workspace, path, description)
-
+      
+      
     @property
     def endpoints(self):
         return Endpoints(self._conn, self._conf, self._get_personal_workspace())

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -925,7 +925,7 @@ class Client(object):
         else:
             return Endpoint._get_or_create_by_name(self._conn, path,
                                             lambda name: Endpoint._get_by_path(self._conn, self._conf, workspace, path),
-                                            lambda name: Endpoint._create( self._conn, self._conf, workspace, path, description))
+                                            lambda name: Endpoint._create( self._conn, self._conf, workspace, path, desc=description))
 
 
 
@@ -1151,8 +1151,7 @@ class Client(object):
         if workspace is None:
             workspace = self._get_personal_workspace()
         return Endpoint._create(self._conn, self._conf, workspace, path, description)
-      
-      
+
     @property
     def endpoints(self):
         return Endpoints(self._conn, self._conf, self._get_personal_workspace())


### PR DESCRIPTION
**tl;dr** subclasses can now specify (almost) whatever they want for `_create_proto_internal()`

-----
`_ModelDBEntity._create_proto()` specifies its expected parameters, which made it inflexible if a subclass doesn't have those exact same ones.

This PR removes those hard parameters and leaves it entirely to the subclass to define its interface for proto creation with `_create_proto_internal()`