### PR TITLE
VR-5847 log file type for ModelVersion artifacts

### DIFF
--- a/client/verta/tests/test_model_registry/test_model_version.py
+++ b/client/verta/tests/test_model_registry/test_model_version.py
@@ -100,6 +100,12 @@ class TestModelVersion:
         retrieved_classfier = model_version.get_model()
         assert np.array_equal(retrieved_classfier.coef_, original_coef)
 
+        # check model api:
+        assert "model_api.json" in model_version.get_artifact_keys()
+        for artifact in model_version._msg.artifacts:
+            if artifact.key == "model_api.json":
+                assert artifact.filename_extension == "json"
+
         # overwrite should work:
         new_classifier = LogisticRegression()
         new_classifier.fit(np.random.random((36, 12)), np.random.random(36).round())
@@ -126,6 +132,7 @@ class TestModelVersion:
         # retrieve the artifact:
         retrieved_coef = model_version.get_artifact("coef")
         assert np.array_equal(retrieved_coef, original_coef)
+        assert model_version._msg.artifacts[0].filename_extension == "pkl"
 
         # Overwrite should work:
         new_classifier = LogisticRegression()

--- a/client/verta/verta/_registry/modelversion.py
+++ b/client/verta/verta/_registry/modelversion.py
@@ -230,7 +230,7 @@ class RegisteredModelVersion(_ModelDBEntity):
                 'type': model_type,
                 'deserialization': method,
             }
-        self.log_artifact("model_api.json", model_api, overwrite)
+        self.log_artifact("model_api.json", model_api, overwrite, "json")
 
     def get_model(self):
         """
@@ -258,7 +258,7 @@ class RegisteredModelVersion(_ModelDBEntity):
         self._msg.ClearField("model")
         self._update()
 
-    def log_artifact(self, key, artifact, overwrite=False):
+    def log_artifact(self, key, artifact, overwrite=False, extension=None):
         """
         Logs an artifact to this Model Version.
 
@@ -274,6 +274,8 @@ class RegisteredModelVersion(_ModelDBEntity):
                 - Otherwise, the object will be serialized and uploaded as an artifact.
         overwrite : bool, default False
             Whether to allow overwriting an existing artifact with key `key`.
+        extension : str, optional
+            Filename extension associated with the artifact.
 
         """
         if key == "model":
@@ -296,10 +298,11 @@ class RegisteredModelVersion(_ModelDBEntity):
             artifact = open(artifact, 'rb')
         artifact_stream, method = _artifact_utils.ensure_bytestream(artifact)
 
-        try:
-            extension = _artifact_utils.get_file_ext(artifact_stream)
-        except (TypeError, ValueError):
-            extension = _artifact_utils.ext_from_method(method)
+        if not extension:
+            try:
+                extension = _artifact_utils.get_file_ext(artifact_stream)
+            except (TypeError, ValueError):
+                extension = _artifact_utils.ext_from_method(method)
 
         artifact_msg = self._create_artifact_msg(key, artifact_stream, artifact_type=artifact_type, extension=extension)
         if same_key_ind == -1:
@@ -544,7 +547,6 @@ class RegisteredModelVersion(_ModelDBEntity):
                                                path_only=False,
                                                artifact_type=artifact_type,
                                                filename_extension=extension)
-
         return artifact_msg
 
     def _get_artifact(self, key, artifact_type):


### PR DESCRIPTION
The mechanism is already baked in, I just forgot to expose it + use it for model_api.json.
Model already has "pkl" as filename_extension. Is there any other cases that we could be missing?