### PR TITLE
Allow tuples for find()'s first argument

### DIFF
--- a/client/verta/verta/_cli/registry/list.py
+++ b/client/verta/verta/_cli/registry/list.py
@@ -33,7 +33,7 @@ def lst_model(filter, output, workspace):
     """
     client = Client()
 
-    models = client.registered_models.with_workspace(workspace).find(filter)
+    models = client.registered_models.with_workspace(workspace).find(*filter)
 
     click.echo()
     if output == "json":
@@ -66,7 +66,7 @@ def lst_model_version(model_name, filter, output, workspace):
         click.echo("Listing versions for model {}".format(model_name))
         registered_model = client.get_registered_model(model_name, workspace)
 
-    model_versions = client.registered_model_versions.with_model(registered_model).find(filter)
+    model_versions = client.registered_model_versions.with_model(registered_model).find(*filter)
 
     click.echo()
     if output == "json":

--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -292,8 +292,8 @@ class LazyList(object):
             # <ExperimentRuns containing 3 runs>
 
         """
-        if len(args) == 1 and isinstance(args[0], list):
-            # to keep backward compatibility, in case user pass in a list
+        if len(args) == 1 and isinstance(args[0], (list, tuple)):
+            # to keep backward compatibility, in case user pass in a list or tuple
             return self.find(*args[0])
         elif not all(isinstance(predicate, six.string_types) for predicate in args):
             raise TypeError("predicates must all be strings")


### PR DESCRIPTION
Our CLI machinery passes a tuple (rather than a list) as the first argument for `find()`, which causes an error since #1680.

It seems reasonable to support tuples for backwards compatibility,
*and also* unpack predicates in the CLI implementation because that's the preferred method going forward