### PR TITLE
Added location info in Log4j logs

### DIFF
--- a/backend/src/main/resources/log4j2.xml
+++ b/backend/src/main/resources/log4j2.xml
@@ -3,7 +3,7 @@
     <Appenders>
         <Console name="ConsoleJSONAppender" target="SYSTEM_OUT">
               <!--  Doc link for key value pair: https://logging.apache.org/log4j/2.x/manual/lookups.html -->
-              <JsonLayout complete="false" compact="true" eventEol="true" stacktraceAsString="true">
+              <JsonLayout complete="false" compact="true" eventEol="true" stacktraceAsString="true" locationInfo="true">
                 <KeyValuePair key="hostName" value="${env:hostName:-}"/>
                 <KeyValuePair key="kubernetes.podIP" value="${k8s:podIp:-}"/>
             </JsonLayout>


### PR DESCRIPTION
it will print logs with location info in the `source` section of JSON. 
```
"source":{"class":"ai.verta.modeldb.App","method":"main","file":"App.java","line":210}
```
**Example:**
```
{"thread":"main","level":"INFO","loggerName":"ai.verta.modeldb.App","message":"Backend server starting.","endOfBatch":false,"loggerFqcn":"org.apache.logging.log4j.spi.AbstractLogger","instant":{"epochSecond":1601453568,"nanoOfSecond":981000000},"threadId":1,"threadPriority":5,"source":{"class":"ai.verta.modeldb.App","method":"main","file":"App.java","line":210},"hostName":"","kubernetes.podIP":""}
```