### PR TITLE
Fixed the sorting order for GetLatestDatasetVersionByDatasetId

### DIFF
--- a/backend/src/main/java/ai/verta/modeldb/dataset/DatasetServiceImpl.java
+++ b/backend/src/main/java/ai/verta/modeldb/dataset/DatasetServiceImpl.java
@@ -879,8 +879,8 @@ public class DatasetServiceImpl extends DatasetServiceImplBase {
           commitDAO.listCommits(
               listCommitsRequest.build(),
               (session ->
-                  repositoryDAO.getRepositoryById(
-                      session, repositoryIdentification, false, false)));
+                  repositoryDAO.getRepositoryById(session, repositoryIdentification, false, false)),
+              false);
       List<String> datasetVersionIds = new ArrayList<>();
       ListValue.Builder listValueBuilder = ListValue.newBuilder();
       List<Commit> commitList = listCommitsResponse.getCommitsList();
@@ -979,8 +979,8 @@ public class DatasetServiceImpl extends DatasetServiceImplBase {
           commitDAO.listCommits(
               listCommitsRequest.build(),
               (session ->
-                  repositoryDAO.getRepositoryById(
-                      session, repositoryIdentification, false, false)));
+                  repositoryDAO.getRepositoryById(session, repositoryIdentification, false, false)),
+              false);
       List<String> datasetVersionIds = new ArrayList<>();
       ListValue.Builder listValueBuilder = ListValue.newBuilder();
       List<Commit> commitList = listCommitsResponse.getCommitsList();

--- a/backend/src/main/java/ai/verta/modeldb/datasetVersion/DatasetVersionServiceImpl.java
+++ b/backend/src/main/java/ai/verta/modeldb/datasetVersion/DatasetVersionServiceImpl.java
@@ -207,7 +207,10 @@ public class DatasetVersionServiceImpl extends DatasetVersionServiceImplBase {
       }
       DatasetVersionDTO datasetVersionDTO =
           getDatasetVersionDTOByDatasetId(
-              request.getDatasetId(), request.getPageNumber(), request.getPageLimit());
+              request.getDatasetId(),
+              request.getPageNumber(),
+              request.getPageLimit(),
+              request.getAscending());
 
       /*Build response*/
       responseObserver.onNext(
@@ -224,7 +227,7 @@ public class DatasetVersionServiceImpl extends DatasetVersionServiceImplBase {
   }
 
   private DatasetVersionDTO getDatasetVersionDTOByDatasetId(
-      String datasetId, int pageNumber, int pageLimit)
+      String datasetId, int pageNumber, int pageLimit, boolean ascending)
       throws InvalidProtocolBufferException, ModelDBException {
 
     /*Get Data*/
@@ -241,7 +244,8 @@ public class DatasetVersionServiceImpl extends DatasetVersionServiceImplBase {
         commitDAO.listCommits(
             listCommitsRequest.build(),
             (session ->
-                repositoryDAO.getRepositoryById(session, repositoryIdentification, false, false)));
+                repositoryDAO.getRepositoryById(session, repositoryIdentification, false, false)),
+            ascending);
 
     long totalRecords = listCommitsResponse.getTotalRecords();
     totalRecords = totalRecords > 0 ? totalRecords - 1 : totalRecords;
