### PR TITLE
VR-6879 use not random file contents for test

### DIFF
--- a/client/verta/tests/test_artifacts.py
+++ b/client/verta/tests/test_artifacts.py
@@ -163,7 +163,7 @@ class TestArtifacts:
     def test_clientside_storage(self, experiment_run, strs, in_tempdir):
         key = strs[0]
         filename = strs[1]
-        FILE_CONTENTS = os.urandom(2**16)
+        FILE_CONTENTS = bytes([3, 4, 5])
 
         # TODO: be able to use existing env var for debugging
         # NOTE: there is an assertion of `== 1` artifact that would need to be changed

--- a/client/verta/tests/test_artifacts.py
+++ b/client/verta/tests/test_artifacts.py
@@ -160,10 +160,20 @@ class TestArtifacts:
             with pytest.raises(ValueError):
                 experiment_run.log_artifact_path(key, artifact)
 
+    @staticmethod
+    def generate_random_data():
+        while True:
+            data = os.urandom(2 ** 16)
+            bytestream = six.BytesIO(data)
+            try:
+                pickle.load(bytestream)
+            except:
+                return data
+
     def test_clientside_storage(self, experiment_run, strs, in_tempdir):
         key = strs[0]
         filename = strs[1]
-        FILE_CONTENTS = bytes([3, 4, 5])
+        FILE_CONTENTS = self.generate_random_data()
 
         # TODO: be able to use existing env var for debugging
         # NOTE: there is an assertion of `== 1` artifact that would need to be changed
@@ -205,7 +215,7 @@ class TestArtifacts:
         key = strs[0]
         filename = strs[1]
         new_filename = strs[2]
-        FILE_CONTENTS = os.urandom(2**16)
+        FILE_CONTENTS = self.generate_random_data()
 
         # create file and upload as artifact
         with open(filename, 'wb') as f:

--- a/client/verta/tests/test_model_registry/test_model_version.py
+++ b/client/verta/tests/test_model_registry/test_model_version.py
@@ -21,6 +21,7 @@ import verta.dataset
 from verta.environment import Python
 from verta._tracking.deployable_entity import _CACHE_DIR
 from verta.endpoint.update import DirectUpdateStrategy
+from ..test_artifacts import TestArtifacts
 
 pytestmark = pytest.mark.not_oss  # skip if run in oss setup. Applied to entire module
 
@@ -160,7 +161,7 @@ class TestModelVersion:
 
     def test_add_artifact_file(self, model_version, in_tempdir):
         filename = "tiny1.bin"
-        FILE_CONTENTS = os.urandom(2**16)
+        FILE_CONTENTS = TestArtifacts.generate_random_data()
         with open(filename, 'wb') as f:
             f.write(FILE_CONTENTS)
         model_version.log_artifact("file", filename)


### PR DESCRIPTION
there is a possibility that during this test run a pickle serialized object with an unexpected type will be created and deserialized. The case is described here: https://vertaai.atlassian.net/browse/VR-6879