### PR TITLE
VR-5858 endpoint.update(wait=True) to wait until only one build is present

### DIFF
--- a/client/verta/tests/test_endpoint/test_endpoint.py
+++ b/client/verta/tests/test_endpoint/test_endpoint.py
@@ -414,3 +414,33 @@ class TestEndpoint:
             else:
                 assert metric["parameters"][0]["name"] == "memory_target"
                 assert metric["parameters"][0]["value"] == "0.7"
+
+    def test_update_twice(self, client, registered_model, created_endpoints):
+        np = pytest.importorskip("numpy")
+        json = pytest.importorskip("json")
+        sklearn = pytest.importorskip("sklearn")
+        from sklearn.linear_model import LogisticRegression
+
+        env = Python(requirements=["scikit-learn"])
+
+        classifier = LogisticRegression()
+        classifier.fit(np.random.random((36, 12)), np.random.random(36).round())
+        model_version = registered_model.create_version("first-version")
+        model_version.log_model(classifier)
+        model_version.log_environment(env)
+
+        new_classifier = LogisticRegression()
+        new_classifier.fit(np.random.random((36, 12)), np.random.random(36).round())
+        new_model_version = registered_model.create_version("second-version")
+        new_model_version.log_model(new_classifier)
+        new_model_version.log_environment(env)
+
+        path = verta._internal_utils._utils.generate_default_name()
+        endpoint = client.set_endpoint(path)
+        created_endpoints.append(endpoint)
+        endpoint.update(model_version, DirectUpdateStrategy(), wait=True)
+
+        # updating endpoint
+        endpoint.update(new_model_version, DirectUpdateStrategy(), wait=True)
+        test_data = np.random.random((4, 12))
+        assert np.array_equal(endpoint.get_deployed_model().predict(test_data), new_classifier.predict(test_data))

--- a/client/verta/verta/_deployment/endpoint.py
+++ b/client/verta/verta/_deployment/endpoint.py
@@ -176,9 +176,9 @@ class Endpoint(object):
             while status_dict['status'] not in ("active", "error") \
                     or (status_dict['status'] == "active" and len(self.get_status()['components']) > 1):
                 print(".", end='')
-                status_dict = self.get_status()
                 sys.stdout.flush()
                 time.sleep(5)
+                status_dict = self.get_status()
 
             print()
             if self.get_status()['status'] == "error":

--- a/client/verta/verta/_deployment/endpoint.py
+++ b/client/verta/verta/_deployment/endpoint.py
@@ -175,9 +175,16 @@ class Endpoint(object):
                 print(".", end='')
                 sys.stdout.flush()
                 time.sleep(5)
-            print()
+
             if self.get_status()['status'] == "error":
+                print()
                 raise RuntimeError("endpoint update failed")
+
+            while len(self.get_status()['components']) > 1:
+                print(".", end='')
+                sys.stdout.flush()
+                time.sleep(5)
+            print()
 
         return self.get_status()
 

--- a/client/verta/verta/_deployment/endpoint.py
+++ b/client/verta/verta/_deployment/endpoint.py
@@ -171,20 +171,18 @@ class Endpoint(object):
         if wait:
             print("waiting for update...", end='')
             sys.stdout.flush()
-            while self.get_status()['status'] not in ("active", "error"):
+
+            status_dict = self.get_status()  # if you think of a better var name, please do use it haha
+            while status_dict['status'] not in ("active", "error") \
+                    or (status_dict['status'] == "active" and len(self.get_status()['components']) > 1):
                 print(".", end='')
+                status_dict = self.get_status()
                 sys.stdout.flush()
                 time.sleep(5)
 
-            if self.get_status()['status'] == "error":
-                print()
-                raise RuntimeError("endpoint update failed")
-
-            while len(self.get_status()['components']) > 1:
-                print(".", end='')
-                sys.stdout.flush()
-                time.sleep(5)
             print()
+            if self.get_status()['status'] == "error":
+                raise RuntimeError("endpoint update failed")
 
         return self.get_status()
 


### PR DESCRIPTION
When wait=True, the client waits until stage status becomes "active". However, there are still 2 builds:
```
{u'components': [{u'build_id': 150549, u'ratio': 1, u'status': u'creating'},
  {u'build_id': 150557, u'status': u'running'}],
 u'creator_request': {u'name': u'production'},
 u'date_created': u'2020-08-06T14:22:56.000Z',
 u'date_updated': u'2020-08-06T15:58:24.000Z',
 'stage_id': 211751,
 u'status': u'active'}
```
If we keep waiting, until there is only one build, the result will be correct.