### PR TITLE
Don't test overwrite for DatasetVersion attributes

### DIFF
--- a/client/verta/tests/test_dataset_versioning/test_dataset_version.py
+++ b/client/verta/tests/test_dataset_versioning/test_dataset_version.py
@@ -28,11 +28,11 @@ class TestDatasetVersion:
         assert dataset_version.get_description() == updated_description
 
         assert client._get_dataset_version2(id=dataset_version.id).get_description() == updated_description
-        
+
     def test_tags(self, client, created_datasets):
         name = verta._internal_utils._utils.generate_default_name()
         dataset = client._set_dataset2(name)
-        dataset_version = dataset.create_path_version(paths=["modelapi_hypothesis/", 
+        dataset_version = dataset.create_path_version(paths=["modelapi_hypothesis/",
                                                              "modelapi_hypothesis/api_generator.py"],
                                                       tags=["tag1", "tag2"])
         created_datasets.append(dataset)
@@ -64,14 +64,14 @@ class TestDatasetVersion:
         assert dataset_version.get_attribute("float-attr") == 0.4
 
         # Test overwriting
-        dataset_version.add_attribute("int-attr", 15)
-        assert dataset_version.get_attribute("int-attr") == 15
+        # TODO: add overwrite test when it is enabled on backend
+        # dataset_version.add_attribute("int-attr", 15)
+        # assert dataset_version.get_attribute("int-attr") == 15
 
         # Test deleting:
         dataset_version.del_attribute('string-attr')
-        assert dataset_version.get_attributes() == {"int-attr": 15, "bool-attr": False,
+        assert dataset_version.get_attributes() == {"int-attr": 12, "bool-attr": False,
                                                     "float-attr": 0.4}
 
         # Deleting non-existing key:
         dataset_version.del_attribute("non-existing")
-


### PR DESCRIPTION
The backend currently improperly allows duplicate keys, and there's no overwrite flag on the API, so this shouldn't be tested for now (causes stochastic failures)