### PR TITLE
VR-7699 custom modules tests fail: captured fewer files than expected

### DIFF
--- a/client/verta/tests/test_deployment.py
+++ b/client/verta/tests/test_deployment.py
@@ -103,14 +103,11 @@ class TestLogModel:
                 continue
 
             for parent_dir, dirnames, filenames in os.walk(path):
-                # skip venvs
-                #     This logic is from _utils.find_filepaths().
-                exec_path_glob = os.path.join(parent_dir, "{}", "bin", "python*")
-                dirnames[:] = [dirname for dirname in dirnames if not glob.glob(exec_path_glob.format(dirname))]
-
                 # only Python files
                 filenames[:] = [filename for filename in filenames if filename.endswith(('.py', '.pyc', '.pyo'))]
 
+                if not _utils.is_in_venv(path) and _utils.is_in_venv(parent_dir):
+                    continue
                 custom_module_filenames.update(map(os.path.basename, filenames))
 
         with zipfile.ZipFile(experiment_run.get_artifact("custom_modules"), 'r') as zipf:

--- a/client/verta/tests/test_model_registry/test_model_version.py
+++ b/client/verta/tests/test_model_registry/test_model_version.py
@@ -21,6 +21,7 @@ import verta.dataset
 from verta.environment import Python
 from verta._tracking.deployable_entity import _CACHE_DIR
 from verta.endpoint.update import DirectUpdateStrategy
+from verta._internal_utils import _utils
 from ..test_artifacts import TestArtifacts
 
 pytestmark = pytest.mark.not_oss  # skip if run in oss setup. Applied to entire module
@@ -465,14 +466,11 @@ class TestDeployability:
                 continue
 
             for parent_dir, dirnames, filenames in os.walk(path):
-                # skip venvs
-                #     This logic is from _utils.find_filepaths().
-                exec_path_glob = os.path.join(parent_dir, "{}", "bin", "python*")
-                dirnames[:] = [dirname for dirname in dirnames if not glob.glob(exec_path_glob.format(dirname))]
-
                 # only Python files
                 filenames[:] = [filename for filename in filenames if filename.endswith(('.py', '.pyc', '.pyo'))]
 
+                if not _utils.is_in_venv(path) and _utils.is_in_venv(parent_dir):
+                    continue
                 custom_module_filenames.update(map(os.path.basename, filenames))
 
         with zipfile.ZipFile(model_version.get_artifact("custom_modules"), 'r') as zipf:


### PR DESCRIPTION
Basically, we change the logic of skipping venv files in
https://github.com/VertaAI/modeldb/pull/1554/
to accommodate the case of pip-installed custom module, but did not update the test to reflect the new logic 🤔 
Let me know what you think about the change. Tests do pass now.