### PR TITLE
Comment out ModelVersion archive

### DIFF
--- a/client/verta/tests/test_model_registry/test_model_version.py
+++ b/client/verta/tests/test_model_registry/test_model_version.py
@@ -365,6 +365,7 @@ class TestModelVersion:
             assert labels1 == labels2
             assert item._msg == msg_other
 
+    @pytest.mark.skip(reason="functionality postponed in Client")
     def test_archive(self, model_version):
         assert (not model_version.is_archived)
 

--- a/client/verta/verta/_registry/modelversion.py
+++ b/client/verta/verta/_registry/modelversion.py
@@ -74,7 +74,7 @@ class RegisteredModelVersion(_ModelDBRegistryEntity, _DeployableEntity):
             "id: {}".format(msg.id),
             "registered model id: {}".format(msg.registered_model_id),
             "experiment run id: {}".format(msg.experiment_run_id),
-            "archived status: {}".format(msg.archived),
+            # "archived status: {}".format(msg.archived),
             "artifact keys: {}".format(artifact_keys),
         ))
 
@@ -98,10 +98,10 @@ class RegisteredModelVersion(_ModelDBRegistryEntity, _DeployableEntity):
         self._refresh_cache()
         return self._msg.registered_model_id
 
-    @property
-    def is_archived(self):
-        self._refresh_cache()
-        return self._msg.archived == _CommonCommonService.TernaryEnum.TRUE
+    # @property
+    # def is_archived(self):
+    #     self._refresh_cache()
+    #     return self._msg.archived == _CommonCommonService.TernaryEnum.TRUE
 
     @property
     def workspace(self):
@@ -700,15 +700,15 @@ class RegisteredModelVersion(_ModelDBRegistryEntity, _DeployableEntity):
             downloaded_to_path = _request_utils.download(response, download_to_path, overwrite_ok=True)
             return os.path.abspath(downloaded_to_path)
 
-    def archive(self):
-        """
-        Archive this Model Version.
+    # def archive(self):
+    #     """
+    #     Archive this Model Version.
 
-        """
-        if self.is_archived:
-            raise RuntimeError("the version has already been archived")
+    #     """
+    #     if self.is_archived:
+    #         raise RuntimeError("the version has already been archived")
 
-        self._update(self.ModelVersionMessage(archived=_CommonCommonService.TernaryEnum.TRUE))
+    #     self._update(self.ModelVersionMessage(archived=_CommonCommonService.TernaryEnum.TRUE))
 
     def add_attribute(self, key, value):
         """

--- a/client/verta/verta/_registry/modelversion.py
+++ b/client/verta/verta/_registry/modelversion.py
@@ -50,8 +50,6 @@ class RegisteredModelVersion(_ModelDBRegistryEntity, _DeployableEntity):
         Whether there is a model associated with this Model Version.
     registered_model_id : int
         ID of this version's Registered Model.
-    is_archived : bool
-        Whether this Model Version is archived.
 
     """
     def __init__(self, conn, conf, msg):


### PR DESCRIPTION
The end-to-end behavior of ModelVersion archive is postponed, so for now we are hiding this functionality.
I've filed VR-6012 to revert this PR in the future.