### PR TITLE
Add support for HDFS in blob types

### DIFF
--- a/client/verta/hdfs-test/install.txt
+++ b/client/verta/hdfs-test/install.txt
@@ -1,0 +1,2 @@
+sudo yum install -y gcc python3-devel krb5-devel
+pip3 install hdfs[kerberos] --user

--- a/client/verta/hdfs-test/install.txt
+++ b/client/verta/hdfs-test/install.txt
@@ -1,2 +1,24 @@
 sudo yum install -y gcc python3-devel krb5-devel
 pip3 install hdfs[kerberos] --user
+
+
+https://www.usessionbuddy.com/post/How-To-Install-Spark-and-Pyspark-On-Centos/
+sudo yum install java-1.8.0-openjdk
+sudo su
+cd /opt
+wget https://mirror.csclub.uwaterloo.ca/apache/spark/spark-2.4.7/spark-2.4.7-bin-hadoop2.7.tgz
+tar -xzf spark-2.4.7-bin-hadoop2.7.tgz
+ln -s spark-2.4.7-bin-hadoop2.7 /opt/spark
+exit
+echo 'export SPARK_HOME=/opt/spark' >> ~/.bashrc
+echo 'export PATH=$SPARK_HOME/bin:$PATH' >> ~/.bashrc
+source ~/.bashrc
+sudo chown -R ec2-user:ec2-user /opt/spark-2.4.7-bin-hadoop2.7
+sudo yum install -y python34-setuptools
+sudo easy_install-3.4 pip
+$SPARK_HOME/sbin/start-master.sh
+pip3 install wheel --user
+pip3 install pyspark==2.4.7 --user
+echo 'export PYTHONPATH=$SPARK_HOME/python:$SPARK_HOME/python/lib/py4j-0.10.7-src.zip' >> ~/.bashrc
+source ~/.bashrc
+export PYSPARK_PYTHON=python3

--- a/client/verta/hdfs-test/install.txt
+++ b/client/verta/hdfs-test/install.txt
@@ -14,8 +14,8 @@ echo 'export SPARK_HOME=/opt/spark' >> ~/.bashrc
 echo 'export PATH=$SPARK_HOME/bin:$PATH' >> ~/.bashrc
 source ~/.bashrc
 sudo chown -R ec2-user:ec2-user /opt/spark-2.4.7-bin-hadoop2.7
-sudo yum install -y python34-setuptools
-sudo easy_install-3.4 pip
+#sudo yum install -y python34-setuptools
+#sudo easy_install-3.4 pip
 $SPARK_HOME/sbin/start-master.sh
 pip3 install wheel --user
 pip3 install pyspark==2.4.7 --user

--- a/client/verta/hdfs-test/test-pyspark.py
+++ b/client/verta/hdfs-test/test-pyspark.py
@@ -1,0 +1,16 @@
+import hashlib
+
+def hash_content(content):
+    import hashlib
+    return hashlib.md5(content).hexdigest()
+
+from pyspark import SparkContext
+sc = SparkContext("local")
+
+from verta.dataset import HDFSPath
+blob = HDFSPath.with_spark(sc, 'hdfs://ip-10-0-147-175.ec2.internal:8020/data/census/*')
+print(blob)
+
+# files = sc.binaryFiles('hdfs://ip-10-0-147-175.ec2.internal:8020/data/census/*')
+# names = files.map(lambda x: (x[0], hashlib.md5(x[1]).hexdigest()))
+# print(names.collect())

--- a/client/verta/hdfs-test/test.py
+++ b/client/verta/hdfs-test/test.py
@@ -3,5 +3,11 @@ from hdfs.client import InsecureClient
 client = InsecureClient("http://ip-10-0-147-175.ec2.internal:50070", user="ec2-user")
 
 print(client.list('/data/census'))
-with client.read('/data/census/census-test.csv') as reader:
-    print(reader.read())
+print(client.content('/data/census/census-test.csv'))
+
+from verta.dataset import HDFSPath
+
+print(HDFSPath(client, '/data/census/census-test.csv'))
+
+# with client.read('/data/census/census-test.csv') as reader:
+#     print(reader.read())

--- a/client/verta/hdfs-test/test.py
+++ b/client/verta/hdfs-test/test.py
@@ -1,0 +1,7 @@
+from hdfs.client import InsecureClient
+
+client = InsecureClient("http://ip-10-0-147-175.ec2.internal:50070", user="ec2-user")
+
+print(client.list('/data/census'))
+with client.read('/data/census/census-test.csv') as reader:
+    print(reader.read())

--- a/client/verta/hdfs-test/test.py
+++ b/client/verta/hdfs-test/test.py
@@ -8,6 +8,8 @@ print(client.content('/data/census/census-test.csv'))
 from verta.dataset import HDFSPath
 
 print(HDFSPath(client, '/data/census/census-test.csv'))
+print(HDFSPath(client, '/data/census/'))
+print(HDFSPath(client, '/data/census'))
 
 # with client.read('/data/census/census-test.csv') as reader:
 #     print(reader.read())

