### PR TITLE
Finish supporting attributes on ModelVersion

### DIFF
--- a/client/verta/verta/_registry/model.py
+++ b/client/verta/verta/_registry/model.py
@@ -63,7 +63,7 @@ class RegisteredModel(_ModelDBRegistryEntity):
         else:
             return _OSS_DEFAULT_WORKSPACE
 
-    def get_or_create_version(self, name=None, desc=None, labels=None, id=None, time_created=None):
+    def get_or_create_version(self, name=None, desc=None, labels=None, attrs=None, id=None, time_created=None):
         """
         Gets or creates a Model Version.
 
@@ -79,6 +79,8 @@ class RegisteredModel(_ModelDBRegistryEntity):
             Description of the Model Version.
         labels : list of str, optional
             Labels of the Model Version.
+        attrs : dict of str to {None, bool, float, int, str}, optional
+            Attributes of the Model Version.
         id : str, optional
             ID of the Model Version. This parameter cannot be provided alongside `name`, and other
             parameters will be ignored.
@@ -103,9 +105,9 @@ class RegisteredModel(_ModelDBRegistryEntity):
             ctx.registered_model = self
             return RegisteredModelVersion._get_or_create_by_name(self._conn, name,
                                                        lambda name: RegisteredModelVersion._get_by_name(self._conn, self._conf, name, self.id),
-                                                       lambda name: RegisteredModelVersion._create(self._conn, self._conf, ctx, name=name, desc=desc, tags=labels, date_created=time_created))
+                                                       lambda name: RegisteredModelVersion._create(self._conn, self._conf, ctx, name=name, desc=desc, tags=labels, attrs=attrs, date_created=time_created))
 
-    def create_version(self, name=None, desc=None, labels=None, time_created=None):
+    def create_version(self, name=None, desc=None, labels=None, attrs=None, time_created=None):
         """
         Creates a model registry entry.
 
@@ -117,6 +119,8 @@ class RegisteredModel(_ModelDBRegistryEntity):
             Description of the Model Version.
         labels : list of str, optional
             Labels of the Model Version.
+        attrs : dict of str to {None, bool, float, int, str}, optional
+            Attributes of the Model Version.
 
         Returns
         -------
@@ -125,7 +129,7 @@ class RegisteredModel(_ModelDBRegistryEntity):
         """
         ctx = _Context(self._conn, self._conf)
         ctx.registered_model = self
-        return RegisteredModelVersion._create(self._conn, self._conf, ctx, name=name, desc=desc, tags=labels, date_created=time_created)
+        return RegisteredModelVersion._create(self._conn, self._conf, ctx, name=name, desc=desc, tags=labels, attrs=attrs, date_created=time_created)
 
 
     def create_version_from_run(self, run_id, name=None):

--- a/client/verta/verta/_registry/modelversion.py
+++ b/client/verta/verta/_registry/modelversion.py
@@ -71,6 +71,7 @@ class RegisteredModelVersion(_ModelDBRegistryEntity, _DeployableEntity):
             "time updated: {}".format(_utils.timestamp_to_str(int(msg.time_updated))),
             "description: {}".format(msg.description),
             "labels: {}".format(msg.labels),
+            "attributes: {}".format(_utils.unravel_key_values(msg.attributes)),
             "id: {}".format(msg.id),
             "registered model id: {}".format(msg.registered_model_id),
             "experiment run id: {}".format(msg.experiment_run_id),
@@ -175,7 +176,7 @@ class RegisteredModelVersion(_ModelDBRegistryEntity, _DeployableEntity):
         registered_model_id = ctx.registered_model.id
 
         model_version_msg = ModelVersionMessage(registered_model_id=registered_model_id, version=name,
-                                                description=desc, labels=tags,
+                                                description=desc, labels=tags, attributes=attrs,
                                                 time_created=date_created, time_updated=date_created,
                                                 experiment_run_id=experiment_run_id)
         endpoint = "/api/v1/registry/registered_models/{}/model_versions".format(registered_model_id)


### PR DESCRIPTION
Followup to https://github.com/VertaAI/modeldb/pull/1280

- support attributes when creating new ModelVersion
- show attributes in repr