### PR TITLE
Revert "VR-5686 use patch in registry update (#1265)"

### DIFF
--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -34,7 +34,7 @@ from . import importer
 
 _GRPC_PREFIX = "Grpc-Metadata-"
 
-_VALID_HTTP_METHODS = {'GET', 'POST', 'PUT', 'DELETE', 'PATCH'}
+_VALID_HTTP_METHODS = {'GET', 'POST', 'PUT', 'DELETE'}
 _VALID_FLAT_KEY_CHARS = set(string.ascii_letters + string.digits + '_-/')
 
 THREAD_LOCALS = threading.local()
@@ -76,11 +76,11 @@ class Connection:
                            raise_on_status=False)  # return Response instead of raising after max retries
         self.ignore_conn_err = ignore_conn_err
 
-    def make_proto_request(self, method, path, params=None, body=None, include_default=True):
+    def make_proto_request(self, method, path, params=None, body=None):
         if params is not None:
             params = proto_to_json(params)
         if body is not None:
-            body = proto_to_json(body, include_default)
+            body = proto_to_json(body)
         response = make_request(method,
                                 "{}://{}{}".format(self.scheme, self.socket, path),
                                 self, params=params, json=body)
@@ -599,7 +599,7 @@ def find_filepaths(paths, extensions=None, include_hidden=False, include_venv=Fa
     return filepaths
 
 
-def proto_to_json(msg, include_default=True):
+def proto_to_json(msg):
     """
     Converts a `protobuf` `Message` object into a JSON-compliant dictionary.
 
@@ -617,7 +617,7 @@ def proto_to_json(msg, include_default=True):
 
     """
     return json.loads(json_format.MessageToJson(msg,
-                                                including_default_value_fields=include_default,
+                                                including_default_value_fields=True,
                                                 preserving_proto_field_name=True,
                                                 use_integers_for_enums=True))
 

--- a/client/verta/verta/_registry/model.py
+++ b/client/verta/verta/_registry/model.py
@@ -226,12 +226,12 @@ class RegisteredModel(_ModelDBRegistryEntity):
         print("created new RegisteredModel: {} in {}".format(registered_model.name, WORKSPACE_PRINT_MSG))
         return registered_model
 
-    RegisteredModelMessage = _RegisteredModelService.RegisteredModel
-
     def set_description(self, desc):
         if not desc:
             raise ValueError("desc is not specified")
-        self._update(self.RegisteredModelMessage(description=desc))
+        self._fetch_with_no_cache()
+        self._msg.description = desc
+        self._update()
 
     def get_description(self):
         self._refresh_cache()
@@ -250,7 +250,11 @@ class RegisteredModel(_ModelDBRegistryEntity):
         if not labels:
             raise ValueError("label is not specified")
 
-        self._update(self.RegisteredModelMessage(labels=labels))
+        self._fetch_with_no_cache()
+        for label in labels:
+            if label not in self._msg.labels:
+                self._msg.labels.append(label)
+        self._update()
 
     def add_label(self, label):
         """
@@ -264,7 +268,10 @@ class RegisteredModel(_ModelDBRegistryEntity):
         """
         if label is None:
             raise ValueError("label is not specified")
-        self._update(self.RegisteredModelMessage(labels=[label]))
+        self._fetch_with_no_cache()
+        if label not in self._msg.labels:
+            self._msg.labels.append(label)
+            self._update()
 
     def del_label(self, label):
         """
@@ -281,7 +288,7 @@ class RegisteredModel(_ModelDBRegistryEntity):
         self._fetch_with_no_cache()
         if label in self._msg.labels:
             self._msg.labels.remove(label)
-            self._update(self._msg, method="PUT")
+            self._update()
 
     def get_labels(self):
         """
@@ -296,9 +303,9 @@ class RegisteredModel(_ModelDBRegistryEntity):
         self._refresh_cache()
         return self._msg.labels
 
-    def _update(self, msg, method="PATCH"):
-        response = self._conn.make_proto_request(method, "/api/v1/registry/registered_models/{}".format(self.id),
-                                           body=msg, include_default=False)
+    def _update(self):
+        response = self._conn.make_proto_request("PUT", "/api/v1/registry/registered_models/{}".format(self.id),
+                                           body=self._msg)
         Message = _RegisteredModelService.SetRegisteredModel
         if isinstance(self._conn.maybe_proto_response(response, Message.Response), NoneProtoResponse):
             raise ValueError("Model not found")


### PR DESCRIPTION
This reverts commit 9d6101b8f3649486a8a3edbdb67837063f69a9b5 (#1265).
Except I had to revert it semi-manually because there were conflicts so I'm not 100% this works, though it passes the sample of tests I've run.

PATCH isn't working as expected. Refer to Slack thread in #model-registry.