### PR TITLE
Check that versionID is not "null" string

### DIFF
--- a/client/scala/src/main/scala/ai/verta/blobs/dataset/S3.scala
+++ b/client/scala/src/main/scala/ai/verta/blobs/dataset/S3.scala
@@ -249,7 +249,7 @@ object S3 {
       obj.getETag(),
       getPath(bucketName, key),
       BigInt(obj.getContentLength()),
-      Option(obj.getVersionId())
+      if (obj.getVersionId() == "null") None else Option(obj.getVersionId())
     )
   }
 
@@ -261,7 +261,7 @@ object S3 {
       version.getETag(),
       getPath(version.getBucketName(), version.getKey()),
       BigInt(version.getSize()),
-      Option(version.getVersionId())
+      if (version.getVersionId() == "null") None else Option(version.getVersionId())
     )
   }
 


### PR DESCRIPTION
This came up when I was trying to convert the tests to use Verta's bucket. Apparently it can return the actual "null" string as version ID 🤦 