### PR TITLE
Sort the tags when converting from a List<TagsMapping> to List<String>

### DIFF
--- a/backend/src/main/java/ai/verta/modeldb/utils/RdbmsUtils.java
+++ b/backend/src/main/java/ai/verta/modeldb/utils/RdbmsUtils.java
@@ -355,7 +355,7 @@ public class RdbmsUtils {
 
   public static List<String> convertTagsMappingListFromTagList(List<TagsMapping> tagsMappings) {
     if (tagsMappings != null) {
-      return tagsMappings.stream().map(TagsMapping::getTag).collect(Collectors.toList());
+      return tagsMappings.stream().map(TagsMapping::getTag).sorted().collect(Collectors.toList());
     }
     return Collections.emptyList();
   }


### PR DESCRIPTION
https://vertaai.atlassian.net/browse/VR-7512

This modifies the conversion logic to ensure that the resulting list of tags is sorted using the natural sort order instead of relying on the database ID.

@nhatsmrt this PR addresses the bug you reported and may affect your tests.