@@ -331,12 +335,14 @@ public class DatasetVersionServiceImpl extends DatasetVersionServiceImplBase {
       /*String sortKey =
       request.getSortKey().isEmpty() ? ModelDBConstants.TIME_LOGGED : request.getSortKey();*/
 
+      int pageNumber = request.getAscending() ? 2 : 1;
       DatasetVersionDTO datasetVersionDTO =
-          getDatasetVersionDTOByDatasetId(request.getDatasetId(), 1, 1);
+          getDatasetVersionDTOByDatasetId(
+              request.getDatasetId(), pageNumber, 1, request.getAscending());
 
       if (datasetVersionDTO.getDatasetVersions().size() != 1) {
         logAndThrowError(
-            "No datasetVersion found for dataset '" + request.getDatasetId(),
+            "No datasetVersion found for dataset '" + request.getDatasetId() + "'",
             Code.NOT_FOUND_VALUE,
             Any.pack(GetLatestDatasetVersionByDatasetId.Response.getDefaultInstance()));
       }

--- a/backend/src/main/java/ai/verta/modeldb/versioning/CommitDAO.java
+++ b/backend/src/main/java/ai/verta/modeldb/versioning/CommitDAO.java
@@ -37,7 +37,8 @@ public interface CommitDAO {
       throws ModelDBException, NoSuchAlgorithmException;
 
   ListCommitsRequest.Response listCommits(
-      ListCommitsRequest request, RepositoryFunction getRepository) throws ModelDBException;
+      ListCommitsRequest request, RepositoryFunction getRepository, boolean ascending)
+      throws ModelDBException;
 
   Commit getCommit(String commitHash, RepositoryFunction getRepository) throws ModelDBException;
 

--- a/backend/src/main/java/ai/verta/modeldb/versioning/CommitDAORdbImpl.java
+++ b/backend/src/main/java/ai/verta/modeldb/versioning/CommitDAORdbImpl.java
@@ -284,7 +284,8 @@ public class CommitDAORdbImpl implements CommitDAO {
   }
 
   public CommitPaginationDTO fetchCommitEntityList(
-      Session session, ListCommitsRequest request, Long repoId) throws ModelDBException {
+      Session session, ListCommitsRequest request, Long repoId, boolean ascending)
+      throws ModelDBException {
     StringBuilder commitQueryBuilder =
         new StringBuilder(
             " FROM "
@@ -314,9 +315,11 @@ public class CommitDAORdbImpl implements CommitDAO {
       commitQueryBuilder.append(" AND cm.date_created <= " + headTime);
     }
 
+    String order = ascending ? " ASC " : " DESC ";
+
     Query<CommitEntity> commitEntityQuery =
         session.createQuery(
-            "SELECT cm " + commitQueryBuilder.toString() + " ORDER BY cm.date_updated DESC");
+            "SELECT cm " + commitQueryBuilder.toString() + " ORDER BY cm.date_updated " + order);
     commitEntityQuery.setParameter("repoId", repoId);
     if (request.hasPagination()) {
       int pageLimit = request.getPagination().getPageLimit();
@@ -338,12 +341,13 @@ public class CommitDAORdbImpl implements CommitDAO {
 
   @Override
   public ListCommitsRequest.Response listCommits(
-      ListCommitsRequest request, RepositoryFunction getRepository) throws ModelDBException {
+      ListCommitsRequest request, RepositoryFunction getRepository, boolean ascending)
+      throws ModelDBException {
     try (Session session = ModelDBHibernateUtil.getSessionFactory().openSession()) {
       RepositoryEntity repository = getRepository.apply(session);
 
       CommitPaginationDTO commitPaginationDTO =
-          fetchCommitEntityList(session, request, repository.getId());
+          fetchCommitEntityList(session, request, repository.getId(), ascending);
       List<Commit> commits =
           commitPaginationDTO.getCommitEntities().stream()
               .map(CommitEntity::toCommitProto)
@@ -354,7 +358,7 @@ public class CommitDAORdbImpl implements CommitDAO {
           .build();
     } catch (Exception ex) {
       if (ModelDBUtils.needToRetry(ex)) {
-        return listCommits(request, getRepository);
+        return listCommits(request, getRepository, ascending);
       } else {
         throw ex;
       }

--- a/backend/src/main/java/ai/verta/modeldb/versioning/VersioningServiceImpl.java
+++ b/backend/src/main/java/ai/verta/modeldb/versioning/VersioningServiceImpl.java
@@ -195,7 +195,8 @@ public class VersioningServiceImpl extends VersioningServiceImplBase {
       ListCommitsRequest.Response response =
           commitDAO.listCommits(
               request,
-              (session) -> repositoryDAO.getRepositoryById(session, request.getRepositoryId()));
+              (session) -> repositoryDAO.getRepositoryById(session, request.getRepositoryId()),
+              false);
       responseObserver.onNext(response);
       responseObserver.onCompleted();
     } catch (Exception e) {

--- a/backend/src/test/java/ai/verta/modeldb/DatasetVersionTest.java
+++ b/backend/src/test/java/ai/verta/modeldb/DatasetVersionTest.java
@@ -459,6 +459,8 @@ public class DatasetVersionTest {
     assertTrue(deleteDatasetResponse.getStatus());
   }
 
+  // TODO: getLatestDatasetVersionByDatasetId not supporting sort key because datasetVersion have
+  // TODO: just one sortable column which is TIME_UPDATED
   @Test
   public void getLatestDatasetVersionByDatasetId() {
 
@@ -524,8 +526,7 @@ public class DatasetVersionTest {
         datasetVersion3,
         getLatestDatasetVersionByDatasetIdResponse.getDatasetVersion());
 
-    // TODO: uncomment when pagination support with the sort key and ascending
-    /*getLatestDatasetVersionByDatasetIdRequest =
+    getLatestDatasetVersionByDatasetIdRequest =
         GetLatestDatasetVersionByDatasetId.newBuilder()
             .setDatasetId(dataset.getId())
             .setAscending(true)
@@ -536,7 +537,7 @@ public class DatasetVersionTest {
     assertEquals(
         "DatasetVersions not match with expected DatasetVersion",
         datasetVersion1,
-        getLatestDatasetVersionByDatasetIdResponse.getDatasetVersion());*/
+        getLatestDatasetVersionByDatasetIdResponse.getDatasetVersion());
 
     getLatestDatasetVersionByDatasetIdRequest =
         GetLatestDatasetVersionByDatasetId.newBuilder()


### PR DESCRIPTION
ascending is already in protos but when we are migrated from Dataset to Repository at that time we do not supported sorting on ascending with commit on getLatestDatasetVersionByDatasetId endpoint. I have added TODO there for order also https://github.com/VertaAI/modeldb/pull/1235/files#diff-26e67cd48910e9882dacfb8e06c3af4cR334 

So now i have just added ascending in flag o that flow and return result based on it. 