### PR TITLE
Update proxy docs to reflect changes in the Makefile and docker image tag

### DIFF
--- a/backend/proxy/README.md
+++ b/backend/proxy/README.md
@@ -2,11 +2,11 @@
 
 This proxy provides a REST+JSON interface to the gRPC backend, which is used by the client and WebApp.
 
-***Note:*** Consider `verta-backend/proxy/` as a root dir for below steps and execute it from there.
+***Note:*** Consider `modeldb/proxy/` as a root dir for below steps and execute it from there.
 
-## Run proxy at local machine without Docker
+## Run proxy on local machine without Docker
 
-* Install `Golang` in local system (https://golang.org/)
+* Install `Golang` to local system (https://golang.org/)
 
 * Run verta-backend OR make sure verta-backend is already running
 
@@ -14,13 +14,13 @@ This proxy provides a REST+JSON interface to the gRPC backend, which is used by 
 
 * Execute ```local_machine_build.sh``` to build/run proxy
 
-* Use following URL for testing to check setup is works properly: http://localhost:8080/v1/project/findProjects
+* Use following URL for testing to check setup works properly: http://localhost:8080/v1/project/findProjects
 
-## Run proxy at local machine using Docker
+## Run proxy on local machine using Docker
 
-* Install Docker in local system
+* Install Docker on local system
 
-* Run verta-backend OR make sure verta-backend is already running at local system
+* Run verta-backend OR make sure verta-backend is already running on local system
 
 * The proxy has the following configurations as environment variables:
   * `MDB_ADDRESS` is the `<local system host>:8085` address of the ModelDB backend.
@@ -28,22 +28,22 @@ This proxy provides a REST+JSON interface to the gRPC backend, which is used by 
 
   ***OR***
 
-  * Add below two line in dockerfile before the `ENTRYPOINT` command
+  * Add below two lines to dockerfile before the `ENTRYPOINT` command
 
     ```yaml
        - ENV MDB_ADDRESS <local system host (Not docker machine)>:8085
        - ENV SERVER_HTTP_PORT 3000
     ```
 
-* To build it, just run `make docker` and an image called `modeldb-proxy` will be created in your local docker system.
+* To build it, just run `make` and an image called `vertaaiofficial/modeldb-proxy` will be created in your local docker system.
 
 * Execute following command to run proxy on docker
 
     ```bash
-    docker run -it -p 3000:3000 modeldb-proxy
+    docker run -it -p 3000:3000 vertaaiofficial/modeldb-proxy
     ``` 
 
-* Use following URL for testing to check setup is works properly:
+* Use following URL for testing to check setup works properly:
 
   ```md
   http://<docker-machine host>:3000/v1/project/findProjects


### PR DESCRIPTION
README.md for the proxy now uses the correct docker image tag name.

@ad-47 for review