### PR TITLE
Don't update query keys for datasets

### DIFF
--- a/client/verta/tests/test_datasets.py
+++ b/client/verta/tests/test_datasets.py
@@ -217,13 +217,13 @@ class TestClientDatasetFunctions:
         # test sorting ascending
         datasets = client.find_datasets(
             dataset_ids=[dataset1.id, dataset2.id],
-            sort_key="date_created", ascending=True,
+            sort_key="time_created", ascending=True,
         )
         assert [dataset.id for dataset in datasets] == [dataset1.id, dataset2.id]
         # and descending
         datasets = client.find_datasets(
             dataset_ids=[dataset1.id, dataset2.id],
-            sort_key="date_created", ascending=False,
+            sort_key="time_created", ascending=False,
         )
         assert [dataset.id for dataset in datasets] == [dataset2.id, dataset1.id]
 

--- a/client/verta/verta/_dataset_versioning/datasets.py
+++ b/client/verta/verta/_dataset_versioning/datasets.py
@@ -13,8 +13,7 @@ class Datasets(_utils.LazyList):
         'id',
         'name',
         'tags',
-        'date_created',
-        'date_updated',
+        'time_created',
     }
 
     def __init__(self, conn, conf):

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -686,8 +686,6 @@ class Client(object):
         if dataset_ids:
             datasets = datasets.with_ids(_utils.as_list_of_str(dataset_ids))
         if sort_key:
-            if sort_key.startswith("time_"):
-                sort_key = "date_" + sort_key[len("time_"):]
             datasets = datasets.sort(sort_key, not ascending)
         if workspace:
             datasets = datasets.with_workspace(workspace)


### PR DESCRIPTION
Reverts VertaAI/modeldb#1179

To maintain compatibility with pre-migration datasets.