### PR TITLE
Install spacy<2.3.3 for Python 2

### DIFF
--- a/client/verta/requirements.txt
+++ b/client/verta/requirements.txt
@@ -12,6 +12,7 @@ six>=1.11
 pytest>=4.3
 
 # unit testing dependencies
+blis<0.7.3; python_version == '2.7'  # needed for spaCy, https://github.com/explosion/cython-blis/issues/42
 boto3
 google-cloud-bigquery
 h5py<3.0.0  # https://github.com/tensorflow/tensorflow/issues/44467
@@ -24,7 +25,7 @@ scikit-learn<0.21; python_version < '3.8'  # https://scikit-learn.org/stable/ins
 scikit-learn>=0.22; python_version >= '3.8'
 scipy<1.3; python_version < '3.8'
 scipy>=1.4; python_version >= '3.8'
-spacy!=2.3.1,!=2.3.4; python_version == '2.7'  # https://github.com/explosion/spaCy/issues/5729
+spacy!=2.3.1; python_version == '2.7'  # https://github.com/explosion/spaCy/issues/5729
 spacy; python_version != '2.7'
 tensorflow<2.0; python_version < '3.8'
 tensorflow>=2.2; python_version >= '3.8'  # https://www.tensorflow.org/install/pip

--- a/client/verta/requirements.txt
+++ b/client/verta/requirements.txt
@@ -12,7 +12,6 @@ six>=1.11
 pytest>=4.3
 
 # unit testing dependencies
-blis<0.7.3; python_version == '2.7'  # needed for spaCy, https://github.com/explosion/cython-blis/issues/42
 boto3
 google-cloud-bigquery
 h5py<3.0.0  # https://github.com/tensorflow/tensorflow/issues/44467
@@ -25,7 +24,7 @@ scikit-learn<0.21; python_version < '3.8'  # https://scikit-learn.org/stable/ins
 scikit-learn>=0.22; python_version >= '3.8'
 scipy<1.3; python_version < '3.8'
 scipy>=1.4; python_version >= '3.8'
-spacy!=2.3.1; python_version == '2.7'  # https://github.com/explosion/spaCy/issues/5729
+spacy!=2.3.1,!=2.3.4; python_version == '2.7'  # https://github.com/explosion/spaCy/issues/5729
 spacy; python_version != '2.7'
 tensorflow<2.0; python_version < '3.8'
 tensorflow>=2.2; python_version >= '3.8'  # https://www.tensorflow.org/install/pip

--- a/client/verta/requirements.txt
+++ b/client/verta/requirements.txt
@@ -12,6 +12,7 @@ six>=1.11
 pytest>=4.3
 
 # unit testing dependencies
+blis<0.7.3; python_version == '2.7'  # needed for spaCy, https://github.com/explosion/cython-blis/issues/42
 boto3
 google-cloud-bigquery
 h5py<3.0.0  # https://github.com/tensorflow/tensorflow/issues/44467

--- a/client/verta/requirements.txt
+++ b/client/verta/requirements.txt
@@ -12,7 +12,6 @@ six>=1.11
 pytest>=4.3
 
 # unit testing dependencies
-blis<0.7.3; python_version == '2.7'  # needed for spaCy, https://github.com/explosion/cython-blis/issues/42
 boto3
 google-cloud-bigquery
 h5py<3.0.0  # https://github.com/tensorflow/tensorflow/issues/44467
@@ -25,7 +24,7 @@ scikit-learn<0.21; python_version < '3.8'  # https://scikit-learn.org/stable/ins
 scikit-learn>=0.22; python_version >= '3.8'
 scipy<1.3; python_version < '3.8'
 scipy>=1.4; python_version >= '3.8'
-spacy!=2.3.1; python_version == '2.7'  # https://github.com/explosion/spaCy/issues/5729
+spacy!=2.3.1,<2.3.3; python_version == '2.7'  # https://github.com/explosion/spaCy/issues/5729
 spacy; python_version != '2.7'
 tensorflow<2.0; python_version < '3.8'
 tensorflow>=2.2; python_version >= '3.8'  # https://www.tensorflow.org/install/pip

--- a/client/verta/requirements.txt
+++ b/client/verta/requirements.txt
@@ -24,7 +24,7 @@ scikit-learn<0.21; python_version < '3.8'  # https://scikit-learn.org/stable/ins
 scikit-learn>=0.22; python_version >= '3.8'
 scipy<1.3; python_version < '3.8'
 scipy>=1.4; python_version >= '3.8'
-spacy!=2.3.1,<2.3.3; python_version == '2.7'  # https://github.com/explosion/spaCy/issues/5729
+spacy!=2.3.1,<2.3.3; python_version == '2.7'  # https://github.com/explosion/spaCy/issues/5729, https://github.com/explosion/spaCy/issues/6454
 spacy; python_version != '2.7'
 tensorflow<2.0; python_version < '3.8'
 tensorflow>=2.2; python_version >= '3.8'  # https://www.tensorflow.org/install/pip


### PR DESCRIPTION
Building wheel for `blis==0.7.3` fails on Debian (https://github.com/explosion/cython-blis/issues/42).