### PR TITLE
VR-6722 Client needs to propagate the original exception for verifyConnection errors

### DIFF
--- a/client/verta/tests/test_entities.py
+++ b/client/verta/tests/test_entities.py
@@ -174,6 +174,7 @@ class TestClient:
         finally:
             os.environ[HOST_KEY], os.environ[EMAIL_KEY], os.environ[DEV_KEY_KEY] = HOST, EMAIL, DEV_KEY
 
+    @pytest.mark.not_oss
     def test_wrong_credentials(self):
         EMAIL_KEY, DEV_KEY_KEY = "VERTA_EMAIL", "VERTA_DEV_KEY"
         old_email, old_dev_key = os.environ[EMAIL_KEY], os.environ[DEV_KEY_KEY]

--- a/client/verta/tests/test_entities.py
+++ b/client/verta/tests/test_entities.py
@@ -174,6 +174,23 @@ class TestClient:
         finally:
             os.environ[HOST_KEY], os.environ[EMAIL_KEY], os.environ[DEV_KEY_KEY] = HOST, EMAIL, DEV_KEY
 
+    def test_wrong_credentials(self):
+        EMAIL_KEY, DEV_KEY_KEY = "VERTA_EMAIL", "VERTA_DEV_KEY"
+        old_email, old_dev_key = os.environ[EMAIL_KEY], os.environ[DEV_KEY_KEY]
+
+        try:
+            os.environ[EMAIL_KEY] = "abc@email.com"
+            os.environ[DEV_KEY_KEY] = "def"
+
+            with pytest.raises(requests.exceptions.HTTPError) as excinfo:
+                verta.Client()
+
+            excinfo_value = str(excinfo.value).strip()
+            assert "401 Client Error" in excinfo_value
+            assert "authentication failed; please check `VERTA_EMAIL` and `VERTA_DEV_KEY`" in excinfo_value
+        finally:
+            os.environ[EMAIL_KEY], os.environ[DEV_KEY_KEY] = old_email, old_dev_key
+
 class TestEntities:
     def test_cache(self, client, strs):
         client.set_project()

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -181,7 +181,7 @@ class Client(object):
                                                "{}://{}/api/v1/modeldb/project/verifyConnection".format(conn.scheme, conn.socket),
                                                conn)
             except requests.ConnectionError as err:
-                conn_error_msg = "connection failed; please check `host` and `port`; original error: \n{}".format(str(err))
+                conn_error_msg = "connection failed; please check `host` and `port`; error message: \n{}".format(str(err))
                 six.raise_from(requests.ConnectionError(conn_error_msg), None)
 
             def is_unauthorized(response): return response.status_code == 401

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -180,15 +180,16 @@ class Client(object):
                 response = _utils.make_request("GET",
                                                "{}://{}/api/v1/modeldb/project/verifyConnection".format(conn.scheme, conn.socket),
                                                conn)
-            except requests.ConnectionError:
-                six.raise_from(requests.ConnectionError("connection failed; please check `host` and `port`"),
-                               None)
+            except requests.ConnectionError as err:
+                conn_error_msg = "connection failed; please check `host` and `port`; original error: \n{}".format(str(err))
+                six.raise_from(requests.ConnectionError(conn_error_msg), None)
 
             def is_unauthorized(response): return response.status_code == 401
 
             if is_unauthorized(response):
-                auth_error_msg = "authentication failed; please check `VERTA_EMAIL` and `VERTA_DEV_KEY`"
-                six.raise_from(requests.HTTPError(auth_error_msg), None)
+                # response.reason was "Unauthorized"
+                new_reason = "authentication failed; please check `VERTA_EMAIL` and `VERTA_DEV_KEY`; {}".format(response.reason)
+                response.reason = new_reason
 
             _utils.raise_for_http_error(response)
             print("connection successfully established")

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -188,7 +188,7 @@ class Client(object):
 
             if is_unauthorized(response):
                 # response.reason was "Unauthorized"
-                new_reason = "authentication failed; please check `VERTA_EMAIL` and `VERTA_DEV_KEY`; {}".format(response.reason)
+                new_reason = "authentication failed; please check `VERTA_EMAIL` and `VERTA_DEV_KEY`\n\n{}".format(response.reason)
                 response.reason = new_reason
 
             _utils.raise_for_http_error(response)

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -181,8 +181,8 @@ class Client(object):
                                                "{}://{}/api/v1/modeldb/project/verifyConnection".format(conn.scheme, conn.socket),
                                                conn)
             except requests.ConnectionError as err:
-                conn_error_msg = "connection failed; please check `host` and `port`; error message: \n{}".format(str(err))
-                six.raise_from(requests.ConnectionError(conn_error_msg), None)
+                err.args = ("connection failed; please check `host` and `port`; error message: \n\n{}".format(err.args[0]),) + err.args[1:]
+                six.raise_from(err, None)
 
             def is_unauthorized(response): return response.status_code == 401
 


### PR DESCRIPTION
Error format: 
```python3
Traceback (most recent call last):
  File "../connection_err.py", line 2, in <module>
    Client()
  File "/Users/nhatpham/Documents/modeldb/client/verta/verta/client.py", line 194, in __init__
    _utils.raise_for_http_error(response)
  File "/Users/nhatpham/Documents/modeldb/client/verta/verta/_internal_utils/_utils.py", line 534, in raise_for_http_error
    six.raise_from(e, None)  # use default reason
  File "/Users/nhatpham/Documents/modeldb/client/verta/verta/external/six/__init__.py", line 737, in raise_from
    raise value
requests.exceptions.HTTPError: 401 Client Error: authentication failed; please check `VERTA_EMAIL` and `VERTA_DEV_KEY`; Unauthorized for url: ...
```