### PR TITLE
Ignore protobuf's internal DeprecationWarnings in pytest output

### DIFF
--- a/client/verta/tests/conftest.py
+++ b/client/verta/tests/conftest.py
@@ -40,11 +40,6 @@ def pytest_addoption(parser):
     parser.addoption("--oss", action="store_true", help="run OSS-compatible tests")
 
 
-def pytest_configure(config):
-    config.addinivalue_line("markers", "oss: mark the given test function as only applicable to OSS.")
-    config.addinivalue_line("markers", "not_oss: mark the given test function not available in OSS.")
-
-
 def pytest_collection_modifyitems(config, items):
     if config.getoption("--oss"):
         skip_not_oss = pytest.mark.skip(reason="not available in OSS")

--- a/client/verta/tests/pytest.ini
+++ b/client/verta/tests/pytest.ini
@@ -2,3 +2,6 @@
 markers =
     oss: mark the given test function as only applicable to OSS.
     not_oss: mark the given test function not available in OSS.
+filterwarnings =
+    # ignore DeprecationWarning from protobuf generated code
+    ignore:.*Create unlinked descriptors is going to go away.*:DeprecationWarning

--- a/client/verta/tests/pytest.ini
+++ b/client/verta/tests/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    oss: mark the given test function as only applicable to OSS.
+    not_oss: mark the given test function not available in OSS.


### PR DESCRIPTION
You know the ~200 lines of
```
=============================== warnings summary ===============================
../verta/_protos/public/common/CommonService_pb2.py:24
  /home/jenkins/agent/workspace/client/run-pytest/client/verta/verta/_protos/public/common/CommonService_pb2.py:24: DeprecationWarning: Call to deprecated create function FileDescriptor(). Note: Create unlinked descriptors is going to go away. Please use get/find descriptors from generated code or query the descriptor_pool.
    dependencies=[google_dot_protobuf_dot_struct__pb2.DESCRIPTOR,])

../verta/_protos/public/common/CommonService_pb2.py:37
  /home/jenkins/agent/workspace/client/run-pytest/client/verta/verta/_protos/public/common/CommonService_pb2.py:37: DeprecationWarning: Call to deprecated create function EnumValueDescriptor(). Note: Create unlinked descriptors is going to go away. Please use get/find descriptors from generated code or query the descriptor_pool.
    type=None),

../verta/_protos/public/common/CommonService_pb2.py:41
  /home/jenkins/agent/workspace/client/run-pytest/client/verta/verta/_protos/public/common/CommonService_pb2.py:41: DeprecationWarning: Call to deprecated create function EnumValueDescriptor(). Note: Create unlinked descriptors is going to go away. Please use get/find descriptors from generated code or query the descriptor_pool.
    type=None),

...
```
in our test logs? No more of that.