### PR TITLE
Only show actual status in not-deployed message

### DIFF
--- a/client/verta/verta/_deployment/endpoint.py
+++ b/client/verta/verta/_deployment/endpoint.py
@@ -436,8 +436,8 @@ class Endpoint(object):
             If the model is not currently deployed.
 
         """
-        status = self.get_status()
-        if status['status'] not in ("active", "updating"):
+        status = self.get_status().get('status', "<no status>")
+        if status not in ("active", "updating"):
             raise RuntimeError("model is not currently deployed (status: {})".format(status))
 
         access_token = self.get_access_token()


### PR DESCRIPTION
@nhatsmrt to "review" this.

I think this should just show the actual status string (instead of the entire status dict) like ExperimentRun does, unless we had a particular reason for showing the whole dict.