### PR TITLE
VR-7701: Recommend user downgrade h5py on Keras save/load error

### DIFF
--- a/client/verta/requirements.txt
+++ b/client/verta/requirements.txt
@@ -14,6 +14,7 @@ pytest>=4.3
 # unit testing dependencies
 boto3
 google-cloud-bigquery
+h5py!=3.0.0  # https://github.com/h5py/h5py/issues/1732
 matplotlib<3.0; python_version < '3.8'
 matplotlib>=3.2; python_version >= '3.8'
 numpy<1.17

--- a/client/verta/setup.py
+++ b/client/verta/setup.py
@@ -29,6 +29,7 @@ setup(
         "click",
         "cloudpickle",
         "googleapis-common-protos>=1.5",
+        "h5py<3.0.0",  # for (de)serializing Keras models https://github.com/tensorflow/tensorflow/issues/44467
         "pathlib2>=2.2",
         "protobuf>=3.8",
         "pyyaml>=5.1",

--- a/client/verta/setup.py
+++ b/client/verta/setup.py
@@ -29,7 +29,6 @@ setup(
         "click",
         "cloudpickle",
         "googleapis-common-protos>=1.5",
-        "h5py<3.0.0",  # for (de)serializing Keras models https://github.com/tensorflow/tensorflow/issues/44467
         "pathlib2>=2.2",
         "protobuf>=3.8",
         "pyyaml>=5.1",

--- a/client/verta/verta/_internal_utils/_artifact_utils.py
+++ b/client/verta/verta/_internal_utils/_artifact_utils.py
@@ -290,6 +290,9 @@ def serialize_model(model):
                 h5py = maybe_dependency("h5py")
                 if (str(e) == "a bytes-like object is required, not 'str'"
                         and h5py is not None and h5py.__version__ == "3.0.0"):
+                    # h5py v3.0.0 improperly checks if a `bytes` contains a `str`.
+                    # Encountering this generic error message here plus the fact
+                    # that h5py==3.0.0 suggests that this is the problem.
                     six.raise_from(KERAS_H5PY_ERROR, e)
                 else:
                     six.raise_from(e, None)
@@ -338,6 +341,9 @@ def deserialize_model(bytestring):
                 h5py = maybe_dependency("h5py")
                 if (str(e) == "'str' object has no attribute 'decode'"
                         and h5py is not None and h5py.__version__ == "3.0.0"):
+                    # h5py v3.0.0 returns a `str` instead of a `bytes` to Keras.
+                    # Encountering this generic error message here plus the fact
+                    # that h5py==3.0.0 suggests that this is the problem.
                     six.raise_from(KERAS_H5PY_ERROR, e)
                 else:
                     six.raise_from(e, None)

--- a/client/verta/verta/_internal_utils/_artifact_utils.py
+++ b/client/verta/verta/_internal_utils/_artifact_utils.py
@@ -32,7 +32,7 @@ BLACKLISTED_KEYS = {
 
 KERAS_H5PY_ERROR = RuntimeError(  # https://github.com/h5py/h5py/issues/1732
     "Keras encountered an error saving/loading the model due to a bug in h5py v3.0.0;"
-    " consider downgrading with `pip install \"h5py!=3.0.0\"`"
+    " consider downgrading with `pip install \"h5py<3.0.0\"`"
 )
 
 


### PR DESCRIPTION
Due to https://github.com/h5py/h5py/issues/1732, `h5py==3.0.0` raises unhelpful string-handling errors Keras's save/load.
We catch the error, verify that `h5py==3.0.0` is installed, and recommend a resolution for the user.