### PR TITLE
Fix endpoint update test

### DIFF
--- a/client/verta/tests/test_endpoint/test_endpoint.py
+++ b/client/verta/tests/test_endpoint/test_endpoint.py
@@ -320,7 +320,7 @@ class TestEndpoint:
         x = model_for_deployment['train_features'].iloc[1].values
         deployed_model = endpoint.get_deployed_model()
 
-        assert deployed_model.predict([x]) == model.predict([x])
+        assert np.allclose(deployed_model.predict([x]), model.predict([x]))
         deployed_model_curl = deployed_model.get_curl()
         assert endpoint.path in deployed_model_curl
 

--- a/client/verta/tests/test_endpoint/test_endpoint.py
+++ b/client/verta/tests/test_endpoint/test_endpoint.py
@@ -320,7 +320,7 @@ class TestEndpoint:
         x = model_for_deployment['train_features'].iloc[1].values
         deployed_model = endpoint.get_deployed_model()
 
-        assert deployed_model.predict([x]) == [2]
+        assert deployed_model.predict([x]) == model.predict([x])
         deployed_model_curl = deployed_model.get_curl()
         assert endpoint.path in deployed_model_curl
 

--- a/client/verta/verta/_deployment/endpoint.py
+++ b/client/verta/verta/_deployment/endpoint.py
@@ -164,13 +164,13 @@ class Endpoint(object):
             An Experiment Run or a Model Version with a model logged.
         strategy : :class:`~verta.deployment.update._strategies._UpdateStrategy`
             Strategy (direct or canary) for updating the Endpoint.
-        wait : bool
+        wait : bool, default False
             Whether to wait for the Endpoint to finish updating before returning.
-        resources : list of :class:`~verta.deployment.resources._Resource`
+        resources : list of :class:`~verta.deployment.resources._Resource`, optional
             Resources allowed for the updated Endpoint.
-        autoscaling : :class:`~verta.deployment.autoscaling._autoscaling.Autoscaling`
+        autoscaling : :class:`~verta.deployment.autoscaling._autoscaling.Autoscaling`, optional
             Autoscaling condition for the updated Endpoint.
-        env_vars : dict of str to str
+        env_vars : dict of str to str, optional
             Environment variables.
 
         Returns


### PR DESCRIPTION
@nhatsmrt to review.

Model predictions may vary run to run, so we should check the deployed model against the original model, rather than hardcoding `[2]`