### PR TITLE
Fix null pointer while MDB throwing custom exception

### DIFF
--- a/backend/src/main/java/ai/verta/modeldb/utils/ModelDBUtils.java
+++ b/backend/src/main/java/ai/verta/modeldb/utils/ModelDBUtils.java
@@ -512,7 +512,8 @@ public class ModelDBUtils {
     }
     LOGGER.warn(
         "Detected exception of type {}, which is not categorized as retryable",
-        communicationsException.getCause().getClass());
+        ex,
+        communicationsException);
     return false;
   }
 


### PR DESCRIPTION
It is happening due to this line https://github.com/VertaAI/modeldb/pull/1426/files#diff-678c1a74bf0f4a56c36bdfba5112c87eR515 so if there is the MDB custom exception then that line throw null pointer for `getClause()`