### PR TITLE
VR-6553 Enable DatasetVersion attributes CRU for Scala Client

### DIFF
--- a/client/scala/src/main/scala/ai/verta/dataset_versioning/DatasetVersion.scala
+++ b/client/scala/src/main/scala/ai/verta/dataset_versioning/DatasetVersion.scala
@@ -1,0 +1,67 @@
+package ai.verta.dataset_versioning
+
+import scala.util.{Try, Success, Failure}
+import scala.concurrent.ExecutionContext
+
+import ai.verta.blobs.dataset.PathBlob
+import ai.verta.client.entities.utils._
+import ai.verta.swagger._public.modeldb.model._
+import ai.verta.swagger._public.modeldb.versioning.model._
+import ai.verta.swagger.client.ClientSet
+
+/** Represents a ModelDB dataset version from path.
+ */
+class DatasetVersion(
+  private val clientSet: ClientSet,
+  private val dataset: Dataset,
+  private val datasetVersion: ModeldbDatasetVersion
+) {
+  /** ID of the dataset version. */
+  def id = datasetVersion.id.get
+
+  // TODO: add overwrite
+  /** Adds potentially multiple attributes to this dataset version.
+   *  @param vals Attributes name and value (String, Int, or Double)
+   */
+  def addAttributes(vals: Map[String, ValueType])(implicit ec: ExecutionContext): Try[Unit] = {
+    val valsList = KVHandler.mapToKVList(vals)
+    if (valsList.isFailure) Failure(valsList.failed.get) else
+      clientSet.datasetVersionService.DatasetVersionService_addDatasetVersionAttributes(ModeldbAddDatasetVersionAttributes(
+        id = Some(id),
+        attributes = valsList.toOption
+      )).map(_ => {})
+  }
+
+  /** Adds an attribute to this dataset version.
+   *  @param key Name of the attribute
+   *  @param value Value of the attribute. Could be String, Int, or Double
+   */
+  def addAttribute(key: String, value: ValueType)(implicit ec: ExecutionContext) =
+    addAttributes(Map(key -> value))
+
+  /** Gets all attributes of this dataset version.
+   *  @return All the attributes (String, Int, or Double)
+   */
+  def getAttributes()(implicit ec: ExecutionContext): Try[Map[String, ValueType]] = {
+    getMessage()
+      .flatMap(dataset_version => {
+        if (dataset_version.attributes.isEmpty)
+          Success(Map[String, ValueType]())
+        else
+          KVHandler.kvListToMap(dataset_version.attributes.get)
+      })
+  }
+
+  /** Get attribute with the given key of this dataset version.
+   *  @param key key of the attribute.
+   @  @return value stored at the attribute.
+   */
+  def getAttribute(key: String)(implicit ec: ExecutionContext): Try[Option[ValueType]] =
+    getAttributes().map(attributes => attributes.get(key))
+
+  // get the latest version of the proto message
+  private def getMessage()(implicit ec: ExecutionContext): Try[ModeldbDatasetVersion] =
+    clientSet.datasetVersionService.DatasetVersionService_getDatasetVersionById(Some(id)).map(
+      response => response.dataset_version.get
+    )
+}

--- a/client/scala/src/test/scala/ai/verta/dataset_versioning/TestDataset.scala
+++ b/client/scala/src/test/scala/ai/verta/dataset_versioning/TestDataset.scala
@@ -1,0 +1,55 @@
+package ai.verta.dataset_versioning
+
+import ai.verta.client._
+import ai.verta.dataset_versioning._
+import ai.verta.blobs.dataset.S3Location
+import ai.verta.client.entities.utils.ValueType
+
+import scala.concurrent.ExecutionContext
+import scala.language.reflectiveCalls
+import scala.util.{Try, Success, Failure}
+
+import org.scalatest.FunSuite
+import org.scalatest.Assertions._
+
+class TestDataset extends FunSuite {
+  implicit val ec = ExecutionContext.global
+
+  def fixture =
+    new {
+        val client = new Client(ClientConnection.fromEnvironment())
+        val dataset = client.getOrCreateDataset("my dataset").get
+    }
+
+  def cleanup(
+    f: AnyRef{val client: Client; val dataset: Dataset}
+  ) = {
+    f.client.deleteDataset(f.dataset.id)
+    f.client.close()
+  }
+
+  test("add and retrieve version's attributes") {
+    val f = fixture
+
+    try {
+      val workingDir = System.getProperty("user.dir")
+      val testDir = workingDir + "/src/test/scala/ai/verta/blobs/testdir"
+      val version = f.dataset.createPathVersion(List(testDir)).get
+
+      version.addAttribute("some", 0.5)
+      version.addAttribute("int", 4)
+      version.addAttributes(Map("other" -> 0.3, "string" -> "desc"))
+
+      assert(version.getAttribute("some").get.get.asDouble.get equals 0.5)
+      assert(version.getAttribute("other").get.get.asDouble.get equals 0.3)
+      assert(version.getAttribute("int").get.get.asBigInt.get equals 4)
+      assert(version.getAttribute("string").get.get.asString.get equals "desc")
+
+      assert(version.getAttributes().get.equals(
+        Map[String, ValueType]("some" -> 0.5, "int" -> 4, "other" -> 0.3, "string" -> "desc")
+      ))
+    } finally {
+      cleanup(f)
+    }
+  }
+}


### PR DESCRIPTION
Same as #1473, but without stuff from other PRs so can be reviewed independently.
Test fails due in (outdated) OSS setup, but passes in dev.