--- a/client/verta/verta/dataset/__init__.py
+++ b/client/verta/verta/dataset/__init__.py
@@ -1,3 +1,4 @@
 from ._dataset import _Dataset
 from ._path import Path
+from ._hdfs import HDFSPath
 from ._s3 import S3

--- a/client/verta/verta/dataset/_hdfs.py
+++ b/client/verta/verta/dataset/_hdfs.py
@@ -20,6 +20,16 @@ class HDFSPath(Path):
         if isinstance(paths, six.string_types):
             paths = [paths]
 
+        filepaths = set()
+        for path in paths:
+            for base, dirs, files in self.client.walk(path):
+                for filename in files:
+                    filepaths.add(base + filename)
+            else:
+                filepaths.add(path)
+
+        paths = sorted(list(filepaths))
+
         paths = list(map(lambda path: _HDFS_PREFIX+path if not path.startswith(_HDFS_PREFIX) else path, paths))
         if base_path and not base_path.startswith(_HDFS_PREFIX):
             base_path = _HDFS_PREFIX+base_path

--- a/client/verta/verta/dataset/_hdfs.py
+++ b/client/verta/verta/dataset/_hdfs.py
@@ -22,10 +22,13 @@ class HDFSPath(Path):
 
         filepaths = set()
         for path in paths:
+            previous_length = len(filepaths)
             for base, dirs, files in self.client.walk(path):
                 for filename in files:
                     filepaths.add(base + "/" + filename)
-            else:
+
+            # If the path was a file, then we didn't add any new entry and we should add the file
+            if len(filepaths) == previous_length:
                 filepaths.add(path)
 
         paths = sorted(list(filepaths))

--- a/client/verta/verta/dataset/_hdfs.py
+++ b/client/verta/verta/dataset/_hdfs.py
@@ -13,7 +13,7 @@ from . import _dataset
 
 _HDFS_PREFIX = "hdfs://"
 
-class HDFSPath(Path):
+class HDFSPath(Path):  # TODO: docstrings, add to docs
     # TODO: support mdb versioning
     def __init__(self, hdfs_client, paths, base_path=None):
         self.client = hdfs_client

--- a/client/verta/verta/dataset/_hdfs.py
+++ b/client/verta/verta/dataset/_hdfs.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function
+
+import hashlib
+
+from ._path import Path
+
+from . import _dataset
+
+class HDFSPath(Path):
+    # TODO: support mdb versioning
+    def __init__(self, hdfs_client, paths, base_path=None):
+        self.client = hdfs_client
+
+        paths = list(map(lambda path: "hdfs:/"+path if not path.startswith("hdfs:/") else path, paths))
+        if base_path and not base_path.startswith("hdfs:/"):
+            base_path = "hdfs:/"+base_path
+
+        super(HDFSPath, self).__init__(paths, base_path)
+
+    def _file_to_component(self, filepath):
+        metadata = self.client.status(filepath)
+        return _dataset.Component(
+            path=filepath,
+            size=metadata['length'],
+            last_modified=metadata['modificationTime'],
+            md5=self._hash_file(filepath),
+        )
+
+    def _hash_file(self, filepath):
+        """
+        Returns the MD5 hash of `filename`.
+
+        Notes
+        -----
+        Loop recommended by https://stackoverflow.com/questions/3431825 and
+        https://stackoverflow.com/questions/1131220.
+
+        """
+        return
+        file_hash = hashlib.md5()
+        with self.client.read(filepath) as f:
+            for chunk in iter(lambda: f.read(2**20), b''):
+                file_hash.update(chunk)
+        return file_hash.hexdigest()

--- a/client/verta/verta/dataset/_hdfs.py
+++ b/client/verta/verta/dataset/_hdfs.py
@@ -80,7 +80,7 @@ class HDFSPath(Path):
             h = hashlib.md5(content).hexdigest()
             return _dataset.Component(
                 path=filepath,
-                # size=metadata['length'],
+                size=len(content),
                 # last_modified=metadata['modificationTime'], # handle timezone?
                 md5=hashlib.md5(content).hexdigest(),
             )

--- a/client/verta/verta/dataset/_hdfs.py
+++ b/client/verta/verta/dataset/_hdfs.py
@@ -24,7 +24,7 @@ class HDFSPath(Path):
         for path in paths:
             for base, dirs, files in self.client.walk(path):
                 for filename in files:
-                    filepaths.add(base + filename)
+                    filepaths.add(base + "/" + filename)
             else:
                 filepaths.add(path)
 

--- a/client/verta/verta/dataset/_hdfs.py
+++ b/client/verta/verta/dataset/_hdfs.py
@@ -72,7 +72,7 @@ class HDFSPath(Path):
         if isinstance(paths, six.string_types):
             paths = [paths]
 
-        rdds = list(map(sc.binaryFiles(paths)))
+        rdds = list(map(sc.binaryFiles, paths))
         rdd = functools.reduce(lambda a,b: a.union(b), rdds)
 
         def get_component(entry):

