### PR TITLE
VR-7747 change client to only show "message" field from http error response if it has one

### DIFF
--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -531,10 +531,14 @@ def raise_for_http_error(response):
         try:
             reason = body_to_json(response)
         except ValueError:
-            reason = response.text.strip()
+            reason = response.text.strip()  # response is not json
 
-        if isinstance(reason, dict) and 'message' in reason:
-            reason = reason['message']
+        if isinstance(reason, dict):
+            if 'message' in reason:
+                reason = reason['message']
+            else:
+                # fall back to entire text
+                reason = response.text.strip()
 
         reason = six.ensure_str(reason)
 

--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -528,7 +528,12 @@ def raise_for_http_error(response):
         curr_time = timestamp_to_str(now(), utc=True)
         time_str = " at {} UTC".format(curr_time)
 
-        reason = six.ensure_str(response.text.strip())
+        try:
+            reason = body_to_json(response)['message']
+        except (ValueError,  # not JSON response
+                 KeyError):  # no 'message' from back end
+            reason = six.ensure_str(response.text.strip())
+
         if not reason:
             e.args = (e.args[0] + time_str,) + e.args[1:]  # attach time to error message
             six.raise_from(e, None)  # use default reason

--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -529,10 +529,12 @@ def raise_for_http_error(response):
         time_str = " at {} UTC".format(curr_time)
 
         try:
-            reason = six.ensure_str(body_to_json(response)['message'])
+            reason = body_to_json(response)['message']
         except (ValueError,  # not JSON response
                  KeyError):  # no 'message' from back end
-            reason = six.ensure_str(response.text.strip())
+            reason = response.text.strip()
+
+        reason = six.ensure_str(reason)
 
         if not reason:
             e.args = (e.args[0] + time_str,) + e.args[1:]  # attach time to error message

--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -529,7 +529,7 @@ def raise_for_http_error(response):
         time_str = " at {} UTC".format(curr_time)
 
         try:
-            reason = body_to_json(response)['message']
+            reason = six.ensure_str(body_to_json(response)['message'])
         except (ValueError,  # not JSON response
                  KeyError):  # no 'message' from back end
             reason = six.ensure_str(response.text.strip())

--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -529,11 +529,12 @@ def raise_for_http_error(response):
         time_str = " at {} UTC".format(curr_time)
 
         try:
-            reason = body_to_json(response)['message']
-        except (ValueError,  # not JSON response
-                TypeError,  # body_to_json return a single string
-                KeyError):  # no 'message' from back end
+            reason = body_to_json(response)
+        except ValueError:
             reason = response.text.strip()
+
+        if isinstance(reason, dict) and 'message' in reason:
+            reason = reason['message']
 
         reason = six.ensure_str(reason)
 

--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -531,7 +531,8 @@ def raise_for_http_error(response):
         try:
             reason = body_to_json(response)['message']
         except (ValueError,  # not JSON response
-                 KeyError):  # no 'message' from back end
+                TypeError,  # body_to_json return a single string
+                KeyError):  # no 'message' from back end
             reason = response.text.strip()
 
         reason = six.ensure_str(reason)


### PR DESCRIPTION
Error msg is now:
```python
429 Client Error: LIMIT_RUN_NUMBER: “Number of experiment runs exceeded”: Your trial account allows you to log upto 10 experiment runs. Try deleting prior experiment runs in order to proceed. for url: <url> at 2020-11-12 19:00:31.865000 UTC
```
(I removed the url for privacy reasons).
Basically re-introduce the logic changed in https://github.com/VertaAI/modeldb/pull/1083, with some slight modifications.