### PR TITLE
Import RegistryService_pb2 as _RegistryService

### DIFF
--- a/client/verta/verta/_registry/entity_registry.py
+++ b/client/verta/verta/_registry/entity_registry.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from verta._internal_utils import _utils
 from verta._tracking.entity import _ModelDBEntity
 

--- a/client/verta/verta/_registry/model.py
+++ b/client/verta/verta/_registry/model.py
@@ -9,7 +9,7 @@ from .._tracking.context import _Context
 from .._internal_utils import _utils
 
 from .._protos.public.common import CommonService_pb2 as _CommonCommonService
-from .._protos.public.registry import RegistryService_pb2 as _RegisteredModelService
+from .._protos.public.registry import RegistryService_pb2 as _RegistryService
 
 from .modelversion import RegisteredModelVersion
 from .modelversions import RegisteredModelVersions
@@ -33,7 +33,7 @@ class RegisteredModel(_ModelDBRegistryEntity):
 
     """
     def __init__(self, conn, conf, msg):
-        super(RegisteredModel, self).__init__(conn, conf, _RegisteredModelService, "registered_model", msg)
+        super(RegisteredModel, self).__init__(conn, conf, _RegistryService, "registered_model", msg)
 
     def __repr__(self):
         self._refresh_cache()
@@ -186,21 +186,21 @@ class RegisteredModel(_ModelDBRegistryEntity):
 
     @classmethod
     def _get_proto_by_id(cls, conn, id):
-        Message = _RegisteredModelService.GetRegisteredModelRequest
+        Message = _RegistryService.GetRegisteredModelRequest
         response = conn.make_proto_request("GET",
                                            "/api/v1/registry/registered_models/{}".format(id))
         return conn.maybe_proto_response(response, Message.Response).registered_model
 
     @classmethod
     def _get_proto_by_name(cls, conn, name, workspace):
-        Message = _RegisteredModelService.GetRegisteredModelRequest
+        Message = _RegistryService.GetRegisteredModelRequest
         response = conn.make_proto_request("GET",
                                            "/api/v1/registry/workspaces/{}/registered_models/{}".format(workspace, name))
         return conn.maybe_proto_response(response, Message.Response).registered_model
 
     @classmethod
     def _create_proto_internal(cls, conn, ctx, name, desc=None, tags=None, attrs=None, date_created=None, public_within_org=None):
-        Message = _RegisteredModelService.RegisteredModel
+        Message = _RegistryService.RegisteredModel
         msg = Message(name=name, description=desc, labels=tags, time_created=date_created, time_updated=date_created)
         if public_within_org:
             if ctx.workspace_name is None:
@@ -216,7 +216,7 @@ class RegisteredModel(_ModelDBRegistryEntity):
         response = conn.make_proto_request("POST",
                                            "/api/v1/registry/workspaces/{}/registered_models".format(ctx.workspace_name),
                                            body=msg)
-        registered_model = conn.must_proto_response(response, _RegisteredModelService.SetRegisteredModel.Response).registered_model
+        registered_model = conn.must_proto_response(response, _RegistryService.SetRegisteredModel.Response).registered_model
 
         if ctx.workspace_name is not None:
             WORKSPACE_PRINT_MSG = "workspace: {}".format(ctx.workspace_name)
@@ -226,7 +226,7 @@ class RegisteredModel(_ModelDBRegistryEntity):
         print("created new RegisteredModel: {} in {}".format(registered_model.name, WORKSPACE_PRINT_MSG))
         return registered_model
 
-    RegisteredModelMessage = _RegisteredModelService.RegisteredModel
+    RegisteredModelMessage = _RegistryService.RegisteredModel
 
     def set_description(self, desc):
         if not desc:
@@ -299,7 +299,7 @@ class RegisteredModel(_ModelDBRegistryEntity):
     def _update(self, msg, method="PATCH"):
         response = self._conn.make_proto_request(method, "/api/v1/registry/registered_models/{}".format(self.id),
                                            body=msg, include_default=False)
-        Message = _RegisteredModelService.SetRegisteredModel
+        Message = _RegistryService.SetRegisteredModel
         if isinstance(self._conn.maybe_proto_response(response, Message.Response), NoneProtoResponse):
             raise ValueError("Model not found")
         self._clear_cache()

--- a/client/verta/verta/_registry/models.py
+++ b/client/verta/verta/_registry/models.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 
 import copy
 
-from .._protos.public.registry import RegistryService_pb2 as _RegisteredModelService
+from .._protos.public.registry import RegistryService_pb2 as _RegistryService
 from .._internal_utils import _utils
 
 from . import RegisteredModel
@@ -23,7 +23,7 @@ class RegisteredModels(_utils.LazyList):
     def __init__(self, conn, conf):
         super(RegisteredModels, self).__init__(
             conn, conf,
-            _RegisteredModelService.FindRegisteredModelRequest(),
+            _RegistryService.FindRegisteredModelRequest(),
         )
 
     def __repr__(self):

--- a/client/verta/verta/_registry/modelversion.py
+++ b/client/verta/verta/_registry/modelversion.py
@@ -9,7 +9,7 @@ from google.protobuf.struct_pb2 import Value
 import requests
 
 from .entity_registry import _ModelDBRegistryEntity
-from .._protos.public.registry import RegistryService_pb2 as _ModelVersionService
+from .._protos.public.registry import RegistryService_pb2 as _RegistryService
 from .._protos.public.common import CommonService_pb2 as _CommonCommonService
 
 import requests
@@ -55,7 +55,7 @@ class RegisteredModelVersion(_ModelDBRegistryEntity, _DeployableEntity):
 
     """
     def __init__(self, conn, conf, msg):
