### PR TITLE
VR-6861: Use unique registered model name in test

### DIFF
--- a/client/verta/tests/test_model_registry/test_model.py
+++ b/client/verta/tests/test_model_registry/test_model.py
@@ -59,7 +59,7 @@ class TestModel:
         assert str(registered_model.get_labels()) in repr
 
     def test_find(self, client, created_registered_models):
-        name = "registered_model_new_test"
+        name = verta._internal_utils._utils.generate_default_name()
         registered_model = client.set_registered_model(name)
         created_registered_models.append(registered_model)
 


### PR DESCRIPTION
Tests run nightly in parallel,  so entity names should be unique when possible.