### PR TITLE
Implement get/log tags for experiment and project

### DIFF
--- a/client/verta/tests/conftest.py
+++ b/client/verta/tests/conftest.py
@@ -444,3 +444,11 @@ def requirements_file():
         tempf.seek(0)
 
         yield tempf
+
+@pytest.fixture
+def created_projects():
+    to_delete =[]
+    yield to_delete
+
+    for project in to_delete:
+        project.delete()

--- a/client/verta/tests/test_entities.py
+++ b/client/verta/tests/test_entities.py
@@ -277,6 +277,21 @@ class TestProject:
         verta._internal_utils._utils.raise_for_http_error(response)
         assert response.json().get('tags', []) == [TAG]
 
+    def test_find_with_tag(self, client, created_projects):
+        tag = "some-tag"
+        diff_tag = "diff-tag"
+
+        project_with_diff_tag = client.set_project("run-with-diff-tag")
+        project_with_diff_tag.log_tag(diff_tag)
+
+        projects_with_tag = []
+        for _ in range(5):
+            projects_with_tag.append(client.set_project())
+            projects_with_tag[-1].log_tag(tag)
+
+        found_projects = client.projects.find("tags ~= {}".format(tag))
+        assert len(found_projects) == len(projects_with_tag)
+
 
 class TestExperiment:
     def test_create(self, client):
@@ -346,6 +361,34 @@ class TestExperiment:
         response = verta._internal_utils._utils.make_request("GET", endpoint, client._conn, params={'id': expt.id})
         verta._internal_utils._utils.raise_for_http_error(response)
         assert response.json().get('tags', []) == [TAG]
+
+    def test_tags(self, client):
+        proj = client.set_project()
+        expt = client.set_experiment(tags=["tag1", "tag2"])
+
+        assert expt.get_tags() == ["tag1", "tag2"]
+
+        expt.add_tag("tag3")
+        assert expt.get_tags() == ["tag1", "tag2", "tag3"]
+
+        expt.add_tags(["tag1", "tag4", "tag5"])
+        assert expt.get_tags() == ["tag1", "tag2", "tag3", "tag4", "tag5"]
+
+    def test_find_with_tag(self, client):
+        proj = client.set_project()
+        tag = "some-tag"
+        diff_tag = "diff-tag"
+
+        expt_with_diff_tag = client.set_experiment("run-with-diff-tag")
+        expt_with_diff_tag.log_tag(diff_tag)
+
+        expts_with_tag = []
+        for _ in range(5):
+            expts_with_tag.append(client.set_experiment())
+            expts_with_tag[-1].log_tag(tag)
+
+        found_expts = proj.experiments.find("tags ~= {}".format(tag))
+        assert len(found_expts) == len(expts_with_tag)
 
 
 class TestExperimentRun:

--- a/client/verta/tests/test_entities.py
+++ b/client/verta/tests/test_entities.py
@@ -277,17 +277,29 @@ class TestProject:
         verta._internal_utils._utils.raise_for_http_error(response)
         assert response.json().get('tags', []) == [TAG]
 
+    def test_tags(self, client):
+        proj = client.set_project(tags=["tag1", "tag2"])
+
+        assert proj.get_tags() == ["tag1", "tag2"]
+
+        proj.log_tag("tag3")
+        assert proj.get_tags() == ["tag1", "tag2", "tag3"]
+
+        proj.log_tags(["tag1", "tag4", "tag5"])
+        assert proj.get_tags() == ["tag1", "tag2", "tag3", "tag4", "tag5"]
+
     def test_find_with_tag(self, client, created_projects):
         tag = "some-tag"
         diff_tag = "diff-tag"
-
-        project_with_diff_tag = client.set_project("run-with-diff-tag")
-        project_with_diff_tag.log_tag(diff_tag)
 
         projects_with_tag = []
         for _ in range(5):
             projects_with_tag.append(client.set_project())
             projects_with_tag[-1].log_tag(tag)
+            created_projects.append(projects_with_tag[-1])
+
+        project_with_diff_tag = client.set_project("run-with-diff-tag")  # last one will be deleted by client fixture
+        project_with_diff_tag.log_tag(diff_tag)
 
         found_projects = client.projects.find("tags ~= {}".format(tag))
         assert len(found_projects) == len(projects_with_tag)
@@ -366,12 +378,12 @@ class TestExperiment:
         proj = client.set_project()
         expt = client.set_experiment(tags=["tag1", "tag2"])
 
-        assert expt.get_tags() == ["tag1", "tag2"]
+        assert expt.log_tag() == ["tag1", "tag2"]
 
-        expt.add_tag("tag3")
+        expt.log_tag("tag3")
         assert expt.get_tags() == ["tag1", "tag2", "tag3"]
 
-        expt.add_tags(["tag1", "tag4", "tag5"])
+        expt.log_tags(["tag1", "tag4", "tag5"])
         assert expt.get_tags() == ["tag1", "tag2", "tag3", "tag4", "tag5"]
 
     def test_find_with_tag(self, client):


### PR DESCRIPTION
Eventually, we will need to refactor the get/log (and potentially delete) tags of these entities into a TaggableEntity superclass.