### PR TITLE
VR-6922 Reduce printing in log_models with custom_modules.

### DIFF
--- a/client/verta/verta/_tracking/deployable_entity.py
+++ b/client/verta/verta/_tracking/deployable_entity.py
@@ -295,9 +295,6 @@ class _DeployableEntity(_ModelDBEntity):
             if init_filename not in zipf.namelist():
                 zipf.writestr(init_filename, b"")
 
-            if self._conf.debug:
-                print("[DEBUG] archive contains:")
-                zipf.printdir()
         bytestream.seek(0)
 
         return bytestream


### PR DESCRIPTION
Removing these lines will eliminate the massive logs. The files in custom modules will not be printed out.