### PR TITLE
Refactor Endpoint._form_update_body()

### DIFF
--- a/client/verta/tests/test_endpoint/test_endpoint.py
+++ b/client/verta/tests/test_endpoint/test_endpoint.py
@@ -283,7 +283,7 @@ class TestEndpoint:
 
         assert token is None
 
-    def test_form_update_body(self):
+    def test_create_update_body(self):
         endpoint = Endpoint(None, None, None, None)
         resources = [
             CpuMillis(500),
@@ -292,7 +292,7 @@ class TestEndpoint:
 
         env_vars = {'CUDA_VISIBLE_DEVICES': "1,2", "VERTA_HOST": "app.verta.ai", "GIT_TERMINAL_PROMPT" : "1"}
 
-        parameter_json = endpoint._form_update_body(resources, DirectUpdateStrategy(), None, env_vars, 0)
+        parameter_json = endpoint._create_update_body(resources, DirectUpdateStrategy(), None, env_vars, 0)
         assert parameter_json == {'build_id': 0, 'env': [{"name": 'CUDA_VISIBLE_DEVICES', 'value': '1,2'},
                                                          {'name': 'GIT_TERMINAL_PROMPT', 'value': '1'},
                                                          {"name": 'VERTA_HOST', 'value': 'app.verta.ai'}],

--- a/client/verta/tests/test_endpoint/test_endpoint.py
+++ b/client/verta/tests/test_endpoint/test_endpoint.py
@@ -292,7 +292,7 @@ class TestEndpoint:
 
         env_vars = {'CUDA_VISIBLE_DEVICES': "1,2", "VERTA_HOST": "app.verta.ai", "GIT_TERMINAL_PROMPT" : "1"}
 
-        parameter_json = endpoint._create_update_body(resources, DirectUpdateStrategy(), None, env_vars, 0)
+        parameter_json = endpoint._create_update_body(DirectUpdateStrategy(), resources, None, env_vars, 0)
         assert parameter_json == {'build_id': 0, 'env': [{"name": 'CUDA_VISIBLE_DEVICES', 'value': '1,2'},
                                                          {'name': 'GIT_TERMINAL_PROMPT', 'value': '1'},
                                                          {"name": 'VERTA_HOST', 'value': 'app.verta.ai'}],

--- a/client/verta/tests/test_endpoint/test_endpoint.py
+++ b/client/verta/tests/test_endpoint/test_endpoint.py
@@ -292,11 +292,16 @@ class TestEndpoint:
 
         env_vars = {'CUDA_VISIBLE_DEVICES': "1,2", "VERTA_HOST": "app.verta.ai", "GIT_TERMINAL_PROMPT" : "1"}
 
-        parameter_json = endpoint._create_update_body(DirectUpdateStrategy(), resources, None, env_vars, 0)
-        assert parameter_json == {'build_id': 0, 'env': [{"name": 'CUDA_VISIBLE_DEVICES', 'value': '1,2'},
-                                                         {'name': 'GIT_TERMINAL_PROMPT', 'value': '1'},
-                                                         {"name": 'VERTA_HOST', 'value': 'app.verta.ai'}],
-                                  'resources': {'cpu_millis': 500, 'memory': '500Mi'}, 'strategy': 'rollout'}
+        parameter_json = endpoint._create_update_body(DirectUpdateStrategy(), resources, None, env_vars)
+        assert parameter_json == {
+            'env': [
+                {"name": 'CUDA_VISIBLE_DEVICES', 'value': '1,2'},
+                {'name': 'GIT_TERMINAL_PROMPT', 'value': '1'},
+                {"name": 'VERTA_HOST', 'value': 'app.verta.ai'}
+            ],
+            'resources': {'cpu_millis': 500, 'memory': '500Mi'},
+            'strategy': 'rollout',
+        }
 
 
     def test_get_deployed_model(self, client, experiment_run, model_version, model_for_deployment, created_endpoints):

--- a/client/verta/verta/_deployment/endpoint.py
+++ b/client/verta/verta/_deployment/endpoint.py
@@ -408,19 +408,23 @@ class Endpoint(object):
             return None
         return tokens[0]['creator_request']['value']
 
-    def _create_update_body(self, strategy, resources, autoscaling, env_vars, build_id):
-        update_body = strategy._as_build_update_req_body(build_id)
-        if resources:
+    def _create_update_body(self, strategy, resources=None, autoscaling=None, env_vars=None, build_id=None):
+        update_body = strategy._as_build_update_req_body()
+
+        if resources is not None:
             update_body["resources"] = reduce(lambda resource_a, resource_b: merge_dicts(resource_a, resource_b),
                                               map(lambda resource: resource.to_dict(), resources))
 
-        if autoscaling:
+        if autoscaling is not None:
             update_body["autoscaling"] = autoscaling._as_dict()
 
-        if env_vars:
+        if env_vars is not None:
             update_body["env"] = list(
                 sorted(map(lambda env_var: {"name": env_var, "value": env_vars[env_var]}, env_vars),
                        key=lambda env_elem: env_elem["name"]))
+
+        if build_id is not None:
+            update_body['build_id'] = build_id
 
         # prepare body for update request
         return update_body

--- a/client/verta/verta/_deployment/endpoint.py
+++ b/client/verta/verta/_deployment/endpoint.py
@@ -200,7 +200,8 @@ class Endpoint(object):
         return self._update_from_build(build_id, strategy, wait, resources, autoscaling, env_vars)
 
     def _update_from_build(self, build_id, strategy, wait=False, resources=None, autoscaling=None, env_vars=None):
-        update_body = self._form_update_body(resources, strategy, autoscaling, env_vars, build_id)
+        update_body = self._create_update_body(resources, strategy, autoscaling, env_vars, build_id)
+        print(update_body)
 
         # Update stages with new build
         url = "{}://{}/api/v1/deployment/workspace/{}/endpoints/{}/stages/{}/update".format(
@@ -407,7 +408,7 @@ class Endpoint(object):
             return None
         return tokens[0]['creator_request']['value']
 
-    def _form_update_body(self, resources, strategy, autoscaling, env_vars, build_id):
+    def _create_update_body(self, resources, strategy, autoscaling, env_vars, build_id):
         update_body = strategy._as_build_update_req_body(build_id)
         if resources:
             update_body["resources"] = reduce(lambda resource_a, resource_b: merge_dicts(resource_a, resource_b),

--- a/client/verta/verta/_deployment/endpoint.py
+++ b/client/verta/verta/_deployment/endpoint.py
@@ -178,31 +178,17 @@ class Endpoint(object):
         status : dict of str to {None, bool, float, int, str, list, dict}
 
         """
-        if not isinstance(strategy, _UpdateStrategy):
-            raise TypeError("`strategy` must be an object from verta.deployment.strategies")
-
         if not isinstance(model_reference, (RegisteredModelVersion, experimentrun.ExperimentRun)):
             raise TypeError("`model_reference` must be an ExperimentRun or RegisteredModelVersion")
 
-        if autoscaling and not isinstance(autoscaling, Autoscaling):
-            raise TypeError("`autoscaling` must be an Autoscaling object")
+        update_body = self._create_update_body(strategy, resources, autoscaling, env_vars)
 
-        if env_vars:
-            env_vars_err_msg = "`env_vars` must be dictionary of str keys and str values"
-            if not isinstance(env_vars, dict):
-                raise TypeError(env_vars_err_msg)
-            for key, value in env_vars.items():
-                if not isinstance(key, six.string_types) or not isinstance(value, six.string_types):
-                    raise TypeError(env_vars_err_msg)
+        # create new build
+        update_body['build_id'] = self._create_build(model_reference)
 
-        # Create new build:
-        build_id = self._create_build(model_reference)
-        return self._update_from_build(build_id, strategy, wait, resources, autoscaling, env_vars)
+        return self._update_from_build(update_body, wait)
 
-    def _update_from_build(self, build_id, strategy, wait=False, resources=None, autoscaling=None, env_vars=None):
-        update_body = self._create_update_body(strategy, resources, autoscaling, env_vars, build_id)
-        print(update_body)
-
+    def _update_from_build(self, update_body, wait=False):
         # Update stages with new build
         url = "{}://{}/api/v1/deployment/workspace/{}/endpoints/{}/stages/{}/update".format(
             self._conn.scheme,
@@ -408,7 +394,25 @@ class Endpoint(object):
             return None
         return tokens[0]['creator_request']['value']
 
-    def _create_update_body(self, strategy, resources=None, autoscaling=None, env_vars=None, build_id=None):
+    def _create_update_body(self, strategy, resources=None, autoscaling=None, env_vars=None):
+        """
+        Converts endpoint update/config util classes into a JSON-friendly dict.
+
+        """
+        if not isinstance(strategy, _UpdateStrategy):
+            raise TypeError("`strategy` must be an object from verta.deployment.strategies")
+
+        if autoscaling and not isinstance(autoscaling, Autoscaling):
+            raise TypeError("`autoscaling` must be an Autoscaling object")
+
+        if env_vars:
+            env_vars_err_msg = "`env_vars` must be dictionary of str keys and str values"
+            if not isinstance(env_vars, dict):
+                raise TypeError(env_vars_err_msg)
+            for key, value in env_vars.items():
+                if not isinstance(key, six.string_types) or not isinstance(value, six.string_types):
+                    raise TypeError(env_vars_err_msg)
+
         update_body = strategy._as_build_update_req_body()
 
         if resources is not None:
@@ -423,10 +427,6 @@ class Endpoint(object):
                 sorted(map(lambda env_var: {"name": env_var, "value": env_vars[env_var]}, env_vars),
                        key=lambda env_elem: env_elem["name"]))
 
-        if build_id is not None:
-            update_body['build_id'] = build_id
-
-        # prepare body for update request
         return update_body
 
     def get_deployed_model(self):

--- a/client/verta/verta/_deployment/endpoint.py
+++ b/client/verta/verta/_deployment/endpoint.py
@@ -200,7 +200,7 @@ class Endpoint(object):
         return self._update_from_build(build_id, strategy, wait, resources, autoscaling, env_vars)
 
     def _update_from_build(self, build_id, strategy, wait=False, resources=None, autoscaling=None, env_vars=None):
-        update_body = self._create_update_body(resources, strategy, autoscaling, env_vars, build_id)
+        update_body = self._create_update_body(strategy, resources, autoscaling, env_vars, build_id)
         print(update_body)
 
         # Update stages with new build
@@ -408,7 +408,7 @@ class Endpoint(object):
             return None
         return tokens[0]['creator_request']['value']
 
-    def _create_update_body(self, resources, strategy, autoscaling, env_vars, build_id):
+    def _create_update_body(self, strategy, resources, autoscaling, env_vars, build_id):
         update_body = strategy._as_build_update_req_body(build_id)
         if resources:
             update_body["resources"] = reduce(lambda resource_a, resource_b: merge_dicts(resource_a, resource_b),

--- a/client/verta/verta/deployment/update/_strategies.py
+++ b/client/verta/verta/deployment/update/_strategies.py
@@ -11,7 +11,7 @@ class _UpdateStrategy(object):
     _STRATEGY = ""
 
     @abc.abstractmethod
-    def _as_build_update_req_body(self, build_id):
+    def _as_build_update_req_body(self):
         """
         Returns
         -------
@@ -24,9 +24,8 @@ class _UpdateStrategy(object):
 class DirectUpdateStrategy(_UpdateStrategy):
     _STRATEGY = "rollout"
 
-    def _as_build_update_req_body(self, build_id):
+    def _as_build_update_req_body(self):
         return {
-            'build_id': build_id,
             'strategy': self._STRATEGY,
         }
 
@@ -59,12 +58,11 @@ class CanaryUpdateStrategy(_UpdateStrategy):
         self._progress_step = step
         self._rules = []
 
-    def _as_build_update_req_body(self, build_id):
+    def _as_build_update_req_body(self):
         if not self._rules:
             raise RuntimeError("canary update strategy must have at least one rule")
 
         return {
-            'build_id': build_id,
             'strategy': self._STRATEGY,
             'canary_strategy': {
                 'progress_interval_seconds': self._progress_interval_seconds,


### PR DESCRIPTION
Enables #1361

Actually also refactors `Endpoint.update()` a little so that `_form_update_body()` (now `_create_update_body`) is more re-usable.

I'd recommend reviewing this commit-by-commit.

- rename `_form_update_body()` to `_create_update_body`, because "form" has been quite confusing for me (I kept interpreting it as a noun)
- removes `build_id` from Strategy's JSON conversion method, and instead assigns it in `Endpoint.update()`
- moves typechecks from `update()` to `_create_update_body()` so they're re-usable