-        super(RegisteredModelVersion, self).__init__(conn, conf, _ModelVersionService, "registered_model_version", msg)
+        super(RegisteredModelVersion, self).__init__(conn, conf, _RegistryService, "registered_model_version", msg)
 
     def __repr__(self):
         self._refresh_cache()
@@ -106,7 +106,7 @@ class RegisteredModelVersion(_ModelDBRegistryEntity, _DeployableEntity):
     @property
     def workspace(self):
         self._refresh_cache()
-        Message = _ModelVersionService.GetRegisteredModelRequest
+        Message = _RegistryService.GetRegisteredModelRequest
         response = self._conn.make_proto_request(
             "GET", "/api/v1/registry/registered_models/{}".format(self.registered_model_id)
         )
@@ -137,7 +137,7 @@ class RegisteredModelVersion(_ModelDBRegistryEntity, _DeployableEntity):
 
     @classmethod
     def _get_proto_by_id(cls, conn, id):
-        Message = _ModelVersionService.GetModelVersionRequest
+        Message = _RegistryService.GetModelVersionRequest
         endpoint = "/api/v1/registry/model_versions/{}".format(id)
         response = conn.make_proto_request("GET", endpoint)
 
@@ -150,7 +150,7 @@ class RegisteredModelVersion(_ModelDBRegistryEntity, _DeployableEntity):
         else:
             raise TypeError("`name` must be a string")
 
-        Message = _ModelVersionService.FindModelVersionRequest
+        Message = _RegistryService.FindModelVersionRequest
         predicates = [
             _CommonCommonService.KeyValueQuery(key="version",
                                                value=value,
@@ -170,8 +170,8 @@ class RegisteredModelVersion(_ModelDBRegistryEntity, _DeployableEntity):
 
     @classmethod
     def _create_proto_internal(cls, conn, ctx, name, desc=None, tags=None, attrs=None, date_created=None, experiment_run_id=None):
-        ModelVersionMessage = _ModelVersionService.ModelVersion
-        SetModelVersionMessage = _ModelVersionService.SetModelVersion
+        ModelVersionMessage = _RegistryService.ModelVersion
+        SetModelVersionMessage = _RegistryService.SetModelVersion
         registered_model_id = ctx.registered_model.id
 
         model_version_msg = ModelVersionMessage(registered_model_id=registered_model_id, version=name,
@@ -185,7 +185,7 @@ class RegisteredModelVersion(_ModelDBRegistryEntity, _DeployableEntity):
         print("created new ModelVersion: {}".format(model_version.version))
         return model_version
 
-    ModelVersionMessage = _ModelVersionService.ModelVersion
+    ModelVersionMessage = _RegistryService.ModelVersion
 
     def log_model(self, model, custom_modules=None, model_api=None, overwrite=False):
         """
@@ -454,7 +454,7 @@ class RegisteredModelVersion(_ModelDBRegistryEntity, _DeployableEntity):
         if method.upper() not in ("GET", "PUT"):
             raise ValueError("`method` must be one of {'GET', 'PUT'}")
 
-        Message = _ModelVersionService.GetUrlForArtifact
+        Message = _RegistryService.GetUrlForArtifact
         msg = Message(
             model_version_id=self.id,
             key=key,
@@ -515,7 +515,7 @@ class RegisteredModelVersion(_ModelDBRegistryEntity, _DeployableEntity):
                     self._conn.socket,
                     self.id
                 )
-                msg = _ModelVersionService.CommitArtifactPart(
+                msg = _RegistryService.CommitArtifactPart(
                     model_version_id=self.id,
                     key=key
                 )
@@ -532,7 +532,7 @@ class RegisteredModelVersion(_ModelDBRegistryEntity, _DeployableEntity):
                 self._conn.socket,
                 self.id
             )
-            msg = _ModelVersionService.CommitMultipartArtifact(
+            msg = _RegistryService.CommitMultipartArtifact(
                 model_version_id=self.id,
                 key=key
             )
@@ -794,7 +794,7 @@ class RegisteredModelVersion(_ModelDBRegistryEntity, _DeployableEntity):
         response = self._conn.make_proto_request(method, "/api/v1/registry/registered_models/{}/model_versions/{}"
                                                  .format(self._msg.registered_model_id, self.id),
                                                  body=msg, include_default=False)
-        Message = _ModelVersionService.SetModelVersion
+        Message = _RegistryService.SetModelVersion
         if isinstance(self._conn.maybe_proto_response(response, Message.Response), NoneProtoResponse):
             raise ValueError("Model not found")
         self._clear_cache()

--- a/client/verta/verta/_registry/modelversions.py
+++ b/client/verta/verta/_registry/modelversions.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 
 import copy
 
-from .._protos.public.registry import RegistryService_pb2 as _RegisteredModelService
+from .._protos.public.registry import RegistryService_pb2 as _RegistryService
 from .._internal_utils import _utils
 
 from .modelversion import RegisteredModelVersion
@@ -25,7 +25,7 @@ class RegisteredModelVersions(_utils.LazyList):
     def __init__(self, conn, conf):
         super(RegisteredModelVersions, self).__init__(
             conn, conf,
-            _RegisteredModelService.FindModelVersionRequest(),
+            _RegistryService.FindModelVersionRequest(),
         )
 
     def __repr__(self):


### PR DESCRIPTION
Also @nhatsmrt to review.

`RegistryService_pb2` was being imported as either `_RegisteredModelService` or `_ModelVersionService`, so I'm renaming it to `_RegistryService` for consistency (also to be consistent with the rest of the Client, which tries to keep the original proto file name).