### PR TITLE
VR-6058 Mulitpart upload loop sometimes raises UnboundLocalError

### DIFF
--- a/client/verta/verta/_registry/modelversion.py
+++ b/client/verta/verta/_registry/modelversion.py
@@ -511,11 +511,15 @@ class RegisteredModelVersion(_ModelDBRegistryEntity, _DeployableEntity):
 
                 # upload part
                 #     Retry connection errors, to make large multipart uploads more robust.
-                for _ in range(3):
+                for i in range(3):
                     try:
                         response = _utils.make_request("PUT", url, self._conn, data=part_stream)
-                    except requests.ConnectionError:  # e.g. broken pipe
+                    except requests.ConnectionError as err:  # e.g. broken pipe
                         time.sleep(1)
+
+                        if i == 2:
+                            raise err
+
                         continue  # try again
                     else:
                         break

--- a/client/verta/verta/_registry/modelversion.py
+++ b/client/verta/verta/_registry/modelversion.py
@@ -511,13 +511,14 @@ class RegisteredModelVersion(_ModelDBRegistryEntity, _DeployableEntity):
 
                 # upload part
                 #     Retry connection errors, to make large multipart uploads more robust.
-                for i in range(3):
+                MAX_TRIES = 3
+                for i in range(MAX_TRIES):
                     try:
                         response = _utils.make_request("PUT", url, self._conn, data=part_stream)
                     except requests.ConnectionError as err:  # e.g. broken pipe
                         time.sleep(1)
 
-                        if i == 2:
+                        if i == MAX_TRIES - 1:
                             raise err
 
                         continue  # try again

--- a/client/verta/verta/_repository/commit.py
+++ b/client/verta/verta/_repository/commit.py
@@ -225,13 +225,14 @@ class Commit(object):
 
                 # upload part
                 #     Retry connection errors, to make large multipart uploads more robust.
-                for i in range(3):
+                MAX_TRIES = 3
+                for i in range(MAX_TRIES):
                     try:
                         response = _utils.make_request("PUT", url, self._conn, data=part_stream)
                     except requests.ConnectionError as err:  # e.g. broken pipe
                         time.sleep(1)
 
-                        if i == 2:
+                        if i == MAX_TRIES - 1:
                             raise err
 
                         continue  # try again

--- a/client/verta/verta/_repository/commit.py
+++ b/client/verta/verta/_repository/commit.py
@@ -225,11 +225,15 @@ class Commit(object):
 
                 # upload part
                 #     Retry connection errors, to make large multipart uploads more robust.
-                for _ in range(3):
+                for i in range(3):
                     try:
                         response = _utils.make_request("PUT", url, self._conn, data=part_stream)
-                    except requests.ConnectionError:  # e.g. broken pipe
+                    except requests.ConnectionError as err:  # e.g. broken pipe
                         time.sleep(1)
+
+                        if i == 2:
+                            raise err
+
                         continue  # try again
                     else:
                         break

--- a/client/verta/verta/_tracking/experimentrun.py
+++ b/client/verta/verta/_tracking/experimentrun.py
@@ -300,13 +300,14 @@ class ExperimentRun(_DeployableEntity):
 
                 # upload part
                 #     Retry connection errors, to make large multipart uploads more robust.
-                for i in range(3):
+                MAX_TRIES = 3
+                for i in range(MAX_TRIES):
                     try:
                         response = _utils.make_request("PUT", url, self._conn, data=part_stream)
                     except requests.ConnectionError as err:  # e.g. broken pipe
                         time.sleep(1)
 
-                        if i == 2:
+                        if i == MAX_TRIES - 1:
                             raise err
 
                         continue  # try again

--- a/client/verta/verta/_tracking/experimentrun.py
+++ b/client/verta/verta/_tracking/experimentrun.py
@@ -300,11 +300,15 @@ class ExperimentRun(_DeployableEntity):
 
                 # upload part
                 #     Retry connection errors, to make large multipart uploads more robust.
-                for _ in range(3):
+                for i in range(3):
                     try:
                         response = _utils.make_request("PUT", url, self._conn, data=part_stream)
-                    except requests.ConnectionError:  # e.g. broken pipe
+                    except requests.ConnectionError as err:  # e.g. broken pipe
                         time.sleep(1)
+
+                        if i == 2:
+                            raise err
+
                         continue  # try again
                     else:
                         break


### PR DESCRIPTION
Seems to work (I tried disconnecting the network in the middle of uploading to test this). Not sure if there's a more pythonic/elegant way to achieve this effect though.