### PR TITLE
Revert "Revert "PESSIMISTIC_WRITE locking""

### DIFF
--- a/backend/src/main/java/ai/verta/modeldb/cron_jobs/DeleteEntitiesCron.java
+++ b/backend/src/main/java/ai/verta/modeldb/cron_jobs/DeleteEntitiesCron.java
@@ -33,6 +33,8 @@ import java.util.stream.Collectors;
 import javax.persistence.OptimisticLockException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.hibernate.LockMode;
+import org.hibernate.LockOptions;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.query.Query;
@@ -796,7 +798,10 @@ public class DeleteEntitiesCron extends TimerTask {
             .append(ModelDBConstants.ENTITY_TYPE)
             .append(" = :entityType")
             .toString();
-    Query deleteLabelsQuery = session.createQuery(deleteLabelsQueryString);
+    Query deleteLabelsQuery =
+        session
+            .createQuery(deleteLabelsQueryString)
+            .setLockOptions(new LockOptions().setLockMode(LockMode.PESSIMISTIC_WRITE));
     deleteLabelsQuery.setParameter("entityHash", entityHash);
     deleteLabelsQuery.setParameter("entityType", idType.getNumber());
     deleteLabelsQuery.executeUpdate();
@@ -810,7 +815,10 @@ public class DeleteEntitiesCron extends TimerTask {
             .append(" AND at.entity_name ")
             .append(" = :entityName")
             .toString();
-    Query deleteLabelsQuery = session.createQuery(deleteAllAttributes);
+    Query deleteLabelsQuery =
+        session
+            .createQuery(deleteAllAttributes)
+            .setLockOptions(new LockOptions().setLockMode(LockMode.PESSIMISTIC_WRITE));
     deleteLabelsQuery.setParameter("entityHash", entityHash);
     deleteLabelsQuery.setParameter("entityName", ModelDBConstants.BLOB);
     deleteLabelsQuery.executeUpdate();

--- a/backend/src/main/java/ai/verta/modeldb/dataset/DatasetDAORdbImpl.java
+++ b/backend/src/main/java/ai/verta/modeldb/dataset/DatasetDAORdbImpl.java
@@ -54,6 +54,8 @@ import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.hibernate.LockMode;
+import org.hibernate.LockOptions;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.query.Query;
@@ -315,7 +317,10 @@ public class DatasetDAORdbImpl implements DatasetDAO {
 
     try (Session session = ModelDBHibernateUtil.getSessionFactory().openSession()) {
       Transaction transaction = session.beginTransaction();
-      Query deletedDatasetsQuery = session.createQuery(DELETED_STATUS_DATASET_QUERY_STRING);
+      Query deletedDatasetsQuery =
+          session
+              .createQuery(DELETED_STATUS_DATASET_QUERY_STRING)
+              .setLockOptions(new LockOptions().setLockMode(LockMode.PESSIMISTIC_WRITE));
       deletedDatasetsQuery.setParameter("deleted", true);
       deletedDatasetsQuery.setParameter("datasetIds", allowedDatasetIds);
       int updatedCount = deletedDatasetsQuery.executeUpdate();
@@ -569,7 +574,8 @@ public class DatasetDAORdbImpl implements DatasetDAO {
   public Dataset updateDatasetName(String datasetId, String datasetName)
       throws InvalidProtocolBufferException {
     try (Session session = ModelDBHibernateUtil.getSessionFactory().openSession()) {
-      DatasetEntity datasetObj = session.load(DatasetEntity.class, datasetId);
+      DatasetEntity datasetObj =
+          session.load(DatasetEntity.class, datasetId, LockMode.PESSIMISTIC_WRITE);
 
       Dataset dataset =
           Dataset.newBuilder()
@@ -600,7 +606,8 @@ public class DatasetDAORdbImpl implements DatasetDAO {
   public Dataset updateDatasetDescription(String datasetId, String datasetDescription)
       throws InvalidProtocolBufferException {
     try (Session session = ModelDBHibernateUtil.getSessionFactory().openSession()) {
-      DatasetEntity datasetObj = session.load(DatasetEntity.class, datasetId);
+      DatasetEntity datasetObj =
+          session.load(DatasetEntity.class, datasetId, LockMode.PESSIMISTIC_WRITE);
       datasetObj.setDescription(datasetDescription);
       datasetObj.setTime_updated(Calendar.getInstance().getTimeInMillis());
       Transaction transaction = session.beginTransaction();
@@ -621,7 +628,8 @@ public class DatasetDAORdbImpl implements DatasetDAO {
   public Dataset addDatasetTags(String datasetId, List<String> tagsList)
       throws InvalidProtocolBufferException {
     try (Session session = ModelDBHibernateUtil.getSessionFactory().openSession()) {
-      DatasetEntity datasetObj = session.get(DatasetEntity.class, datasetId);
+      DatasetEntity datasetObj =
+          session.get(DatasetEntity.class, datasetId, LockMode.PESSIMISTIC_WRITE);
       if (datasetObj == null) {
         String errorMessage = "Dataset not found for given ID";
         LOGGER.info(errorMessage);
@@ -679,13 +687,19 @@ public class DatasetDAORdbImpl implements DatasetDAO {
       StringBuilder stringQueryBuilder = new StringBuilder("delete from TagsMapping tm WHERE ");
       if (deleteAll) {
         stringQueryBuilder.append(" tm.datasetEntity." + ModelDBConstants.ID + " = :datasetId");
-        Query query = session.createQuery(stringQueryBuilder.toString());
+        Query query =
+            session
+                .createQuery(stringQueryBuilder.toString())
+                .setLockOptions(new LockOptions().setLockMode(LockMode.PESSIMISTIC_WRITE));
         query.setParameter(ModelDBConstants.DATASET_ID_STR, datasetId);
         query.executeUpdate();
       } else {
         stringQueryBuilder.append(" tm." + ModelDBConstants.TAGS + " in (:tags)");
         stringQueryBuilder.append(" AND tm.datasetEntity." + ModelDBConstants.ID + " = :datasetId");
-        Query query = session.createQuery(stringQueryBuilder.toString());
+        Query query =
+            session
+                .createQuery(stringQueryBuilder.toString())
+                .setLockOptions(new LockOptions().setLockMode(LockMode.PESSIMISTIC_WRITE));
         query.setParameter("tags", datasetTagList);
         query.setParameter(ModelDBConstants.DATASET_ID_STR, datasetId);
         query.executeUpdate();
@@ -710,7 +724,8 @@ public class DatasetDAORdbImpl implements DatasetDAO {
   public Dataset addDatasetAttributes(String datasetId, List<KeyValue> attributesList)
       throws InvalidProtocolBufferException {
     try (Session session = ModelDBHibernateUtil.getSessionFactory().openSession()) {
-      DatasetEntity datasetObj = session.get(DatasetEntity.class, datasetId);
+      DatasetEntity datasetObj =
+          session.get(DatasetEntity.class, datasetId, LockMode.PESSIMISTIC_WRITE);
       datasetObj.setAttributeMapping(
           RdbmsUtils.convertAttributesFromAttributeEntityList(
               datasetObj, ModelDBConstants.ATTRIBUTES, attributesList));
@@ -733,7 +748,8 @@ public class DatasetDAORdbImpl implements DatasetDAO {
   public Dataset updateDatasetAttributes(String datasetId, KeyValue attribute)
       throws InvalidProtocolBufferException {
     try (Session session = ModelDBHibernateUtil.getSessionFactory().openSession()) {
-      DatasetEntity datasetObj = session.get(DatasetEntity.class, datasetId);
+      DatasetEntity datasetObj =
+          session.get(DatasetEntity.class, datasetId, LockMode.PESSIMISTIC_WRITE);
       if (datasetObj == null) {
         String errorMessage = "Dataset not found for given ID";
         LOGGER.info(errorMessage);
@@ -815,14 +831,20 @@ public class DatasetDAORdbImpl implements DatasetDAO {
           new StringBuilder("delete from AttributeEntity attr WHERE ");
       if (deleteAll) {
         stringQueryBuilder.append(" attr.datasetEntity." + ModelDBConstants.ID + " = :datasetId");
-        Query query = session.createQuery(stringQueryBuilder.toString());
+        Query query =
+            session
+                .createQuery(stringQueryBuilder.toString())
+                .setLockOptions(new LockOptions().setLockMode(LockMode.PESSIMISTIC_WRITE));
         query.setParameter(ModelDBConstants.DATASET_ID_STR, datasetId);
         query.executeUpdate();
       } else {
         stringQueryBuilder.append(" attr." + ModelDBConstants.KEY + " in (:keys)");
         stringQueryBuilder.append(
             " AND attr.datasetEntity." + ModelDBConstants.ID + " = :datasetId");
-        Query query = session.createQuery(stringQueryBuilder.toString());
+        Query query =
+            session
+                .createQuery(stringQueryBuilder.toString())
+                .setLockOptions(new LockOptions().setLockMode(LockMode.PESSIMISTIC_WRITE));
         query.setParameter("keys", attributeKeyList);
         query.setParameter(ModelDBConstants.DATASET_ID_STR, datasetId);
         query.executeUpdate();
@@ -845,7 +867,8 @@ public class DatasetDAORdbImpl implements DatasetDAO {
   public Dataset setDatasetVisibility(String datasetId, DatasetVisibility datasetVisibility)
       throws InvalidProtocolBufferException {
     try (Session session = ModelDBHibernateUtil.getSessionFactory().openSession()) {
-      DatasetEntity datasetEntity = session.load(DatasetEntity.class, datasetId);
+      DatasetEntity datasetEntity =
+          session.load(DatasetEntity.class, datasetId, LockMode.PESSIMISTIC_WRITE);
 
       Integer oldVisibilityInt = datasetEntity.getDataset_visibility();
       DatasetVisibility oldVisibility = DatasetVisibility.PRIVATE;
@@ -967,7 +990,8 @@ public class DatasetDAORdbImpl implements DatasetDAO {
       throws InvalidProtocolBufferException {
 
     try (Session session = ModelDBHibernateUtil.getSessionFactory().openSession()) {
-      DatasetEntity datasetEntity = session.load(DatasetEntity.class, datasetId);
+      DatasetEntity datasetEntity =
+          session.load(DatasetEntity.class, datasetId, LockMode.PESSIMISTIC_WRITE);
       getWorkspaceRoleBindings(
           datasetEntity.getLegacy_workspace_id(),
           WorkspaceType.forNumber(datasetEntity.getWorkspace_type()),

--- a/backend/src/main/java/ai/verta/modeldb/datasetVersion/DatasetVersionDAORdbImpl.java
+++ b/backend/src/main/java/ai/verta/modeldb/datasetVersion/DatasetVersionDAORdbImpl.java
@@ -45,6 +45,8 @@ import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.hibernate.LockMode;
+import org.hibernate.LockOptions;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.query.Query;
@@ -135,7 +137,10 @@ public class DatasetVersionDAORdbImpl implements DatasetVersionDAO {
   public Boolean deleteDatasetVersionsByDatasetIDs(List<String> datasetIds) {
     try (Session session = ModelDBHibernateUtil.getSessionFactory().openSession()) {
       Transaction transaction = session.beginTransaction();
-      Query query = session.createQuery(DELETED_STATUS_DATASET_VERSION_BY_DATASET_QUERY_STRING);
+      Query query =
+          session
+              .createQuery(DELETED_STATUS_DATASET_VERSION_BY_DATASET_QUERY_STRING)
+              .setLockOptions(new LockOptions().setLockMode(LockMode.PESSIMISTIC_WRITE));
       query.setParameter("deleted", true);
       query.setParameterList("datasetIds", datasetIds);
       int updatedCount = query.executeUpdate();
@@ -489,7 +494,7 @@ public class DatasetVersionDAORdbImpl implements DatasetVersionDAO {
       throws InvalidProtocolBufferException {
     try (Session session = ModelDBHibernateUtil.getSessionFactory().openSession()) {
       DatasetVersionEntity datasetVersionObj =
-          session.get(DatasetVersionEntity.class, datasetVersionId);
+          session.get(DatasetVersionEntity.class, datasetVersionId, LockMode.PESSIMISTIC_WRITE);
       datasetVersionObj.setDescription(datasetVersionDescription);
       long currentTimestamp = Calendar.getInstance().getTimeInMillis();
       datasetVersionObj.setTime_updated(currentTimestamp);
@@ -512,7 +517,7 @@ public class DatasetVersionDAORdbImpl implements DatasetVersionDAO {
       throws InvalidProtocolBufferException {
     try (Session session = ModelDBHibernateUtil.getSessionFactory().openSession()) {
       DatasetVersionEntity datasetVersionObj =
-          session.get(DatasetVersionEntity.class, datasetVersionId);
+          session.get(DatasetVersionEntity.class, datasetVersionId, LockMode.PESSIMISTIC_WRITE);
       if (datasetVersionObj == null) {
         LOGGER.info(ModelDBMessages.DATA_VERSION_NOT_FOUND_ERROR_MSG);
         Status status =
@@ -558,14 +563,20 @@ public class DatasetVersionDAORdbImpl implements DatasetVersionDAO {
       Transaction transaction = session.beginTransaction();
 
       if (deleteAll) {
-        Query query = session.createQuery(DELETE_DATASET_VERSION_QUERY_PREFIX);
+        Query query =
+            session
+                .createQuery(DELETE_DATASET_VERSION_QUERY_PREFIX)
+                .setLockOptions(new LockOptions().setLockMode(LockMode.PESSIMISTIC_WRITE));
         query.setParameter(ModelDBConstants.DATASET_VERSION_ID_STR, datasetVersionId);
         query.executeUpdate();
       } else {
         StringBuilder stringQueryBuilder =
             new StringBuilder(DELETE_DATASET_VERSION_QUERY_PREFIX)
                 .append(" AND tm." + ModelDBConstants.TAGS + " in (:tags)");
-        Query query = session.createQuery(stringQueryBuilder.toString());
+        Query query =
+            session
+                .createQuery(stringQueryBuilder.toString())
+                .setLockOptions(new LockOptions().setLockMode(LockMode.PESSIMISTIC_WRITE));
         query.setParameter("tags", datasetVersionTagList);
         query.setParameter(ModelDBConstants.DATASET_VERSION_ID_STR, datasetVersionId);
         query.executeUpdate();
@@ -593,7 +604,7 @@ public class DatasetVersionDAORdbImpl implements DatasetVersionDAO {
       throws InvalidProtocolBufferException {
     try (Session session = ModelDBHibernateUtil.getSessionFactory().openSession()) {
       DatasetVersionEntity datasetVersionObj =
-          session.get(DatasetVersionEntity.class, datasetVersionId);
+          session.get(DatasetVersionEntity.class, datasetVersionId, LockMode.PESSIMISTIC_WRITE);
       datasetVersionObj.setAttributeMapping(
           RdbmsUtils.convertAttributesFromAttributeEntityList(
               datasetVersionObj, ModelDBConstants.ATTRIBUTES, attributesList));
@@ -618,7 +629,7 @@ public class DatasetVersionDAORdbImpl implements DatasetVersionDAO {
       throws InvalidProtocolBufferException {
     try (Session session = ModelDBHibernateUtil.getSessionFactory().openSession()) {
       DatasetVersionEntity datasetVersionObj =
-          session.get(DatasetVersionEntity.class, datasetVersionId);
+          session.get(DatasetVersionEntity.class, datasetVersionId, LockMode.PESSIMISTIC_WRITE);
       if (datasetVersionObj == null) {
         LOGGER.info(ModelDBMessages.DATA_VERSION_NOT_FOUND_ERROR_MSG);
         Status status =
@@ -702,7 +713,10 @@ public class DatasetVersionDAORdbImpl implements DatasetVersionDAO {
       Transaction transaction = session.beginTransaction();
 
       if (deleteAll) {
-        Query query = session.createQuery(DELETE_KEY_VALUE_DATASET_VERSION_QUERY_PREFIX);
+        Query query =
+            session
+                .createQuery(DELETE_KEY_VALUE_DATASET_VERSION_QUERY_PREFIX)
+                .setLockOptions(new LockOptions().setLockMode(LockMode.PESSIMISTIC_WRITE));
         query.setParameter(ModelDBConstants.DATASET_VERSION_ID_STR, datasetVersionId);
         query.executeUpdate();
       } else {
@@ -711,7 +725,10 @@ public class DatasetVersionDAORdbImpl implements DatasetVersionDAO {
                 .append(" AND attr.")
                 .append(ModelDBConstants.KEY)
                 .append(" in (:keys)");
-        Query query = session.createQuery(deleteKeyValueDatasetVersionQuery.toString());
+        Query query =
+            session
+                .createQuery(deleteKeyValueDatasetVersionQuery.toString())
+                .setLockOptions(new LockOptions().setLockMode(LockMode.PESSIMISTIC_WRITE));
         query.setParameter("keys", attributeKeyList);
         query.setParameter(ModelDBConstants.DATASET_VERSION_ID_STR, datasetVersionId);
         query.executeUpdate();
@@ -738,7 +755,7 @@ public class DatasetVersionDAORdbImpl implements DatasetVersionDAO {
       throws InvalidProtocolBufferException {
     try (Session session = ModelDBHibernateUtil.getSessionFactory().openSession()) {
       DatasetVersionEntity datasetVersionObj =
-          session.get(DatasetVersionEntity.class, datasetVersionId);
+          session.get(DatasetVersionEntity.class, datasetVersionId, LockMode.PESSIMISTIC_WRITE);
       datasetVersionObj.setDataset_version_visibility(datasetVersionVisibility.ordinal());
       long currentTimestamp = Calendar.getInstance().getTimeInMillis();
       datasetVersionObj.setTime_updated(currentTimestamp);

--- a/backend/src/main/java/ai/verta/modeldb/experimentRun/ExperimentRunDAORdbImpl.java
+++ b/backend/src/main/java/ai/verta/modeldb/experimentRun/ExperimentRunDAORdbImpl.java
@@ -2753,7 +2753,7 @@ public class ExperimentRunDAORdbImpl implements ExperimentRunDAO {
           acquireWriteLock(
               buildArtifactPartLockKey(
                   artifactEntity.getId(), request.getArtifactPart().getPartNumber()))) {
-        VersioningUtils.saveOrUpdateArtifactPartEntity(
+        VersioningUtils.saveArtifactPartEntity(
             request.getArtifactPart(),
             session,
             String.valueOf(artifactEntity.getId()),

--- a/backend/src/main/java/ai/verta/modeldb/lineage/LineageDAORdbImpl.java
+++ b/backend/src/main/java/ai/verta/modeldb/lineage/LineageDAORdbImpl.java
@@ -21,6 +21,8 @@ import java.util.Optional;
 import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.hibernate.LockMode;
+import org.hibernate.LockOptions;
 import org.hibernate.Session;
 import org.hibernate.query.Query;
 
@@ -198,7 +200,12 @@ public class LineageDAORdbImpl implements LineageDAO {
   }
 
   private void deleteLineage(Session session, LineageEntry input, LineageEntry output) {
-    getExisting(session, input, output).ifPresent(session::delete);
+    getExisting(session, input, output)
+        .ifPresent(
+            lineageEntity -> {
+              session.lock(lineageEntity, LockMode.PESSIMISTIC_WRITE);
+              session.delete(lineageEntity);
+            });
   }
 
   private void addLineage(Session session, LineageEntry input, LineageEntry output) {
@@ -206,7 +213,9 @@ public class LineageDAORdbImpl implements LineageDAO {
   }
 
   private void saveOrUpdate(Session session, LineageEntry input, LineageEntry output) {
-    session.saveOrUpdate(new LineageEntity(input, output));
+    LineageEntity lineageEntity = new LineageEntity(input, output);
+    session.buildLockRequest(new LockOptions().setLockMode(LockMode.PESSIMISTIC_WRITE));
+    session.saveOrUpdate(lineageEntity);
   }
 
   private Optional<LineageEntity> getExisting(

--- a/backend/src/main/java/ai/verta/modeldb/metadata/MetadataDAORdbImpl.java
+++ b/backend/src/main/java/ai/verta/modeldb/metadata/MetadataDAORdbImpl.java
@@ -20,6 +20,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.hibernate.LockMode;
+import org.hibernate.LockOptions;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.query.Query;
@@ -124,7 +126,7 @@ public class MetadataDAORdbImpl implements MetadataDAO {
     MetadataPropertyMappingEntity.LabelMappingId id0 =
         MetadataPropertyMappingEntity.createId(id, key);
     MetadataPropertyMappingEntity existingEntity =
-        session.get(MetadataPropertyMappingEntity.class, id0);
+        session.get(MetadataPropertyMappingEntity.class, id0, LockMode.PESSIMISTIC_WRITE);
     if (existingEntity == null) {
       session.saveOrUpdate(new MetadataPropertyMappingEntity(id0, value));
     } else {
@@ -137,7 +139,8 @@ public class MetadataDAORdbImpl implements MetadataDAO {
   public void addLabels(Session session, IdentificationType id, List<String> labels) {
     for (String label : labels) {
       LabelsMappingEntity.LabelMappingId id0 = LabelsMappingEntity.createId(id, label);
-      LabelsMappingEntity existingLabelsMappingEntity = session.get(LabelsMappingEntity.class, id0);
+      LabelsMappingEntity existingLabelsMappingEntity =
+          session.get(LabelsMappingEntity.class, id0, LockMode.PESSIMISTIC_WRITE);
       if (existingLabelsMappingEntity == null) {
         session.save(new LabelsMappingEntity(id0));
       }
@@ -309,7 +312,10 @@ public class MetadataDAORdbImpl implements MetadataDAO {
           .append(ModelDBConstants.ENTITY_TYPE)
           .append(" = :")
           .append(ModelDBConstants.ENTITY_TYPE);
-      Query<LabelsMappingEntity> query = session.createQuery(stringQueryBuilder.toString());
+      Query<LabelsMappingEntity> query =
+          session
+              .createQuery(stringQueryBuilder.toString())
+              .setLockOptions(new LockOptions().setLockMode(LockMode.PESSIMISTIC_WRITE));
       query.setParameter(ModelDBConstants.ENTITY_HASH, getEntityHash(id));
       query.setParameter(ModelDBConstants.ENTITY_TYPE, id.getIdTypeValue());
       query.executeUpdate();
@@ -317,7 +323,7 @@ public class MetadataDAORdbImpl implements MetadataDAO {
       for (String label : labels) {
         LabelsMappingEntity.LabelMappingId id0 = LabelsMappingEntity.createId(id, label);
         LabelsMappingEntity existingLabelsMappingEntity =
-            session.get(LabelsMappingEntity.class, id0);
+            session.get(LabelsMappingEntity.class, id0, LockMode.PESSIMISTIC_WRITE);
         if (existingLabelsMappingEntity != null) {
           session.delete(existingLabelsMappingEntity);
         }
@@ -333,7 +339,7 @@ public class MetadataDAORdbImpl implements MetadataDAO {
       MetadataPropertyMappingEntity.LabelMappingId id0 =
           MetadataPropertyMappingEntity.createId(id, key);
       MetadataPropertyMappingEntity existingMetadataMappingEntity =
-          session.get(MetadataPropertyMappingEntity.class, id0);
+          session.get(MetadataPropertyMappingEntity.class, id0, LockMode.PESSIMISTIC_WRITE);
       if (existingMetadataMappingEntity != null) {
         session.delete(existingMetadataMappingEntity);
       } else {
@@ -364,7 +370,7 @@ public class MetadataDAORdbImpl implements MetadataDAO {
             KeyValuePropertyMappingEntity.createId(
                 request.getId(), keyValue.getKey(), request.getPropertyName());
         KeyValuePropertyMappingEntity existingEntity =
-            session.get(KeyValuePropertyMappingEntity.class, id0);
+            session.get(KeyValuePropertyMappingEntity.class, id0, LockMode.PESSIMISTIC_WRITE);
         if (existingEntity == null) {
           existingEntity = new KeyValuePropertyMappingEntity(id0, keyValue.getValue());
           session.saveOrUpdate(existingEntity);
@@ -437,7 +443,10 @@ public class MetadataDAORdbImpl implements MetadataDAO {
             .append(ModelDBConstants.PROPERTY_NAME)
             .append(" = :")
             .append(ModelDBConstants.PROPERTY_NAME);
-        Query<LabelsMappingEntity> query = session.createQuery(stringQueryBuilder.toString());
+        Query<LabelsMappingEntity> query =
+            session
+                .createQuery(stringQueryBuilder.toString())
+                .setLockOptions(new LockOptions().setLockMode(LockMode.PESSIMISTIC_WRITE));
         query.setParameter(ModelDBConstants.ENTITY_HASH, getEntityHash(request.getId()));
         query.setParameter(ModelDBConstants.PROPERTY_NAME, request.getPropertyName());
         query.executeUpdate();
@@ -447,7 +456,7 @@ public class MetadataDAORdbImpl implements MetadataDAO {
               KeyValuePropertyMappingEntity.createId(
                   request.getId(), key, request.getPropertyName());
           KeyValuePropertyMappingEntity kvEntity =
-              session.get(KeyValuePropertyMappingEntity.class, id0);
+              session.get(KeyValuePropertyMappingEntity.class, id0, LockMode.PESSIMISTIC_WRITE);
           if (kvEntity != null) {
             session.delete(kvEntity);
           }

--- a/backend/src/main/java/ai/verta/modeldb/project/ProjectDAORdbImpl.java
+++ b/backend/src/main/java/ai/verta/modeldb/project/ProjectDAORdbImpl.java
@@ -64,6 +64,8 @@ import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.hibernate.LockMode;
+import org.hibernate.LockOptions;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.query.Query;
@@ -268,7 +270,8 @@ public class ProjectDAORdbImpl implements ProjectDAO {
   public Project updateProjectName(String projectId, String projectName)
       throws InvalidProtocolBufferException {
     try (Session session = ModelDBHibernateUtil.getSessionFactory().openSession()) {
-      ProjectEntity projectEntity = session.load(ProjectEntity.class, projectId);
+      ProjectEntity projectEntity =
+          session.load(ProjectEntity.class, projectId, LockMode.PESSIMISTIC_WRITE);
 
       Project project =
           Project.newBuilder()
@@ -298,7 +301,8 @@ public class ProjectDAORdbImpl implements ProjectDAO {
   public Project updateProjectDescription(String projectId, String projectDescription)
       throws InvalidProtocolBufferException {
     try (Session session = ModelDBHibernateUtil.getSessionFactory().openSession()) {
-      ProjectEntity projectEntity = session.load(ProjectEntity.class, projectId);
+      ProjectEntity projectEntity =
+          session.load(ProjectEntity.class, projectId, LockMode.PESSIMISTIC_WRITE);
       projectEntity.setDescription(projectDescription);
       projectEntity.setDate_updated(Calendar.getInstance().getTimeInMillis());
       Transaction transaction = session.beginTransaction();
@@ -319,7 +323,8 @@ public class ProjectDAORdbImpl implements ProjectDAO {
   public Project updateProjectReadme(String projectId, String projectReadme)
       throws InvalidProtocolBufferException {
     try (Session session = ModelDBHibernateUtil.getSessionFactory().openSession()) {
-      ProjectEntity projectEntity = session.load(ProjectEntity.class, projectId);
+      ProjectEntity projectEntity =
+          session.load(ProjectEntity.class, projectId, LockMode.PESSIMISTIC_WRITE);
       projectEntity.setReadme_text(projectReadme);
       projectEntity.setDate_updated(Calendar.getInstance().getTimeInMillis());
       Transaction transaction = session.beginTransaction();
@@ -340,7 +345,8 @@ public class ProjectDAORdbImpl implements ProjectDAO {
   public Project logProjectCodeVersion(String projectId, CodeVersion updatedCodeVersion)
       throws InvalidProtocolBufferException {
     try (Session session = ModelDBHibernateUtil.getSessionFactory().openSession()) {
-      ProjectEntity projectEntity = session.get(ProjectEntity.class, projectId);
+      ProjectEntity projectEntity =
+          session.get(ProjectEntity.class, projectId, LockMode.PESSIMISTIC_WRITE);
 
       CodeVersionEntity existingCodeVersionEntity = projectEntity.getCode_version_snapshot();
       if (existingCodeVersionEntity == null) {
@@ -382,7 +388,8 @@ public class ProjectDAORdbImpl implements ProjectDAO {
   public Project updateProjectAttributes(String projectId, KeyValue attribute)
       throws InvalidProtocolBufferException {
     try (Session session = ModelDBHibernateUtil.getSessionFactory().openSession()) {
-      ProjectEntity projectObj = session.get(ProjectEntity.class, projectId);
+      ProjectEntity projectObj =
+          session.get(ProjectEntity.class, projectId, LockMode.PESSIMISTIC_WRITE);
       if (projectObj == null) {
         String errorMessage = "Project not found for given ID";
         LOGGER.info(errorMessage);
@@ -464,7 +471,8 @@ public class ProjectDAORdbImpl implements ProjectDAO {
   public Project addProjectTags(String projectId, List<String> tagsList)
       throws InvalidProtocolBufferException {
     try (Session session = ModelDBHibernateUtil.getSessionFactory().openSession()) {
-      ProjectEntity projectObj = session.get(ProjectEntity.class, projectId);
+      ProjectEntity projectObj =
+          session.get(ProjectEntity.class, projectId, LockMode.PESSIMISTIC_WRITE);
       if (projectObj == null) {
         String errorMessage = "Project not found for given ID";
         LOGGER.info(errorMessage);
@@ -506,11 +514,17 @@ public class ProjectDAORdbImpl implements ProjectDAO {
       Transaction transaction = session.beginTransaction();
 
       if (deleteAll) {
-        Query query = session.createQuery(DELETE_ALL_PROJECT_TAGS_HQL);
+        Query query =
+            session
+                .createQuery(DELETE_ALL_PROJECT_TAGS_HQL)
+                .setLockOptions(new LockOptions().setLockMode(LockMode.PESSIMISTIC_WRITE));
         query.setParameter(ModelDBConstants.PROJECT_ID_STR, projectId);
         query.executeUpdate();
       } else {
-        Query query = session.createQuery(DELETE_SELECTED_PROJECT_TAGS_HQL);
+        Query query =
+            session
+                .createQuery(DELETE_SELECTED_PROJECT_TAGS_HQL)
+                .setLockOptions(new LockOptions().setLockMode(LockMode.PESSIMISTIC_WRITE));
         query.setParameter("tags", projectTagList);
         query.setParameter(ModelDBConstants.PROJECT_ID_STR, projectId);
         query.executeUpdate();
@@ -574,7 +588,8 @@ public class ProjectDAORdbImpl implements ProjectDAO {
   public Project addProjectAttributes(String projectId, List<KeyValue> attributesList)
       throws InvalidProtocolBufferException {
     try (Session session = ModelDBHibernateUtil.getSessionFactory().openSession()) {
-      ProjectEntity projectObj = session.get(ProjectEntity.class, projectId);
+      ProjectEntity projectObj =
+          session.get(ProjectEntity.class, projectId, LockMode.PESSIMISTIC_WRITE);
       projectObj.setAttributeMapping(
           RdbmsUtils.convertAttributesFromAttributeEntityList(
               projectObj, ModelDBConstants.ATTRIBUTES, attributesList));
@@ -601,11 +616,17 @@ public class ProjectDAORdbImpl implements ProjectDAO {
       Transaction transaction = session.beginTransaction();
 
       if (deleteAll) {
-        Query query = session.createQuery(DELETE_ALL_PROJECT_ATTRIBUTES_HQL);
+        Query query =
+            session
+                .createQuery(DELETE_ALL_PROJECT_ATTRIBUTES_HQL)
+                .setLockOptions(new LockOptions().setLockMode(LockMode.PESSIMISTIC_WRITE));
         query.setParameter(ModelDBConstants.PROJECT_ID_STR, projectId);
         query.executeUpdate();
       } else {
-        Query query = session.createQuery(DELETE_SELECTED_PROJECT_ATTRIBUTES_HQL);
+        Query query =
+            session
+                .createQuery(DELETE_SELECTED_PROJECT_ATTRIBUTES_HQL)
+                .setLockOptions(new LockOptions().setLockMode(LockMode.PESSIMISTIC_WRITE));
         query.setParameter("keys", attributeKeyList);
         query.setParameter(ModelDBConstants.PROJECT_ID_STR, projectId);
         query.executeUpdate();
@@ -754,7 +775,10 @@ public class ProjectDAORdbImpl implements ProjectDAO {
 
     try (Session session = ModelDBHibernateUtil.getSessionFactory().openSession()) {
       Transaction transaction = session.beginTransaction();
-      Query deletedProjectQuery = session.createQuery(DELETED_STATUS_PROJECT_QUERY_STRING);
+      Query deletedProjectQuery =
+          session
+              .createQuery(DELETED_STATUS_PROJECT_QUERY_STRING)
+              .setLockOptions(new LockOptions().setLockMode(LockMode.PESSIMISTIC_WRITE));
       deletedProjectQuery.setParameter("deleted", true);
       deletedProjectQuery.setParameter("projectIds", allowedProjectIds);
       int updatedCount = deletedProjectQuery.executeUpdate();

--- a/backend/src/main/java/ai/verta/modeldb/versioning/BlobDAORdbImpl.java
+++ b/backend/src/main/java/ai/verta/modeldb/versioning/BlobDAORdbImpl.java
@@ -2024,7 +2024,7 @@ public class BlobDAORdbImpl implements BlobDAO {
           getDatasetComponentBlob(blobExpandedMap.getKey().getBlob(), pathDatasetComponentBlobPath);
       String computeSha = componentWithSHAMap.get("computeSha");
 
-      VersioningUtils.saveOrUpdateArtifactPartEntity(
+      VersioningUtils.saveArtifactPartEntity(
           artifactPart, session, computeSha, ArtifactPartEntity.VERSION_BLOB_ARTIFACT);
       return CommitVersionedBlobArtifactPart.Response.newBuilder().build();
     } catch (Exception e) {

--- a/backend/src/main/java/ai/verta/modeldb/versioning/BlobDAORdbImpl.java
+++ b/backend/src/main/java/ai/verta/modeldb/versioning/BlobDAORdbImpl.java
@@ -76,6 +76,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.hibernate.LockMode;
+import org.hibernate.LockOptions;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.query.Query;
@@ -201,6 +203,7 @@ public class BlobDAORdbImpl implements BlobDAO {
       session.beginTransaction();
       CommitEntity commitEntity =
           commitDAO.getCommitEntity(session, commitHash, (session1 -> repositoryEntity));
+      session.lock(commitEntity, LockMode.PESSIMISTIC_WRITE);
       setBlobsAttributes(
           session, repositoryEntity.getId(), commitEntity.getCommit_hash(), blobList, addAttribute);
       commitEntity.setDate_updated(new Date().getTime());
@@ -287,6 +290,7 @@ public class BlobDAORdbImpl implements BlobDAO {
       session.beginTransaction();
       CommitEntity commitEntity =
           commitDAO.getCommitEntity(session, commitHash, (session1 -> repositoryEntity));
+      session.lock(commitEntity, LockMode.PESSIMISTIC_WRITE);
       if (deleteAll) {
         String entityHash =
             VersioningUtils.getVersioningCompositeId(
@@ -299,6 +303,7 @@ public class BlobDAORdbImpl implements BlobDAO {
         for (String removeAttrKey : attributesKeys) {
           for (AttributeEntity existingAttribute : existingAttributes) {
             if (existingAttribute.getKey().equals(removeAttrKey)) {
+              session.lock(existingAttribute, LockMode.PESSIMISTIC_WRITE);
               session.delete(existingAttribute);
             }
           }
@@ -900,26 +905,32 @@ public class BlobDAORdbImpl implements BlobDAO {
       String errorNameB = null;
       if (!request.getCommitA().isEmpty()) {
         errorNameA = request.getCommitA();
-        internalCommitA = session.get(CommitEntity.class, request.getCommitA());
+        internalCommitA =
+            session.get(CommitEntity.class, request.getCommitA(), LockMode.PESSIMISTIC_WRITE);
       }
 
       if (!request.getCommitB().isEmpty()) {
         errorNameB = request.getCommitB();
-        internalCommitB = session.get(CommitEntity.class, request.getCommitB());
+        internalCommitB =
+            session.get(CommitEntity.class, request.getCommitB(), LockMode.PESSIMISTIC_WRITE);
       }
 
       if (!request.getBranchA().isEmpty()) {
         errorNameA = request.getBranchA();
         BranchEntity branchAEntity =
             repositoryDAO.getBranchEntity(session, repositoryEntity.getId(), request.getBranchA());
-        internalCommitA = session.get(CommitEntity.class, branchAEntity.getCommit_hash());
+        internalCommitA =
+            session.get(
+                CommitEntity.class, branchAEntity.getCommit_hash(), LockMode.PESSIMISTIC_WRITE);
       }
 
       if (!request.getBranchB().isEmpty()) {
         errorNameB = request.getBranchB();
         BranchEntity branchBEntity =
             repositoryDAO.getBranchEntity(session, repositoryEntity.getId(), request.getBranchB());
-        internalCommitB = session.get(CommitEntity.class, branchBEntity.getCommit_hash());
+        internalCommitB =
+            session.get(
+                CommitEntity.class, branchBEntity.getCommit_hash(), LockMode.PESSIMISTIC_WRITE);
       }
 
       if (internalCommitA == null) {
@@ -1078,7 +1089,9 @@ public class BlobDAORdbImpl implements BlobDAO {
         BranchEntity branchAEntity =
             repositoryDAO.getBranchEntity(
                 readSession, repositoryEntity.getId(), request.getBranchA());
-        internalCommitA = readSession.get(CommitEntity.class, branchAEntity.getCommit_hash());
+        internalCommitA =
+            readSession.get(
+                CommitEntity.class, branchAEntity.getCommit_hash(), LockMode.PESSIMISTIC_WRITE);
       }
 
       if (!request.getBranchB().isEmpty()) {
@@ -1087,19 +1100,25 @@ public class BlobDAORdbImpl implements BlobDAO {
         BranchEntity branchBEntity =
             repositoryDAO.getBranchEntity(
                 readSession, repositoryEntity.getId(), request.getBranchB());
-        internalCommitB = readSession.get(CommitEntity.class, branchBEntity.getCommit_hash());
+        internalCommitB =
+            readSession.get(
+                CommitEntity.class, branchBEntity.getCommit_hash(), LockMode.PESSIMISTIC_WRITE);
       }
 
       if (!request.getCommitShaA().isEmpty()) {
         LOGGER.debug("Commit A found in request");
         branchOrCommitA = request.getCommitShaA().substring(0, 7);
-        internalCommitA = readSession.get(CommitEntity.class, request.getCommitShaA());
+        internalCommitA =
+            readSession.get(
+                CommitEntity.class, request.getCommitShaA(), LockMode.PESSIMISTIC_WRITE);
       }
 
       if (!request.getCommitShaB().isEmpty()) {
         LOGGER.debug("Commit B found in request");
         branchOrCommitB = request.getCommitShaB().substring(0, 7);
-        internalCommitB = readSession.get(CommitEntity.class, request.getCommitShaB());
+        internalCommitB =
+            readSession.get(
+                CommitEntity.class, request.getCommitShaB(), LockMode.PESSIMISTIC_WRITE);
       }
 
       if (internalCommitA == null) {
@@ -1186,6 +1205,7 @@ public class BlobDAORdbImpl implements BlobDAO {
                 parentCommits,
                 blobContainerList,
                 mergeMessage);
+        writeSession.lock(commitEntity, LockMode.PESSIMISTIC_WRITE);
         writeSession.saveOrUpdate(commitEntity);
         writeSession.getTransaction().commit();
         return MergeRepositoryCommitsRequest.Response.newBuilder()
@@ -1279,8 +1299,11 @@ public class BlobDAORdbImpl implements BlobDAO {
             Status.Code.NOT_FOUND);
       }
 
-      commitToRevertEntity = session.get(CommitEntity.class, request.getCommitToRevertSha());
-      baseCommitEntity = session.get(CommitEntity.class, request.getBaseCommitSha());
+      commitToRevertEntity =
+          session.get(
+              CommitEntity.class, request.getCommitToRevertSha(), LockMode.PESSIMISTIC_WRITE);
+      baseCommitEntity =
+          session.get(CommitEntity.class, request.getBaseCommitSha(), LockMode.PESSIMISTIC_WRITE);
 
       if (commitToRevertEntity.getParent_commits() == null
           || commitToRevertEntity.getParent_commits().isEmpty()) {
@@ -1944,7 +1967,10 @@ public class BlobDAORdbImpl implements BlobDAO {
     } else {
       throw new ModelDBException("Invalid content case found in DatasetBlob", Status.Code.INTERNAL);
     }
-    Query query = session.createQuery(getUploadStatusQuery.toString());
+    Query query =
+        session
+            .createQuery(getUploadStatusQuery.toString())
+            .setLockOptions(new LockOptions().setLockMode(LockMode.PESSIMISTIC_WRITE));
     query.setParameter("pathId", datasetComponentPathId);
     return query.list();
   }
@@ -1977,6 +2003,7 @@ public class BlobDAORdbImpl implements BlobDAO {
     try (Session session = ModelDBHibernateUtil.getSessionFactory().openSession()) {
       RepositoryEntity repository = repositoryFunction.apply(session);
       CommitEntity commitEntity = commitFunction.apply(session, session1 -> repository);
+      session.lock(commitEntity, LockMode.PESSIMISTIC_WRITE);
 
       Map<String, Map.Entry<BlobExpanded, String>> locationBlobWithHashMap =
           getCommitBlobMapWithHash(
@@ -2098,6 +2125,7 @@ public class BlobDAORdbImpl implements BlobDAO {
     try (Session session = ModelDBHibernateUtil.getSessionFactory().openSession()) {
       RepositoryEntity repository = repositoryFunction.apply(session);
       CommitEntity commitEntity = commitFunction.apply(session, session1 -> repository);
+      session.lock(commitEntity, LockMode.PESSIMISTIC_WRITE);
 
       Map<String, Map.Entry<BlobExpanded, String>> locationBlobWithHashMap =
           getCommitBlobMapWithHash(

--- a/backend/src/main/java/ai/verta/modeldb/versioning/VersioningUtils.java
+++ b/backend/src/main/java/ai/verta/modeldb/versioning/VersioningUtils.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.hibernate.LockMode;
 import org.hibernate.Session;
 import org.hibernate.query.Query;
 
@@ -226,6 +227,7 @@ public class VersioningUtils {
         new ArtifactPartEntity(
             artifactId, artifactType, artifactPart.getPartNumber(), artifactPart.getEtag());
     session.beginTransaction();
+    session.lock(artifactPartEntity, LockMode.PESSIMISTIC_WRITE);
     session.saveOrUpdate(artifactPartEntity);
     session.getTransaction().commit();
   }

--- a/backend/src/main/java/ai/verta/modeldb/versioning/VersioningUtils.java
+++ b/backend/src/main/java/ai/verta/modeldb/versioning/VersioningUtils.java
@@ -227,7 +227,6 @@ public class VersioningUtils {
         new ArtifactPartEntity(
             artifactId, artifactType, artifactPart.getPartNumber(), artifactPart.getEtag());
     session.beginTransaction();
-    session.lock(artifactPartEntity, LockMode.PESSIMISTIC_WRITE);
     session.saveOrUpdate(artifactPartEntity);
     session.getTransaction().commit();
   }

--- a/backend/src/main/java/ai/verta/modeldb/versioning/VersioningUtils.java
+++ b/backend/src/main/java/ai/verta/modeldb/versioning/VersioningUtils.java
@@ -221,7 +221,7 @@ public class VersioningUtils {
     }
   }
 
-  public static void saveOrUpdateArtifactPartEntity(
+  public static void saveArtifactPartEntity(
       ArtifactPart artifactPart, Session session, String artifactId, int artifactType) {
     ArtifactPartEntity artifactPartEntity =
         new ArtifactPartEntity(

--- a/backend/src/test/java/ai/verta/modeldb/HydratedServiceTest.java
+++ b/backend/src/test/java/ai/verta/modeldb/HydratedServiceTest.java
@@ -48,6 +48,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.AfterClass;
@@ -961,8 +962,14 @@ public class HydratedServiceTest {
 
     for (Experiment experiment : experimentMap.values()) {
       Experiment responseExperiment = hydratedExperimentMap.get(experiment.getId()).getExperiment();
+      List<String> tags = experiment.getTagsList().stream().sorted().collect(Collectors.toList());
       experiment =
-          experiment.toBuilder().setDateUpdated(responseExperiment.getDateUpdated()).build();
+          experiment
+              .toBuilder()
+              .clearTags()
+              .addAllTags(tags)
+              .setDateUpdated(responseExperiment.getDateUpdated())
+              .build();
       experimentMap.put(experiment.getId(), experiment);
       assertEquals(
           "Expected experimentRun not exist in the hydrated experimentRun",
@@ -1683,8 +1690,15 @@ public class HydratedServiceTest {
         LOGGER.info("GetExperimentsInProject Response : " + experimentList.size());
         for (Experiment experiment : experimentList) {
           Experiment expectedExperiment = experimentMap.get(experiment.getId());
+          List<String> tags =
+              expectedExperiment.getTagsList().stream().sorted().collect(Collectors.toList());
           expectedExperiment =
-              expectedExperiment.toBuilder().setDateUpdated(experiment.getDateUpdated()).build();
+              expectedExperiment
+                  .toBuilder()
+                  .clearTags()
+                  .addAllTags(tags)
+                  .setDateUpdated(experiment.getDateUpdated())
+                  .build();
           experimentMap.put(expectedExperiment.getId(), expectedExperiment);
           assertEquals(
               "Experiment not match with expected Experiment", expectedExperiment, experiment);
@@ -2055,8 +2069,15 @@ public class HydratedServiceTest {
         isExpectedResultFound = true;
         for (Experiment experiment : experimentList) {
           Experiment expectedExperiment = experimentMap.get(experiment.getId());
+          List<String> tags =
+              expectedExperiment.getTagsList().stream().sorted().collect(Collectors.toList());
           expectedExperiment =
-              expectedExperiment.toBuilder().setDateUpdated(experiment.getDateUpdated()).build();
+              expectedExperiment
+                  .toBuilder()
+                  .clearTags()
+                  .addAllTags(tags)
+                  .setDateUpdated(experiment.getDateUpdated())
+                  .build();
           experimentMap.put(expectedExperiment.getId(), expectedExperiment);
           assertEquals(
               "Experiment not match with expected experiment", expectedExperiment, experiment);


### PR DESCRIPTION
Reverts VertaAI/modeldb#1698

Fixes the bug causing the the StaleObjectException reported in https://vertaai.atlassian.net/browse/VR-8223 which was due to attempting to obtain a pessimistic write lock on a new object that had not yet been written.  