### PR TITLE
Separate S3 DatasetVersion test into separate case

### DIFF
--- a/client/verta/tests/test_dataset_versioning/test_dataset_version.py
+++ b/client/verta/tests/test_dataset_versioning/test_dataset_version.py
@@ -8,11 +8,12 @@ class TestDatasetVersion:
         name = verta._internal_utils._utils.generate_default_name()
         dataset = client._set_dataset2(name)
         created_datasets.append(dataset)
-        dataset_version = dataset.create_path_version(paths=["modelapi_hypothesis/",
-                                                             "modelapi_hypothesis/api_generator.py"])
+        dataset_version = dataset.create_path_version(paths=["modelapi_hypothesis/"])
+        dataset_version2 = dataset.create_path_version(paths=["modelapi_hypothesis/api_generator.py"])
 
         assert dataset_version.id == client._get_dataset_version2(id=dataset_version.id).id
-        assert dataset_version.id == dataset.get_latest_version().id
+        assert dataset_version2.id == client._get_dataset_version2(id=dataset_version2.id).id
+        assert dataset_version2.id == dataset.get_latest_version().id
 
     def test_create_get_s3(self, client, created_datasets):
         pytest.importorskip("boto3")
@@ -23,7 +24,6 @@ class TestDatasetVersion:
         dataset_version = dataset.create_s3_version(paths=["s3://verta-starter/", "s3://verta-starter/census-test.csv"])
 
         assert dataset_version.id == client._get_dataset_version2(dataset_version.id).id
-        assert dataset_version.id == dataset.get_latest_version().id
 
     def test_description(self, client, created_datasets):
         name = verta._internal_utils._utils.generate_default_name()

--- a/client/verta/tests/test_dataset_versioning/test_dataset_version.py
+++ b/client/verta/tests/test_dataset_versioning/test_dataset_version.py
@@ -11,7 +11,7 @@ class TestDatasetVersion:
         dataset_version = dataset.create_path_version(paths=["modelapi_hypothesis/"])
         dataset_version2 = dataset.create_path_version(paths=["modelapi_hypothesis/api_generator.py"])
 
-        assert dataset_version.id == client._get_dataset_version2(id=dataset_version.id).id
+        assert dataset_version.id == client._get_dataset_version2(dataset_version.id).id
         assert dataset_version2.id == client._get_dataset_version2(id=dataset_version2.id).id
         assert dataset_version2.id == dataset.get_latest_version().id
 

--- a/client/verta/tests/test_dataset_versioning/test_dataset_version.py
+++ b/client/verta/tests/test_dataset_versioning/test_dataset_version.py
@@ -1,17 +1,29 @@
+import pytest
+
 import verta
 
+
 class TestDatasetVersion:
-    def test_create_get(self, client, created_datasets):
+    def test_create_get_path(self, client, created_datasets):
+        name = verta._internal_utils._utils.generate_default_name()
+        dataset = client._set_dataset2(name)
+        created_datasets.append(dataset)
+        dataset_version = dataset.create_path_version(paths=["modelapi_hypothesis/",
+                                                             "modelapi_hypothesis/api_generator.py"])
+
+        assert dataset_version.id == client._get_dataset_version2(id=dataset_version.id).id
+        assert dataset_version.id == dataset.get_latest_version().id
+
+    def test_create_get_s3(self, client, created_datasets):
+        pytest.importorskip("boto3")
+
         name = verta._internal_utils._utils.generate_default_name()
         dataset = client._set_dataset2(name)
         created_datasets.append(dataset)
         dataset_version = dataset.create_s3_version(paths=["s3://verta-starter/", "s3://verta-starter/census-test.csv"])
-        dataset_version2 = dataset.create_path_version(paths=["modelapi_hypothesis/",
-                                                              "modelapi_hypothesis/api_generator.py"])
 
         assert dataset_version.id == client._get_dataset_version2(dataset_version.id).id
-        assert dataset_version2.id == client._get_dataset_version2(id=dataset_version2.id).id
-        assert dataset_version2.id == dataset.get_latest_version().id
+        assert dataset_version.id == dataset.get_latest_version().id
 
     def test_description(self, client, created_datasets):
         name = verta._internal_utils._utils.generate_default_name()
@@ -28,11 +40,11 @@ class TestDatasetVersion:
         assert dataset_version.get_description() == updated_description
 
         assert client._get_dataset_version2(id=dataset_version.id).get_description() == updated_description
-        
+
     def test_tags(self, client, created_datasets):
         name = verta._internal_utils._utils.generate_default_name()
         dataset = client._set_dataset2(name)
-        dataset_version = dataset.create_path_version(paths=["modelapi_hypothesis/", 
+        dataset_version = dataset.create_path_version(paths=["modelapi_hypothesis/",
                                                              "modelapi_hypothesis/api_generator.py"],
                                                       tags=["tag1", "tag2"])
         created_datasets.append(dataset)
@@ -74,4 +86,3 @@ class TestDatasetVersion:
 
         # Deleting non-existing key:
         dataset_version.del_attribute("non-existing")
-


### PR DESCRIPTION
The test was failing (instead of skipping) when `boto3` isn't installed;
I've split the S3 version creation into its own case so that it can gracefully check for the import.