### PR TITLE
Revert metadata overwrite and find_datasets() keys

### DIFF
--- a/client/verta/tests/test_datasets.py
+++ b/client/verta/tests/test_datasets.py
@@ -217,13 +217,13 @@ class TestClientDatasetFunctions:
         # test sorting ascending
         datasets = client.find_datasets(
             dataset_ids=[dataset1.id, dataset2.id],
-            sort_key="date_created", ascending=True,
+            sort_key="time_created", ascending=True,
         )
         assert [dataset.id for dataset in datasets] == [dataset1.id, dataset2.id]
         # and descending
         datasets = client.find_datasets(
             dataset_ids=[dataset1.id, dataset2.id],
-            sort_key="date_created", ascending=False,
+            sort_key="time_created", ascending=False,
         )
         assert [dataset.id for dataset in datasets] == [dataset2.id, dataset1.id]
 

--- a/client/verta/tests/test_metadata.py
+++ b/client/verta/tests/test_metadata.py
@@ -83,7 +83,7 @@ class TestHyperparameters:
 
         for key, val in six.viewitems(hyperparameters):
             experiment_run.log_hyperparameter(key, val)
-            experiment_run.log_hyperparameter(key, val, overwrite=True)
+            # experiment_run.log_hyperparameter(key, val, overwrite=True)
             with pytest.raises(ValueError):
                 experiment_run.log_hyperparameter(key, val)
 
@@ -215,7 +215,7 @@ class TestMetrics:
         metrics = dict(zip(strs, scalar_values))
 
         experiment_run.log_metrics(metrics)
-        experiment_run.log_metrics(metrics, overwrite=True)
+        # experiment_run.log_metrics(metrics, overwrite=True)
 
         with pytest.raises(KeyError):
             experiment_run.get_metric(holdout)
@@ -230,7 +230,7 @@ class TestMetrics:
 
         for key, val in six.viewitems(metrics):
             experiment_run.log_metric(key, val)
-            experiment_run.log_metric(key, val, overwrite=True)
+            # experiment_run.log_metric(key, val, overwrite=True)
             with pytest.raises(ValueError):
                 experiment_run.log_metric(key, val)
 

--- a/client/verta/verta/_dataset_versioning/datasets.py
+++ b/client/verta/verta/_dataset_versioning/datasets.py
@@ -13,8 +13,7 @@ class Datasets(_utils.LazyList):
         'id',
         'name',
         'tags',
-        'date_created',
-        'date_updated',
+        'time_created',
     }
 
     def __init__(self, conn, conf):

--- a/client/verta/verta/_tracking/experimentrun.py
+++ b/client/verta/verta/_tracking/experimentrun.py
@@ -775,7 +775,7 @@ class ExperimentRun(_ModelDBEntity):
                                        self._conn, json={'id': self.id, 'hyperparameter_keys': keys})
         _utils.raise_for_http_error(response)
 
-    def log_metric(self, key, value, overwrite=False):
+    def log_metric(self, key, value):
         """
         Logs a metric to this Experiment Run.
 
@@ -787,8 +787,6 @@ class ExperimentRun(_ModelDBEntity):
             Name of the metric.
         value : one of {None, bool, float, int, str}
             Value of the metric.
-        overwrite : bool, default False
-            Whether to allow overwriting an existing metric with key `key`.
 
         """
         _utils.validate_flat_key(key)
@@ -796,8 +794,6 @@ class ExperimentRun(_ModelDBEntity):
         metric = _CommonCommonService.KeyValue(key=key, value=_utils.python_to_val_proto(value))
         msg = _ExperimentRunService.LogMetric(id=self.id, metric=metric)
         data = _utils.proto_to_json(msg)
-        if overwrite:
-            self._delete_metrics([key])
         response = _utils.make_request("POST",
                                        "{}://{}/api/v1/modeldb/experiment-run/logMetric".format(self._conn.scheme, self._conn.socket),
                                        self._conn, json=data)
@@ -810,7 +806,7 @@ class ExperimentRun(_ModelDBEntity):
 
         self._clear_cache()
 
-    def log_metrics(self, metrics, overwrite=False):
+    def log_metrics(self, metrics):
         """
         Logs potentially multiple metrics to this Experiment Run.
 
@@ -818,8 +814,6 @@ class ExperimentRun(_ModelDBEntity):
         ----------
         metrics : dict of str to {None, bool, float, int, str}
             Metrics.
-        overwrite : bool, default False
-            Whether to allow overwriting an existing metric with key `key`.
 
         """
         # validate all keys first
@@ -835,8 +829,6 @@ class ExperimentRun(_ModelDBEntity):
 
         msg = _ExperimentRunService.LogMetrics(id=self.id, metrics=metric_keyvals)
         data = _utils.proto_to_json(msg)
