### PR TITLE
Fix test for same endpoint, different workspace

### DIFF
--- a/client/verta/tests/test_organization.py
+++ b/client/verta/tests/test_organization.py
@@ -43,7 +43,8 @@ class TestOrganization:
         repository_name = _utils.generate_default_name()
         model_name = _utils.generate_default_name()
         version_name = _utils.generate_default_name()
-        endpoint_path = _utils.generate_default_name()
+        # TODO: until VR-6053, endpoints with same name diff workspace returns an error
+        # endpoint_path = _utils.generate_default_name()
 
         project = client.create_project(project_name)
         exp = client.create_experiment(exp_name)
@@ -56,13 +57,13 @@ class TestOrganization:
         version = model.create_version(name=version_name)
         created_registered_models.append(model)
 
-        endpoint = client.create_endpoint(path=endpoint_path)
-        created_endpoints.append(endpoint)
+        # endpoint = client.create_endpoint(path=endpoint_path)
+        # created_endpoints.append(endpoint)
 
         # create entities with same name, but different workspace:
         new_model = client.create_registered_model(name=model_name, workspace=organization.name)
         new_version = new_model.create_version(name=version_name)
-        new_endpoint = client.create_endpoint(path=endpoint_path, workspace=organization.name)
+        # new_endpoint = client.create_endpoint(path=endpoint_path, workspace=organization.name)
 
         new_project = client.create_project(project_name, workspace=organization.name)
         new_exp = client.create_experiment(exp_name)
@@ -72,12 +73,12 @@ class TestOrganization:
         new_dataset = client._create_dataset2(dataset_name, workspace=organization.name)
         created_datasets.append(new_dataset)
 
-        created_endpoints.append(new_endpoint)
+        # created_endpoints.append(new_endpoint)
         created_registered_models.append(new_model)
 
         assert model.id != new_model.id
         assert version.id != new_version.id
-        assert endpoint.id != new_endpoint.id
+        # assert endpoint.id != new_endpoint.id
         assert project.id != new_project.id
         assert exp.id != new_exp.id
         assert run.id != new_run.id

--- a/client/verta/tests/test_organization.py
+++ b/client/verta/tests/test_organization.py
@@ -1,6 +1,8 @@
 import pytest
 import json
 
+import requests
+
 from verta import Client
 from verta._internal_utils import _utils
 from verta._protos.public.uac import Organization_pb2 as _Organization
@@ -43,8 +45,7 @@ class TestOrganization:
         repository_name = _utils.generate_default_name()
         model_name = _utils.generate_default_name()
         version_name = _utils.generate_default_name()
-        # TODO: until VR-6053, endpoints with same name diff workspace returns an error
-        # endpoint_path = _utils.generate_default_name()
+        endpoint_path = _utils.generate_default_name()
 
         project = client.create_project(project_name)
         exp = client.create_experiment(exp_name)
@@ -57,13 +58,17 @@ class TestOrganization:
         version = model.create_version(name=version_name)
         created_registered_models.append(model)
 
-        # endpoint = client.create_endpoint(path=endpoint_path)
-        # created_endpoints.append(endpoint)
+        endpoint = client.create_endpoint(path=endpoint_path)
+        created_endpoints.append(endpoint)
 
         # create entities with same name, but different workspace:
         new_model = client.create_registered_model(name=model_name, workspace=organization.name)
         new_version = new_model.create_version(name=version_name)
-        # new_endpoint = client.create_endpoint(path=endpoint_path, workspace=organization.name)
+        # new_endpoint = client.create_endpoint(path=endpoint_path, workspace=organization.name)  TODO: uncomment after VR-6053
+        # TODO: remove followinng three lines after VR-6053; until then, endpoints with same name diff workspace is a 409
+        with pytest.raises(requests.HTTPError) as excinfo:
+            client.create_endpoint(path=endpoint_path, workspace=organization.name)
+        assert excinfo.value.response.status_code == 409
 
         new_project = client.create_project(project_name, workspace=organization.name)
         new_exp = client.create_experiment(exp_name)
@@ -73,12 +78,12 @@ class TestOrganization:
         new_dataset = client._create_dataset2(dataset_name, workspace=organization.name)
         created_datasets.append(new_dataset)
 
-        # created_endpoints.append(new_endpoint)
+        # created_endpoints.append(new_endpoint)  TODO: uncomment after VR-6053
         created_registered_models.append(new_model)
 
         assert model.id != new_model.id
         assert version.id != new_version.id
-        # assert endpoint.id != new_endpoint.id
+        # assert endpoint.id != new_endpoint.id  TODO: uncommment after VR-6053
         assert project.id != new_project.id
         assert exp.id != new_exp.id
         assert run.id != new_run.id


### PR DESCRIPTION
Deployment backend currently returns
```
requests.exceptions.HTTPError: 409 Client Error: "Path already in use by endpoint ######"
```
when creating endpoint w/ same name in different workspace.

I'm adjusting the test to check for that error, until the ticket for enabling creation is implemented.