### PR TITLE
VR-6903 Client tests need to skip registry tests and endpoint tests when running in OSS mode

### DIFF
--- a/client/verta/tests/test_cli/test_endpoint.py
+++ b/client/verta/tests/test_cli/test_endpoint.py
@@ -14,6 +14,8 @@ from verta.endpoint.resources import Resources
 
 from ..utils import get_build_ids
 
+pytestmark = pytest.mark.not_oss  # skip if run in oss setup. Applied to entire module
+
 
 class TestList:
     def test_list_endpoint(self, created_endpoints):

--- a/client/verta/tests/test_cli/test_registry.py
+++ b/client/verta/tests/test_cli/test_registry.py
@@ -18,6 +18,7 @@ from verta.endpoint.update._strategies import DirectUpdateStrategy
 
 from ..utils import sys_path_manager
 
+pytestmark = pytest.mark.not_oss  # skip if run in oss setup. Applied to entire module
 
 
 class TestCreate:

--- a/client/verta/tests/test_endpoint/test_endpoint.py
+++ b/client/verta/tests/test_endpoint/test_endpoint.py
@@ -20,6 +20,8 @@ from verta.utils import ModelAPI
 
 from ..utils import (get_build_ids, sys_path_manager)
 
+pytestmark = pytest.mark.not_oss  # skip if run in oss setup. Applied to entire module
+
 
 class TestEndpoint:
     def test_create(self, client, created_endpoints):

--- a/client/verta/tests/test_endpoint/test_resources.py
+++ b/client/verta/tests/test_endpoint/test_resources.py
@@ -3,6 +3,8 @@ import pytest
 from verta.endpoint.resources import Resources
 from verta.endpoint.update import DirectUpdateStrategy
 
+pytestmark = pytest.mark.not_oss  # skip if run in oss setup. Applied to entire module
+
 
 @pytest.mark.parametrize("data", [3, 64, 0.25])
 def test_cpu_milli(client, data, in_tempdir):

--- a/client/verta/tests/test_model_registry/test_model.py
+++ b/client/verta/tests/test_model_registry/test_model.py
@@ -3,6 +3,8 @@ import requests
 
 import verta
 
+pytestmark = pytest.mark.not_oss  # skip if run in oss setup. Applied to entire module
+
 
 class TestModel:
     def test_create(self, client, created_registered_models):

--- a/client/verta/tests/test_model_registry/test_model_version.py
+++ b/client/verta/tests/test_model_registry/test_model_version.py
@@ -22,6 +22,8 @@ from verta.environment import Python
 from verta._tracking.deployable_entity import _CACHE_DIR
 from verta.endpoint.update import DirectUpdateStrategy
 
+pytestmark = pytest.mark.not_oss  # skip if run in oss setup. Applied to entire module
+
 
 class TestMDBIntegration:
     def test_from_run(self, experiment_run, model_for_deployment, registered_model):


### PR DESCRIPTION
Skip entire module, following example in:
https://docs.pytest.org/en/stable/example/markers.html#marking-whole-classes-or-modules
Model registry is not supported by OSS setup, so needs to be skipped too.