### PR TITLE
Propagate out error during uploading

### DIFF
--- a/client/scala/src/main/scala/ai/verta/repository/Commit.scala
+++ b/client/scala/src/main/scala/ai/verta/repository/Commit.scala
@@ -96,18 +96,24 @@ class Commit(
         // do not update the branch's head right away (in case uploading data fails)
 
         // upload the artifacts given by blobsToVersion map then clean up
-        val uploadAttempt: Try[Unit] = newCommit.map(newCommit => {
-          blobsToVersion
+        val uploadAttempt: Try[Unit] = newCommit.flatMap(newCommit => {
+          val attempts = blobsToVersion
             .mapValues(_.getAllMetadata) // Map[String, Iterable[FileMetadata]]
-            .map(pair => pair._2.map(metadata => newCommit.uploadArtifact(pair._1, metadata.path, new File(metadata.localPath.get))))
-        }).flatMap(_ => Try(blobsToVersion.values.map(_.cleanUpUploadedComponents()).map(_.get)))
+            .map(pair => pair._2.map(metadata => newCommit.uploadArtifact(pair._1, metadata.path, new File(metadata.localPath.get)))) // Map[String, Iterable[Try[Unit]]]
+            .values.flatten // Traversable[Try[Unit]]
 
-        uploadAttempt.flatMap(_ =>
-          if (commitBranch.isDefined)
-            newCommit.flatMap(_.newBranch(commitBranch.get))
-          else
-            newCommit
-        ) // if uploading fails, return the failure instead
+            Try(attempts.foreach(_.get)) // propagate the failure out. Try[Unit]
+        })
+
+        // needs to cleanup, regardless of success or failure of upload
+        val cleanupAttempt = Try(blobsToVersion.values.map(_.cleanUpUploadedComponents()).foreach(_.get)) // Try[Unit]
+
+        for (
+          // if either upload or cleanup fails, return that failure instead:
+          _ <- uploadAttempt;
+          _ <- cleanupAttempt;
+          returnedCommit <- if (commitBranch.isDefined) newCommit.flatMap(_.newBranch(commitBranch.get)) else newCommit
+        ) yield returnedCommit
       })
   }
 

--- a/client/scala/src/main/scala/ai/verta/repository/Commit.scala
+++ b/client/scala/src/main/scala/ai/verta/repository/Commit.scala
@@ -97,10 +97,10 @@ class Commit(
 
         // upload the artifacts given by blobsToVersion map then clean up
         val uploadAttempt: Try[Unit] = newCommit.flatMap(newCommit => {
-          val attempts = blobsToVersion
+          val attempts: Iterable[Try[Unit]] = blobsToVersion
             .mapValues(_.getAllMetadata) // Map[String, Iterable[FileMetadata]]
             .map(pair => pair._2.map(metadata => newCommit.uploadArtifact(pair._1, metadata.path, new File(metadata.localPath.get)))) // Map[String, Iterable[Try[Unit]]]
-            .values.flatten // Traversable[Try[Unit]]
+            .flatten
 
             Try(attempts.foreach(_.get)) // propagate the failure out. Try[Unit]
         })

--- a/client/scala/src/main/scala/ai/verta/repository/Commit.scala
+++ b/client/scala/src/main/scala/ai/verta/repository/Commit.scala
@@ -99,7 +99,7 @@ class Commit(
         val uploadAttempt: Try[Unit] = newCommit.flatMap(newCommit => {
           val attempts: Iterable[Try[Unit]] = blobsToVersion
             .mapValues(_.getAllMetadata) // Map[String, Iterable[FileMetadata]]
-            .map(pair => pair._2.map(metadata => newCommit.uploadArtifact(pair._1, metadata.path, new File(metadata.localPath.get)))) // Map[String, Iterable[Try[Unit]]]
+            .map(pair => pair._2.map(metadata => newCommit.uploadArtifact(pair._1, metadata.path, new File(metadata.localPath.get)))) // Iterable[Iterable[Try[Unit]]]
             .flatten
 
             Try(attempts.foreach(_.get)) // propagate the failure out. Try[Unit]


### PR DESCRIPTION
I tested this by running it against the ml lib demo. The failure is actually propagated out properly. This did not take care of the failure itself, but always useful to let the user know that their upload attempt fails.

Other tests still pass.