### PR TITLE
Fix verta.deployment API page

### DIFF
--- a/client/verta/docs/api/api/deployment.rst
+++ b/client/verta/docs/api/api/deployment.rst
@@ -6,5 +6,7 @@ Deployment
     See the ``ExperimentRun`` :ref:`experiment-run-deployment` documentation for how to log artifacts
     for deployment, and deploy/undeploy models through the Client.
 
-.. automodule:: verta.deployment
+.. autoclass:: verta.deployment.DeployedModel
     :members:
+.. autofunction:: verta.deployment.prediction_input_unpack
+.. autofunction:: verta.deployment.prediction_io_cleanup


### PR DESCRIPTION
`verta/deployment.py` was moved into `verta/deployment/`, so the docs' pointers needed to be updated.