### PR TITLE
VR-3285: Support Python 3.8 (don't use ast to parse find)

### DIFF
--- a/client/verta/tests/test_query.py
+++ b/client/verta/tests/test_query.py
@@ -74,6 +74,15 @@ class TestFind:
         result = proj.expt_runs.find("experiment_id == '{}'".format(expt.id))
         assert set(run.id for run in result) == set(run.id for run in runs)
 
+    def test_name(self, client):
+        proj = client.set_project()
+        run = client.set_experiment_run()
+
+        # no quotes around value!
+        result = proj.expt_runs.find("name == {}".format(run.name))
+        assert len(result) == 1
+        assert result[0].id == run.id
+
     @pytest.mark.skip(reason="not implemented")
     def test_date_created(self, client):
         key = "date_created"

--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import ast
 import copy
 import datetime
 import glob
@@ -310,22 +309,11 @@ class LazyList(object):
 
             try:
                 value = float(value)
-            except ValueError:  # not a number
-                # parse value
-                try:
-                    expr_node = ast.parse(value, mode='eval')
-                except SyntaxError:
-                    e = ValueError("value `{}` must be a number or string literal".format(value))
-                    six.raise_from(e, None)
-                value_node = expr_node.body
-                if type(value_node) is ast.Str:
-                    value = value_node.s
-                elif type(value_node) is ast.Compare:
-                    e = ValueError("predicate `{}` must be a two-operand comparison".format(predicate))
-                    six.raise_from(e, None)
-                else:
-                    e = ValueError("value `{}` must be a number or string literal".format(value))
-                    six.raise_from(e, None)
+            except ValueError:  # not a number, so process as string
+                # maintain old behavior where input would be wrapped in quotes
+                if ((value.startswith('\'') and value.endswith('\''))
+                        or (value.startswith('"') and value.endswith('"'))):
+                    value = value[1:-1]
 
             new_list._msg.predicates.append(  # pylint: disable=no-member
                 _CommonCommonService.KeyValueQuery(


### PR DESCRIPTION
Intern-Michael decided that `ast` was the correct solution for this simple string parsing logic.
`ast` is not the correct solution.

---
`.find()` is broken in 3.8 because of changes to `ast`; this PR resolves that.
Incidentally, this also enables `.find("name == foo")` instead of `.find("name == \"foo\"")`, which I know was an ask at one point but I can't find the ticket for it.