### PR TITLE
Remove duplicated module-level constants from client.py

### DIFF
--- a/client/verta/tests/test_deployment.py
+++ b/client/verta/tests/test_deployment.py
@@ -17,6 +17,7 @@ import requests
 import yaml
 
 import verta
+from verta._tracking.experimentrun import _CACHE_DIR
 from verta._internal_utils import _histogram_utils
 from verta._internal_utils import _utils
 
@@ -216,7 +217,7 @@ class TestFetchArtifacts:
             artifacts = experiment_run.fetch_artifacts(strs)
 
             assert set(six.viewkeys(artifacts)) == set(strs)
-            assert all(filepath.startswith(verta.client._CACHE_DIR)
+            assert all(filepath.startswith(_CACHE_DIR)
                        for filepath in six.viewvalues(artifacts))
 
             for key, filepath in six.viewitems(artifacts):
@@ -226,7 +227,7 @@ class TestFetchArtifacts:
 
                 assert file_contents == artifact_contents
         finally:
-            shutil.rmtree(verta.client._CACHE_DIR, ignore_errors=True)
+            shutil.rmtree(_CACHE_DIR, ignore_errors=True)
 
     def test_cached_fetch_artifacts(self, experiment_run, strs, flat_dicts):
         key = strs[0]
@@ -242,7 +243,7 @@ class TestFetchArtifacts:
 
             assert os.path.getmtime(filepath) == last_modified
         finally:
-            shutil.rmtree(verta.client._CACHE_DIR, ignore_errors=True)
+            shutil.rmtree(_CACHE_DIR, ignore_errors=True)
 
     def test_fetch_zip(self, experiment_run, strs, dir_and_files):
         dirpath, filepaths = dir_and_files
@@ -253,7 +254,7 @@ class TestFetchArtifacts:
         try:
             dirpath = experiment_run.fetch_artifacts([key])[key]
 
-            assert dirpath.startswith(verta.client._CACHE_DIR)
+            assert dirpath.startswith(_CACHE_DIR)
 
             retrieved_filepaths = set()
             for root, _, files in os.walk(dirpath):
@@ -264,7 +265,7 @@ class TestFetchArtifacts:
 
             assert filepaths == retrieved_filepaths
         finally:
-            shutil.rmtree(verta.client._CACHE_DIR, ignore_errors=True)
+            shutil.rmtree(_CACHE_DIR, ignore_errors=True)
 
     def test_cached_fetch_zip(self, experiment_run, strs, dir_and_files):
         dirpath, _ = dir_and_files
@@ -281,7 +282,7 @@ class TestFetchArtifacts:
 
             assert os.path.getmtime(dirpath) == last_modified
         finally:
-            shutil.rmtree(verta.client._CACHE_DIR, ignore_errors=True)
+            shutil.rmtree(_CACHE_DIR, ignore_errors=True)
 
     def test_fetch_tgz(self, experiment_run, strs, dir_and_files):
         dirpath, filepaths = dir_and_files
@@ -300,7 +301,7 @@ class TestFetchArtifacts:
         try:
             dirpath = experiment_run.fetch_artifacts([key])[key]
 
-            assert dirpath.startswith(verta.client._CACHE_DIR)
+            assert dirpath.startswith(_CACHE_DIR)
 
             retrieved_filepaths = set()
             for root, _, files in os.walk(dirpath):
@@ -311,7 +312,7 @@ class TestFetchArtifacts:
 
             assert filepaths == retrieved_filepaths
         finally:
-            shutil.rmtree(verta.client._CACHE_DIR, ignore_errors=True)
+            shutil.rmtree(_CACHE_DIR, ignore_errors=True)
 
     def test_fetch_tar(self, experiment_run, strs, dir_and_files):
         dirpath, filepaths = dir_and_files
@@ -330,7 +331,7 @@ class TestFetchArtifacts:
         try:
             dirpath = experiment_run.fetch_artifacts([key])[key]
 
-            assert dirpath.startswith(verta.client._CACHE_DIR)
+            assert dirpath.startswith(_CACHE_DIR)
 
             retrieved_filepaths = set()
             for root, _, files in os.walk(dirpath):
@@ -341,7 +342,7 @@ class TestFetchArtifacts:
 
             assert filepaths == retrieved_filepaths
         finally:
-            shutil.rmtree(verta.client._CACHE_DIR, ignore_errors=True)
+            shutil.rmtree(_CACHE_DIR, ignore_errors=True)
 
     def test_fetch_tar_gz(self, experiment_run, strs, dir_and_files):
         dirpath, filepaths = dir_and_files
@@ -360,7 +361,7 @@ class TestFetchArtifacts:
         try:
             dirpath = experiment_run.fetch_artifacts([key])[key]
 
-            assert dirpath.startswith(verta.client._CACHE_DIR)
+            assert dirpath.startswith(_CACHE_DIR)
 
             retrieved_filepaths = set()
             for root, _, files in os.walk(dirpath):
@@ -371,7 +372,7 @@ class TestFetchArtifacts:
 
             assert filepaths == retrieved_filepaths
         finally:
-            shutil.rmtree(verta.client._CACHE_DIR, ignore_errors=True)
+            shutil.rmtree(_CACHE_DIR, ignore_errors=True)
 
     def test_wrong_type_artifacts_error(self, experiment_run, all_values):
         # remove lists of strings and empty lists, because they're valid arguments

--- a/client/verta/tests/test_entities.py
+++ b/client/verta/tests/test_entities.py
@@ -9,6 +9,7 @@ import requests
 import pytest
 
 from verta._registry import RegisteredModels
+from verta._tracking.experimentrun import _CACHE_DIR
 from . import utils
 
 import verta
@@ -179,7 +180,7 @@ class TestEntities:
 
         for entity in entities:
             filename = strs[0]
-            filepath = os.path.join(verta.client._CACHE_DIR, filename)
+            filepath = os.path.join(_CACHE_DIR, filename)
             contents = six.ensure_binary(strs[1])
 
             assert not os.path.isfile(filepath)
@@ -194,7 +195,7 @@ class TestEntities:
                 with open(filepath, 'rb') as f:
                     assert f.read() == contents
             finally:
-                shutil.rmtree(verta.client._CACHE_DIR, ignore_errors=True)
+                shutil.rmtree(_CACHE_DIR, ignore_errors=True)
 
 
 class TestProject:

--- a/client/verta/verta/_tracking/entity.py
+++ b/client/verta/verta/_tracking/entity.py
@@ -456,4 +456,3 @@ class _ModelDBEntity(object):
         else:
             # workspace is organization
             return _utils.body_to_json(response)['organization']['name']
-

--- a/client/verta/verta/_tracking/experimentrun.py
+++ b/client/verta/verta/_tracking/experimentrun.py
@@ -759,7 +759,7 @@ class ExperimentRun(_ModelDBEntity):
                                            self._conn.scheme, self._conn.socket),
                                        self._conn, json={'id': self.id, 'metric_keys': keys})
         _utils.raise_for_http_error(response)
