### PR TITLE
VR-6718 Support list as value type in attributes for Scala client

### DIFF
--- a/client/scala/src/main/scala/ai/verta/client/entities/utils/KVHandler.scala
+++ b/client/scala/src/main/scala/ai/verta/client/entities/utils/KVHandler.scala
@@ -13,6 +13,8 @@ object KVHandler {
       Success(v.int_value.get)
     else if (v.string_value.isDefined)
       Success(v.string_value.get)
+    else if (v.list_value.isDefined)
+      Try(v.list_value.get.map(obj => convertToValueType(obj, err)).map(_.get))
     else
       Failure(new IllegalArgumentException(err))
   }
@@ -22,6 +24,9 @@ object KVHandler {
       case IntValueType(x) => Success(new GenericObject(int_value = Some(x)))
       case DoubleValueType(x) => Success(new GenericObject(double_value = Some(x)))
       case StringValueType(x) => Success(new GenericObject(string_value = Some(x)))
+      case ListValueType(xs) =>
+        Try(xs.map(x => convertFromValueType(x, err)).map(_.get))
+          .map(list => new GenericObject(list_value = Some(list)))
     }
   }
 

--- a/client/scala/src/main/scala/ai/verta/client/entities/utils/ValueType.scala
+++ b/client/scala/src/main/scala/ai/verta/client/entities/utils/ValueType.scala
@@ -11,6 +11,7 @@ sealed trait ValueType {
   def asBigInt: Option[BigInt] = None
   def asString: Option[String] = None
   def asDouble: Option[Double] = None
+  def asList: Option[List[ValueType]] = None
 }
 
 /** Represent (Big) integer observations, metrics, hyperparameters, etc.
@@ -32,6 +33,13 @@ case class StringValueType(private val s: String) extends ValueType {
  */
 case class DoubleValueType(private val d: Double) extends ValueType {
   override def asDouble = Some(d)
+}
+
+/** Represent list values of attributes.
+ *  User should not instantiate this class themselves but rely on implicit conversion
+ */
+case class ListValueType(private val l: List[ValueType]) extends ValueType {
+  override def asList: Option[List[ValueType]] = Some(l)
 }
 
 object ValueType {
@@ -58,4 +66,10 @@ object ValueType {
    *  @return the equivalent ValueType instance
    */
   implicit def fromDouble(d: Double): ValueType = DoubleValueType(d)
+
+  /** Implicit conversion method to convert a list to ValueType
+   *  @param l the list
+   *  @return the equivalent ValueType instance
+   */
+  implicit def fromList(l: List[ValueType]): ValueType = ListValueType(l)
 }

--- a/client/scala/src/main/scala/ai/verta/client/entities/utils/ValueType.scala
+++ b/client/scala/src/main/scala/ai/verta/client/entities/utils/ValueType.scala
@@ -2,7 +2,7 @@ package ai.verta.client.entities.utils
 
 import scala.language.implicitConversions
 
-/** Union type of (Big)Int, String, and Double
+/** Union type of (Big)Int, String, Double, and List
  *  Represent the possible type of observations, metrics, hyperparameters, etc.
  *  Instances of subtypes of this trait should be instantiated via implicit conversion
  *  Use asBigInt, asString, asDouble to get the actual value

--- a/client/scala/src/main/scala/ai/verta/client/entities/utils/ValueType.scala
+++ b/client/scala/src/main/scala/ai/verta/client/entities/utils/ValueType.scala
@@ -35,7 +35,7 @@ case class DoubleValueType(private val d: Double) extends ValueType {
   override def asDouble = Some(d)
 }
 
-/** Represent list values of attributes.
+/** Represent list values.
  *  User should not instantiate this class themselves but rely on implicit conversion
  */
 case class ListValueType(private val l: List[ValueType]) extends ValueType {

--- a/client/scala/src/main/scala/ai/verta/client/entities/utils/ValueType.scala
+++ b/client/scala/src/main/scala/ai/verta/client/entities/utils/ValueType.scala
@@ -5,7 +5,7 @@ import scala.language.implicitConversions
 /** Union type of (Big)Int, String, Double, and List.
  *  Represent the possible type of observations, metrics, hyperparameters, attribute values, etc.
  *  Instances of subtypes of this trait should be instantiated via implicit conversion.
- *  Use asBigInt, asString, asDouble to get the actual value.
+ *  Use asBigInt, asString, asDouble, asList to get the actual value.
  */
 sealed trait ValueType {
   def asBigInt: Option[BigInt] = None

--- a/client/scala/src/main/scala/ai/verta/client/entities/utils/ValueType.scala
+++ b/client/scala/src/main/scala/ai/verta/client/entities/utils/ValueType.scala
@@ -2,7 +2,7 @@ package ai.verta.client.entities.utils
 
 import scala.language.implicitConversions
 
-/** Union type of (Big)Int, String, Double, and List
+/** Union type of (Big)Int, String, Double, and List.
  *  Represent the possible type of observations, metrics, hyperparameters, etc.
  *  Instances of subtypes of this trait should be instantiated via implicit conversion
  *  Use asBigInt, asString, asDouble to get the actual value

--- a/client/scala/src/main/scala/ai/verta/client/entities/utils/ValueType.scala
+++ b/client/scala/src/main/scala/ai/verta/client/entities/utils/ValueType.scala
@@ -3,9 +3,9 @@ package ai.verta.client.entities.utils
 import scala.language.implicitConversions
 
 /** Union type of (Big)Int, String, Double, and List.
- *  Represent the possible type of observations, metrics, hyperparameters, etc.
- *  Instances of subtypes of this trait should be instantiated via implicit conversion
- *  Use asBigInt, asString, asDouble to get the actual value
+ *  Represent the possible type of observations, metrics, hyperparameters, attribute values, etc.
+ *  Instances of subtypes of this trait should be instantiated via implicit conversion.
+ *  Use asBigInt, asString, asDouble to get the actual value.
  */
 sealed trait ValueType {
   def asBigInt: Option[BigInt] = None

--- a/client/scala/src/main/scala/ai/verta/swagger/client/objects/GenericObject.scala
+++ b/client/scala/src/main/scala/ai/verta/swagger/client/objects/GenericObject.scala
@@ -22,6 +22,8 @@ object GenericObject {
       JDouble(obj.double_value.get)
     else if (obj.int_value.isDefined)
       JInt(obj.int_value.get)
+    else if (obj.list_value.isDefined)
+      JArray(obj.list_value.get.map(toJson))
     else
       throw new Exception(s"unknown type for ${obj.toString} (${obj.getClass.toString})")
   }
@@ -31,6 +33,7 @@ object GenericObject {
       case JString(x) => GenericObject(string_value = Some(x))
       case JDouble(x) => GenericObject(double_value = Some(x))
       case JInt(x) => GenericObject(int_value = Some(x))
+      case JArray(elements) => GenericObject(list_value = Some(elements.map(fromJson)))
       case _ => throw new Exception(s"unknown type for ${v.toString} (${v.getClass.toString})")
     }
 }

--- a/client/scala/src/test/scala/ai/verta/client/entities/TestExperimentRun.scala
+++ b/client/scala/src/test/scala/ai/verta/client/entities/TestExperimentRun.scala
@@ -69,12 +69,17 @@ class TestExperimentRun extends FunSuite {
     try {
       logger(f.expRun)("some", 0.5)
       logger(f.expRun)("int", 4)
+
+      val listMetadata = List[ValueType](4, 0.5, "some-value")
+      logger(f.expRun)("list", listMetadata)
+
       multiLogger(f.expRun)(Map("other" -> 0.3, "string" -> "desc"))
 
       assert(getter(f.expRun)("some").get.get.asDouble.get equals 0.5)
       assert(getter(f.expRun)("other").get.get.asDouble.get equals 0.3)
       assert(getter(f.expRun)("int").get.get.asBigInt.get equals 4)
       assert(getter(f.expRun)("string").get.get.asString.get equals "desc")
+      assert(getter(f.expRun)("list").get.get.asList.get equals listMetadata)
 
       if (someGetter.isDefined)
         assert(someGetter.get(f.expRun)(List("some", "other")).get  equals
@@ -82,7 +87,10 @@ class TestExperimentRun extends FunSuite {
         )
 
       assert(allGetter(f.expRun)().get equals
-        Map[String, ValueType]("some" -> 0.5, "int" -> 4, "other" -> 0.3, "string" -> "desc")
+        Map[String, ValueType](
+          "some" -> 0.5, "int" -> 4, "other" -> 0.3, "string" -> "desc",
+          "list" -> listMetadata
+        )
       )
     } finally {
       cleanup(f)
@@ -291,7 +299,7 @@ class TestExperimentRun extends FunSuite {
                             .flatMap(_.save("Add a blob")).get
       val logAttempt2 = f.expRun.logCommit(newCommit, Some(Map[String, String]("mnp/qrs" -> "abc/def")))
       assert(logAttempt2.isFailure)
-      
+
       val newRetrievedCommit = f.expRun.getCommit().get.commit
       assert(newRetrievedCommit equals commit)
     } finally {

--- a/client/scala/src/test/scala/ai/verta/client/entities/utils/TestValueType.scala
+++ b/client/scala/src/test/scala/ai/verta/client/entities/utils/TestValueType.scala
@@ -1,0 +1,31 @@
+package ai.verta.client.entities.utils
+
+import ai.verta.client.entities.DummyArtifact
+
+import org.scalatest.FunSuite
+import org.scalatest.Assertions._
+
+
+class TestValueType extends FunSuite {
+  test("ListValueType should correctly infer type, and not accept wrong type") {
+    val list: ValueType = List[ValueType](1, "abc", 4.5)
+    val underlyingList = list.asList.get
+
+    assert(underlyingList(0).asBigInt.get == BigInt(1))
+    assert(underlyingList(1).asString.get == "abc")
+    assert(underlyingList(2).asDouble.get == 4.5)
+
+    val artifact = new DummyArtifact("hello")
+    assertTypeError("val list: ValueType = List[ValueType](artifact)")
+  }
+
+  test("Converting ListValueType to GenericObject and back should not corrupt the values") {
+    val list: ValueType = List[ValueType](1, "abc", 4.5)
+
+    val convertedList = KVHandler.convertFromValueType(list, "conversion failed")
+      .flatMap(obj => KVHandler.convertToValueType(obj, "conversion failed"))
+      .get
+
+    assert(list == convertedList)
+  }
+}


### PR DESCRIPTION
Value type now supports a heterogeneous list (of other value types). This is useful for attributes whose values are lists (e.g column names in AtlasDatasetBlob).