### PR TITLE
Set testing requirement h5py<3.0.0

### DIFF
--- a/client/verta/requirements.txt
+++ b/client/verta/requirements.txt
@@ -14,7 +14,7 @@ pytest>=4.3
 # unit testing dependencies
 boto3
 google-cloud-bigquery
-h5py!=3.0.0  # https://github.com/h5py/h5py/issues/1732
+h5py<3.0.0  # https://github.com/tensorflow/tensorflow/issues/44467
 matplotlib<3.0; python_version < '3.8'
 matplotlib>=3.2; python_version >= '3.8'
 numpy<1.17


### PR DESCRIPTION
`h5py` v3.1.0 fixed a bug on the model save codepath, but model loading still fails on the TensorFlow side.