--- a/client/verta/verta/dataset/_hdfs.py
+++ b/client/verta/verta/dataset/_hdfs.py
@@ -42,7 +42,7 @@ class HDFSPath(Path):  # TODO: docstrings, add to docs
 
     def _file_to_component(self, filepath):
         original_filepath = filepath
-        filepath = filepath[len(_HDFS_PREFIX):]
+        filepath = filepath[len(_HDFS_PREFIX):]  # prefix prepended in init
         metadata = self.client.status(filepath)
         return _dataset.Component(
             path=original_filepath,

--- a/client/verta/verta/dataset/_hdfs.py
+++ b/client/verta/verta/dataset/_hdfs.py
@@ -6,12 +6,17 @@ import hashlib
 
 from ._path import Path
 
+from ..external import six
+
 from . import _dataset
 
 class HDFSPath(Path):
     # TODO: support mdb versioning
     def __init__(self, hdfs_client, paths, base_path=None):
         self.client = hdfs_client
+
+        if isinstance(paths, six.string_types):
+            paths = [paths]
 
         paths = list(map(lambda path: "hdfs:/"+path if not path.startswith("hdfs:/") else path, paths))
         if base_path and not base_path.startswith("hdfs:/"):

--- a/client/verta/verta/dataset/_path.py
+++ b/client/verta/verta/dataset/_path.py
@@ -56,11 +56,11 @@ class Path(_dataset._Dataset):
 
     """
     def __init__(self, paths, base_path=None, enable_mdb_versioning=False):
+        super(Path, self).__init__(enable_mdb_versioning=enable_mdb_versioning)
+
         if isinstance(paths, six.string_types):
             paths = [paths]
         paths = map(os.path.expanduser, paths)
-
-        super(Path, self).__init__(enable_mdb_versioning=enable_mdb_versioning)
 
         filepaths = _file_utils.flatten_file_trees(paths)
         components = list(map(self._file_to_component, filepaths))

--- a/client/verta/verta/dataset/_path.py
+++ b/client/verta/verta/dataset/_path.py
@@ -106,18 +106,16 @@ class Path(_dataset._Dataset):
 
         return blob_msg
 
-    @classmethod
-    def _file_to_component(cls, filepath):
+    def _file_to_component(self, filepath):
         return _dataset.Component(
             path=filepath,
             size=os.stat(filepath).st_size,
             last_modified=_utils.timestamp_to_ms(os.stat(filepath).st_mtime),
-            md5=cls._hash_file(filepath),
+            md5=self._hash_file(filepath),
         )
 
     # TODO: move to _file_utils.calc_md5()
-    @staticmethod
-    def _hash_file(filepath):
+    def _hash_file(self, filepath):
         """
         Returns the MD5 hash of `filename`.
 


### PR DESCRIPTION
The HDFS blob is converted to a Path after we use the client to fetch all the metadata related to HDFS itself.

This is the result of running `python hdfs-test/test.py`. It needs to be converted into a proper test.
```
['census-test.csv', 'census-train.csv']
{'directoryCount': 0, 'fileCount': 1, 'length': 9950413, 'quota': -1, 'spaceConsumed': 9950413, 'spaceQuota': -1, 'typeQuota': {}}
HDFSPath Version
    hdfs://data/census/census-test.csv
        9950413 bytes
        last modified: 2020-11-22 18:12:09.330000
        MD5 checksum: 7b0b17a5271852616ed19a72914e776d
HDFSPath Version
    hdfs://data/census/census-test.csv
        9950413 bytes
        last modified: 2020-11-22 18:12:09.330000
        MD5 checksum: 7b0b17a5271852616ed19a72914e776d
    hdfs://data/census/census-train.csv
        3271573 bytes
        last modified: 2020-11-22 18:12:01.846000
        MD5 checksum: 64af2ff44dd04acceb277d024939b619
HDFSPath Version
    hdfs://data/census/census-test.csv
        9950413 bytes
        last modified: 2020-11-22 18:12:09.330000
        MD5 checksum: 7b0b17a5271852616ed19a72914e776d
    hdfs://data/census/census-train.csv
        3271573 bytes
        last modified: 2020-11-22 18:12:01.846000
        MD5 checksum: 64af2ff44dd04acceb277d024939b619
```

Using pyspark:
```
$ python3 hdfs-test/test-pyspark.py 
20/11/22 23:05:00 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
Using Spark's default log4j profile: org/apache/spark/log4j-defaults.properties
Setting default log level to "WARN".
To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).
HDFSPath Version                                                                
    hdfs://ip-10-0-147-175.ec2.internal:8020/data/census/census-test.csv
        9950413 bytes
        MD5 checksum: 7b0b17a5271852616ed19a72914e776d
    hdfs://ip-10-0-147-175.ec2.internal:8020/data/census/census-train.csv
        3271573 bytes
        MD5 checksum: 64af2ff44dd04acceb277d024939b619
```
Note: pyspark doesn't provide a *supported* way to get the timestamp from the hdfs location. There are hacks to do that, but they use unsupported APIs (private), so we don't support them either.
Note2: this pyspark functionality is actually independent of the type of data (s3 or even local), so we should probably place it somewhere else later.