### PR TITLE
sort datasetversions on creation, support sort on getLatestDatasetVersion

### DIFF
--- a/backend/src/main/java/ai/verta/modeldb/datasetVersion/DatasetVersionServiceImpl.java
+++ b/backend/src/main/java/ai/verta/modeldb/datasetVersion/DatasetVersionServiceImpl.java
@@ -371,13 +371,20 @@ public class DatasetVersionServiceImpl extends DatasetVersionServiceImplBase {
         repositoryEntity =
             repositoryDAO.getProtectedRepositoryById(repositoryIdentification, false);
       }
+      List<DatasetVersion> datasetVersions =
+          new ArrayList<>(
+              convertRepoDatasetVersions(repositoryEntity, commitPaginationDTO.getCommits()));
 
-      DatasetVersion datasetVersion =
-          convertRepoDatasetVersions(repositoryEntity, commitPaginationDTO.getCommits()).get(0);
+      if (datasetVersions.size() != 1) {
+        logAndThrowError(
+            "No datasetVersion found for dataset '" + request.getDatasetId() + "'",
+            Code.NOT_FOUND_VALUE,
+            Any.pack(GetLatestDatasetVersionByDatasetId.Response.getDefaultInstance()));
+      }
       /*Build response*/
       responseObserver.onNext(
           GetLatestDatasetVersionByDatasetId.Response.newBuilder()
-              .setDatasetVersion(datasetVersion)
+              .setDatasetVersion(datasetVersions.get(0))
               .build());
       responseObserver.onCompleted();
 

--- a/backend/src/main/java/ai/verta/modeldb/versioning/CommitDAORdbImpl.java
+++ b/backend/src/main/java/ai/verta/modeldb/versioning/CommitDAORdbImpl.java
@@ -922,7 +922,7 @@ public class CommitDAORdbImpl implements CommitDAO {
           commitPaginationDTO.setTotalRecords(0L);
           return commitPaginationDTO;
         }
-      } else {
+      } else if (!isDatasetVersion || (workspaceName != null && !workspaceName.isEmpty())) {
         WorkspaceDTO workspaceDTO =
             roleService.getWorkspaceDTOByWorkspaceName(
                 currentLoginUserInfo, request.getWorkspaceName());
@@ -1194,7 +1194,12 @@ public class CommitDAORdbImpl implements CommitDAO {
           sortKey = ModelDBConstants.DATE_UPDATED;
         }
       } else {
-        sortKey = ModelDBConstants.DATE_UPDATED;
+        if (isDatasetVersion) {
+          sortKey = ModelDBConstants.DATE_CREATED;
+          ascending = false;
+        } else {
+          sortKey = ModelDBConstants.DATE_UPDATED;
+        }
       }
 
       StringBuilder orderClause =


### PR DESCRIPTION
Dataset version default sorting on creation instead of updation elsewhere
fix getLatestDatasetVersion which returns the last created datasetversion
make findDatasetVersion work across workspaces