### PR TITLE
Use shortened URL for make_proto_request()

### DIFF
--- a/client/verta/verta/_tracking/experimentrun.py
+++ b/client/verta/verta/_tracking/experimentrun.py
@@ -232,12 +232,8 @@ class ExperimentRun(_DeployableEntity):
                 # TODO: check that `artifact_hash` hasn't changed
 
                 # check if multipart upload was in progress
-                url = "{}://{}/api/v1/modeldb/experiment-run/getCommittedArtifactParts".format(
-                    self._conn.scheme,
-                    self._conn.socket,
-                )
                 msg = _CommonService.GetCommittedArtifactParts(id=self.id, key=key)
-                response = self._conn.make_proto_request("GET", url, params=msg)
+                response = self._conn.make_proto_request("GET", "/api/v1/modeldb/experiment-run/getCommittedArtifactParts", params=msg)
                 response = self._conn.must_proto_response(response, msg.Response)
                 if not response.artifact_parts:
                     url_for_artifact = self._get_url_for_artifact(key, "PUT", part_num=1)


### PR DESCRIPTION
`Connection.make_proto_request()` doesn't need the `https://app.verta.ai/`, which was causing a bug.