-        
+
     def _delete_observations(self, keys):
         response = _utils.make_request("DELETE",
                                        "{}://{}/api/v1/modeldb/experiment-run/deleteObservations".format(

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -47,6 +47,7 @@ from ._repository import commit as commit_module
 from . import deployment
 from . import utils
 
+from ._tracking import entity
 from ._tracking import (
     _Context,
     Project,
@@ -68,21 +69,6 @@ from ._dataset_versioning.datasets import Datasets
 from ._deployment import (
     Endpoint,
     Endpoints,
-)
-
-
-_OSS_DEFAULT_WORKSPACE = "personal"
-
-# for ExperimentRun._log_modules()
-_CUSTOM_MODULES_DIR = "/app/custom_modules/"  # location in DeploymentService model container
-
-# for ExperimentRun.log_model()
-_MODEL_ARTIFACTS_ATTR_KEY = "verta_model_artifacts"
-
-_CACHE_DIR = os.path.join(
-    os.path.expanduser("~"),
-    ".verta",
-    "cache",
 )
 
 
@@ -284,7 +270,7 @@ class Client(object):
                     pass
                 else:
                     _utils.raise_for_http_error(response)
-        return _OSS_DEFAULT_WORKSPACE
+        return entity._OSS_DEFAULT_WORKSPACE
 
     def _load_config(self):
         with _config_utils.read_merged_config() as config:


### PR DESCRIPTION
Since splitting `client.py` into `_tracking/*`, there were duplicated module-level constants. I've removed them from `client.py` in favor of those defined in `entity.py` and `experimentrun.py`