### PR TITLE
VR-6809 remove folders from s3 get dataset version part info

### DIFF
--- a/client/verta/verta/_dataset.py
+++ b/client/verta/verta/_dataset.py
@@ -843,16 +843,23 @@ class S3DatasetVersionInfo(PathDatasetVersionInfo):
         if self.key is not None:
             # look up object by key
             obj = conn.head_object(Bucket=self.bucket_name, Key=self.key)
+            self._append_s3_object_info(dataset_part_infos, obj, self.key)
             dataset_part_infos.append(self.get_s3_object_info(obj, self.key))
         elif self.key_prefix is not None:
             # look up objects by key prefix
             for obj in conn.list_objects(Bucket=self.bucket_name, Prefix=self.key_prefix)['Contents']:
+                self._append_s3_object_info(dataset_part_infos, obj)
                 dataset_part_infos.append(self.get_s3_object_info(obj))
         else:
             # look up all objects in bucket
             for obj in conn.list_objects(Bucket=self.bucket_name)['Contents']:
-                dataset_part_infos.append(self.get_s3_object_info(obj))
+                self._append_s3_object_info(dataset_part_infos, obj)
         return dataset_part_infos
+
+    def _append_s3_object_info(self, dataset_part_infos, object_info, key=None):
+        if object_info['Key'].endswith('/'):  # folder, not object
+            return
+        dataset_part_infos.append(self.get_s3_object_info(object_info, key))
 
     @staticmethod
     def get_s3_object_info(object_info, key=None):

--- a/client/verta/verta/_dataset.py
+++ b/client/verta/verta/_dataset.py
@@ -844,12 +844,10 @@ class S3DatasetVersionInfo(PathDatasetVersionInfo):
             # look up object by key
             obj = conn.head_object(Bucket=self.bucket_name, Key=self.key)
             self._append_s3_object_info(dataset_part_infos, obj, self.key)
-            dataset_part_infos.append(self.get_s3_object_info(obj, self.key))
         elif self.key_prefix is not None:
             # look up objects by key prefix
             for obj in conn.list_objects(Bucket=self.bucket_name, Prefix=self.key_prefix)['Contents']:
                 self._append_s3_object_info(dataset_part_infos, obj)
-                dataset_part_infos.append(self.get_s3_object_info(obj))
         else:
             # look up all objects in bucket
             for obj in conn.list_objects(Bucket=self.bucket_name)['Contents']:


### PR DESCRIPTION
Couldn't reproduce the part with " S3 sometimes returns folders from its ListObjects request, and sometimes it doesn’t." It always returns folders for me. This change is just for filtering files without folders for get dataset version