### PR TITLE
Quicken rollout to resolve test failure

### DIFF
--- a/client/verta/tests/test_endpoint/test_endpoint.py
+++ b/client/verta/tests/test_endpoint/test_endpoint.py
@@ -228,8 +228,8 @@ class TestEndpoint:
             "run_id": experiment_run.id,
             "strategy": "canary",
             "canary_strategy": {
-                "progress_step": 0.05,
-                "progress_interval_seconds": 30,
+                "progress_step": 0.5,
+                "progress_interval_seconds": 1,
                 "rules": [
                     {"rule": "latency_avg_max",
                      "rule_parameters": [
@@ -270,8 +270,8 @@ class TestEndpoint:
             "run_id": experiment_run.id,
             "strategy": "canary",
             "canary_strategy": {
-                "progress_step": 0.05,
-                "progress_interval_seconds": 30,
+                "progress_step": 0.5,
+                "progress_interval_seconds": 1,
                 "rules": [
                     {"rule": "latency_avg_max",
                      "rule_parameters": [
@@ -429,8 +429,8 @@ class TestEndpoint:
             "model_version_id": model_version.id,
             "strategy": "canary",
             "canary_strategy": {
-                "progress_step": 0.05,
-                "progress_interval_seconds": 30,
+                "progress_step": 0.5,
+                "progress_interval_seconds": 1,
                 "rules": [
                     {"rule": "latency_avg_max",
                      "rule_parameters": [
@@ -453,7 +453,8 @@ class TestEndpoint:
         endpoint.update_from_config(filepath, wait=True)
 
         test_data = np.random.random((4, 12))
-        assert np.array_equal(endpoint.get_deployed_model().predict(test_data), classifier.predict(test_data))
+        prediction = endpoint.get_deployed_model().predict(test_data)
+        assert np.array_equal(prediction, classifier.predict(test_data))
 
     def test_update_autoscaling(self, client, created_endpoints, experiment_run, model_for_deployment):
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])


### PR DESCRIPTION
`test_update_from_json_config_model_version` had been failing because prediction endpoint returns `503`s for more than three minutes after the new build is completed!

Shortening the duration of the canary update reduces that period to about 1 second.