### PR TITLE
Add ones-place zero to JSON input to fix test

### DIFF
--- a/client/verta/docs/tutorials/deployment/endpoint_resources.rst
+++ b/client/verta/docs/tutorials/deployment/endpoint_resources.rst
@@ -41,7 +41,7 @@ Compute resources can also be configured via the CLI:
 
     verta deployment update endpoint /some-path --model-version-id "<id>" \
         --strategy direct \
-        --resources '{"cpu": .25, "memory": "512Mi"}'
+        --resources '{"cpu": 0.25, "memory": "512Mi"}'
 
 ``--resources`` takes a JSON string representing its values. The Python API documentation for
 :ref:`update-resources` contains a JSON-equivalent example for the object.

--- a/client/verta/docs/tutorials/deployment/endpoint_update_config.rst
+++ b/client/verta/docs/tutorials/deployment/endpoint_update_config.rst
@@ -31,7 +31,7 @@ For example:
                 ]
             },
             "env_vars": {"VERTA_HOST": "<Verta host URL>"},
-            "resources": {"cpu": .25, "memory": "100M"}
+            "resources": {"cpu": 0.25, "memory": "100M"}
         }
 
 .. TODO: Link to configuration file fields.

--- a/client/verta/docs/tutorials/workflow.rst
+++ b/client/verta/docs/tutorials/workflow.rst
@@ -84,7 +84,7 @@ We also need to define some hyperparameters to specify a configuration for our m
 
     hyperparams = {'kernel': "rbf",
                    'C': 1e-2,
-                   'gamma': .2}
+                   'gamma': 0.2}
 
 Then we can finally train a model on our data:
 

--- a/client/verta/tests/test_cli/test_endpoint.py
+++ b/client/verta/tests/test_cli/test_endpoint.py
@@ -10,6 +10,7 @@ from verta._cli import cli
 from verta._internal_utils import _utils
 from verta.environment import Python
 from verta.endpoint.update._strategies import DirectUpdateStrategy
+from verta.endpoint.resources import Resources
 
 from ..utils import get_build_ids
 
@@ -364,7 +365,7 @@ class TestUpdate:
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
         experiment_run.log_requirements(['scikit-learn'])
 
-        resources = '{"cpu": .25, "memory": "100M"}'
+        resources = '{"cpu": 0.25, "memory": "100M"}'
 
         runner = CliRunner()
         result = runner.invoke(
@@ -373,7 +374,8 @@ class TestUpdate:
              '--resources', resources],
         )
         assert not result.exception
-        assert endpoint.get_update_status()['update_request']['resources'] == json.loads(resources)
+        resources_dict = Resources._from_dict(json.loads(resources))._as_dict()  # config is `cpu`, wire is `cpu_millis`
+        assert endpoint.get_update_status()['update_request']['resources'] == resources_dict
 
     def test_update_autoscaling(self, client, created_endpoints, experiment_run, model_for_deployment):
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])

--- a/client/verta/tests/test_endpoint/test_endpoint.py
+++ b/client/verta/tests/test_endpoint/test_endpoint.py
@@ -537,7 +537,7 @@ class TestEndpoint:
                 ]
             },
             "env_vars": {"VERTA_HOST": "app.verta.ai"},
-            "resources": {"cpu": .25, "memory": "100M"}
+            "resources": {"cpu": 0.25, "memory": "100M"}
         }
 
         filepath = "config.json"

--- a/client/verta/verta/_cli/deployment/update.py
+++ b/client/verta/verta/_cli/deployment/update.py
@@ -93,9 +93,9 @@ def update_endpoint(path, run_id, model_version_id, filename, strategy, resource
             strategy_obj.add_rule(_UpdateRule._from_dict(json.loads(rule)))
 
     if resources:
-        resources_list = Resources._from_dict(json.loads(resources))
+        resources = Resources._from_dict(json.loads(resources))
     else:
-        resources_list = None
+        resources = None
 
     if autoscaling:
         autoscaling_obj = Autoscaling._from_dict(json.loads(autoscaling))
@@ -109,4 +109,4 @@ def update_endpoint(path, run_id, model_version_id, filename, strategy, resource
     else:
         env_vars_dict = None
 
-    endpoint.update(model_reference, strategy_obj, resources=resources_list, autoscaling=autoscaling_obj, env_vars=env_vars_dict)
+    endpoint.update(model_reference, strategy_obj, resources=resources, autoscaling=autoscaling_obj, env_vars=env_vars_dict)

--- a/client/verta/verta/endpoint/resources.py
+++ b/client/verta/verta/endpoint/resources.py
@@ -24,7 +24,7 @@ class Resources(object):
     .. code-block:: json
 
         {
-            "resources": {"cpu": .25, "memory": "512Mi"}
+            "resources": {"cpu": 0.25, "memory": "512Mi"}
         }
 
     Parameters


### PR DESCRIPTION
It seems `'.25'` is not valid JSON, and should be `'0.25'` instead.