### PR TITLE
VR-6720 Update client docs not restrict autoscaling *_scale to (0, 1]

### DIFF
--- a/client/verta/verta/endpoint/autoscaling/_autoscaling.py
+++ b/client/verta/verta/endpoint/autoscaling/_autoscaling.py
@@ -24,9 +24,9 @@ class Autoscaling(object):
         Minimum number of replicas to scale down to.
     max_replicas : int
         Maximum number of replicas to scale up to.
-    min_scale : float in (0, 1]
+    min_scale : float in (0, 1)
         Minimum growth factor for scaling.
-    max_scale : float in (0, 1]
+    max_scale : float > 1
         Maximum growth factor for scaling.
 
     """


### PR DESCRIPTION
Per our conversation, I believe that the doc should let the user know that min_scale is in the range of (0, 1), and max_scale is > 1. Let me know if these should be something else.