### PR TITLE
VR-5617: Make model container paths configurable through environment variables

### DIFF
--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -40,9 +40,6 @@ _VALID_FLAT_KEY_CHARS = set(string.ascii_letters + string.digits + '_-/')
 THREAD_LOCALS = threading.local()
 THREAD_LOCALS.active_experiment_run = None
 
-# location in DeploymentService model container
-SAVED_MODEL_DIR = os.environ.get('VERTA_SAVED_MODEL_DIR', "/app/tf_saved_model/")
-
 # TODO: remove this in favor of _config_utils when #635 is merged
 HOME_VERTA_DIR = os.path.expanduser(os.path.join('~', ".verta"))
 

--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -40,7 +40,8 @@ _VALID_FLAT_KEY_CHARS = set(string.ascii_letters + string.digits + '_-/')
 THREAD_LOCALS = threading.local()
 THREAD_LOCALS.active_experiment_run = None
 
-SAVED_MODEL_DIR = "/app/tf_saved_model/"
+# location in DeploymentService model container
+SAVED_MODEL_DIR = os.environ.get('VERTA_SAVED_MODEL_DIR', "/app/tf_saved_model/")
 
 # TODO: remove this in favor of _config_utils when #635 is merged
 HOME_VERTA_DIR = os.path.expanduser(os.path.join('~', ".verta"))

--- a/client/verta/verta/_tracking/experimentrun.py
+++ b/client/verta/verta/_tracking/experimentrun.py
@@ -44,7 +44,8 @@ from .. import deployment
 from .. import utils
 
 
-_CUSTOM_MODULES_DIR = "/app/custom_modules/"  # location in DeploymentService model container
+# location in DeploymentService model container
+_CUSTOM_MODULES_DIR = os.environ.get('VERTA_CUSTOM_MODULES_DIR', "/app/custom_modules/")
 
 _MODEL_ARTIFACTS_ATTR_KEY = "verta_model_artifacts"
 

--- a/client/verta/verta/utils.py
+++ b/client/verta/verta/utils.py
@@ -254,7 +254,7 @@ class TFSavedModel(object):
 
         self.__dict__.update(state)
 
-        self.saved_model_dir = _utils.SAVED_MODEL_DIR
+        self.saved_model_dir = os.environ.get('VERTA_SAVED_MODEL_DIR', "/app/tf_saved_model/")
         self.session = tf.Session()
 
         input_tensors, output_tensors = self._map_tensors()


### PR DESCRIPTION
Best I can tell, these are the only hard-coded model service paths (searched with `['"]/(?!api)`)

Custom modules will need a larger change to actually be supported; filed VR-5617 to follow up.
`TFSavedModel` works; I've verified this manually, and made an aesthetic change that helps clarify this.
`setup_script` doesn't involve a hard-coded path.

I've filed VR-5693 to actually document the probably-almost-a-dozen environment variables checked by the Client.