### PR TITLE
Restore staticmethod decorator

### DIFF
--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -111,6 +111,7 @@ class Connection:
     def must_response(response):
         raise_for_http_error(response)
 
+    @staticmethod
     def _request_to_curl(request):
         """
         Prints a cURL to reproduce `request`.


### PR DESCRIPTION
It had been accidentally removed when resolving a merge conflict