### PR TITLE
Rename CpuMilli to CpuMillis

### DIFF
--- a/client/verta/tests/test_endpoint/test_endpoint.py
+++ b/client/verta/tests/test_endpoint/test_endpoint.py
@@ -5,7 +5,7 @@ import requests
 
 import verta
 from verta._deployment import Endpoint
-from verta.deployment.resources import CpuMilli, Memory
+from verta.deployment.resources import CpuMillis, Memory
 from verta.deployment.update import DirectUpdateStrategy, CanaryUpdateStrategy
 from verta.deployment.update.rules import AverageLatencyThresholdRule
 from verta._internal_utils import _utils
@@ -259,7 +259,7 @@ class TestEndpoint:
         strategy = CanaryUpdateStrategy(interval=1, step=0.5)
 
         strategy.add_rule(AverageLatencyThresholdRule(0.8))
-        updated_status = endpoint.update(experiment_run, strategy, resources = [ CpuMilli(500), Memory("500Mi"), ],
+        updated_status = endpoint.update(experiment_run, strategy, resources = [ CpuMillis(500), Memory("500Mi"), ],
                                          env_vars = {'CUDA_VISIBLE_DEVICES': "1,2", "VERTA_HOST": "app.verta.ai"})
 
         # Check that a new build is added:
@@ -277,7 +277,7 @@ class TestEndpoint:
     def test_form_update_body(self):
         endpoint = Endpoint(None, None, None, None)
         resources = [
-            CpuMilli(500),
+            CpuMillis(500),
             Memory("500Mi"),
         ]
 

--- a/client/verta/tests/test_endpoint/test_resources.py
+++ b/client/verta/tests/test_endpoint/test_resources.py
@@ -1,23 +1,23 @@
 import pytest
 
-from verta.deployment.resources import CpuMilli, Memory
+from verta.deployment.resources import CpuMillis, Memory
 
 
 @pytest.mark.parametrize("data", [3, 64])
 def test_cpu_milli(data):
-    CpuMilli(data)
+    CpuMillis(data)
 
 
 @pytest.mark.parametrize("data", [-12, 0])
 def test_cpu_milli_negative(data):
     with pytest.raises(ValueError):
-        CpuMilli(data)
+        CpuMillis(data)
 
 
 @pytest.mark.parametrize("data", ["T", 0.5])
 def test_cpu_milli_negative_type(data):
     with pytest.raises(TypeError):
-        CpuMilli(data)
+        CpuMillis(data)
 
 
 @pytest.mark.parametrize("data", ['128974848', '129e6', '129M', '123Mi'])

--- a/client/verta/verta/deployment/resources.py
+++ b/client/verta/verta/deployment/resources.py
@@ -12,7 +12,7 @@ class _Resource(object):
         self.parameter = parameter
 
 
-class CpuMilli(_Resource):
+class CpuMillis(_Resource):
     milli_err_msg = "`cpu_millis` must be int greater than 0"
 
     def __init__(self, parameter):
@@ -20,7 +20,7 @@ class CpuMilli(_Resource):
             raise TypeError(self.milli_err_msg)
         if parameter <= 0:
             raise ValueError(self.milli_err_msg)
-        super(CpuMilli, self).__init__(parameter)
+        super(CpuMillis, self).__init__(parameter)
 
     def to_dict(self):
         return {"cpu_millis": self.parameter}


### PR DESCRIPTION
To be more consistent with the backend API schema, since the field is actually `cpu_millis`
This is my bad for not realizing this when designing the original Client API 😦 