### PR TITLE
Remove the logging of the YAML properties map

### DIFF
--- a/backend/src/main/java/ai/verta/modeldb/utils/ModelDBUtils.java
+++ b/backend/src/main/java/ai/verta/modeldb/utils/ModelDBUtils.java
@@ -80,7 +80,6 @@ public class ModelDBUtils {
     Yaml yaml = new Yaml();
     @SuppressWarnings("unchecked")
     Map<String, Object> prop = (Map<String, Object>) yaml.load(inputStream);
-    LOGGER.debug("YAML map {}", prop);
     return prop;
   }
 


### PR DESCRIPTION
This map contains DB creds and other secrets, and should not be logged.