-        if overwrite:
-            self._delete_metrics(keys)
         response = _utils.make_request("POST",
                                        "{}://{}/api/v1/modeldb/experiment-run/logMetrics".format(self._conn.scheme, self._conn.socket),
                                        self._conn, json=data)
@@ -883,7 +875,7 @@ class ExperimentRun(_ModelDBEntity):
         self._refresh_cache()
         return self._metrics
 
-    def log_hyperparameter(self, key, value, overwrite=False):
+    def log_hyperparameter(self, key, value):
         """
         Logs a hyperparameter to this Experiment Run.
 
@@ -893,8 +885,6 @@ class ExperimentRun(_ModelDBEntity):
             Name of the hyperparameter.
         value : one of {None, bool, float, int, str}
             Value of the hyperparameter.
-        overwrite : bool, default False
-            Whether to allow overwriting an existing hyperparameter with key `key`.
 
         """
         _utils.validate_flat_key(key)
@@ -902,8 +892,6 @@ class ExperimentRun(_ModelDBEntity):
         hyperparameter = _CommonCommonService.KeyValue(key=key, value=_utils.python_to_val_proto(value))
         msg = _ExperimentRunService.LogHyperparameter(id=self.id, hyperparameter=hyperparameter)
         data = _utils.proto_to_json(msg)
-        if overwrite:
-            self._delete_hyperparameters([key])
         response = _utils.make_request("POST",
                                        "{}://{}/api/v1/modeldb/experiment-run/logHyperparameter".format(self._conn.scheme, self._conn.socket),
                                        self._conn, json=data)
@@ -916,7 +904,7 @@ class ExperimentRun(_ModelDBEntity):
 
         self._clear_cache()
 
-    def log_hyperparameters(self, hyperparams, overwrite=False):
+    def log_hyperparameters(self, hyperparams):
         """
         Logs potentially multiple hyperparameters to this Experiment Run.
 
@@ -924,8 +912,6 @@ class ExperimentRun(_ModelDBEntity):
         ----------
         hyperparameters : dict of str to {None, bool, float, int, str}
             Hyperparameters.
-        overwrite : bool, default False
-            Whether to allow overwriting an existing hyperparameter with key `key`.
 
         """
         # validate all keys first
@@ -941,8 +927,6 @@ class ExperimentRun(_ModelDBEntity):
 
         msg = _ExperimentRunService.LogHyperparameters(id=self.id, hyperparameters=hyperparameter_keyvals)
         data = _utils.proto_to_json(msg)
-        if overwrite:
-            self._delete_hyperparameters(keys)
         response = _utils.make_request("POST",
                                        "{}://{}/api/v1/modeldb/experiment-run/logHyperparameters".format(self._conn.scheme, self._conn.socket),
                                        self._conn, json=data)
@@ -1657,7 +1641,7 @@ class ExperimentRun(_ModelDBEntity):
         ))
         return committed_parts
 
-    def log_observation(self, key, value, timestamp=None, epoch_num=None, overwrite=False):
+    def log_observation(self, key, value, timestamp=None, epoch_num=None):
         """
         Logs an observation to this Experiment Run.
 
@@ -1673,8 +1657,6 @@ class ExperimentRun(_ModelDBEntity):
         epoch_num : non-negative int, optional
             Epoch number associated with this observation. If not provided, it will automatically
             be incremented from prior observations for the same `key`.
-        overwrite : bool, default False
-            Whether to allow overwriting an existing observation with key `key`.
 
         Warnings
         --------
@@ -1703,8 +1685,6 @@ class ExperimentRun(_ModelDBEntity):
 
         msg = _ExperimentRunService.LogObservation(id=self.id, observation=observation)
         data = _utils.proto_to_json(msg)
-        if overwrite:
-            self._delete_observations([key])
         response = _utils.make_request("POST",
                                        "{}://{}/api/v1/modeldb/experiment-run/logObservation".format(self._conn.scheme, self._conn.socket),
                                        self._conn, json=data)

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -686,8 +686,6 @@ class Client(object):
         if dataset_ids:
             datasets = datasets.with_ids(_utils.as_list_of_str(dataset_ids))
         if sort_key:
-            if sort_key.startswith("time_"):
-                sort_key = "date_" + sort_key[len("time_"):]
             datasets = datasets.sort(sort_key, not ascending)
         if workspace:
             datasets = datasets.with_workspace(workspace)


### PR DESCRIPTION
This reverts commits e681b57a (#1261) and be5e632c (#1262).

The backend that corresponds to these Client changes isn't ready to be shipped yet; I'm reverting them until then, so that patches can be easily published.