### PR TITLE
Limit spaCy version for Python 3.5 as well

### DIFF
--- a/client/verta/requirements.txt
+++ b/client/verta/requirements.txt
@@ -25,7 +25,7 @@ scikit-learn>=0.22; python_version >= '3.8'
 scipy<1.3; python_version < '3.8'
 scipy>=1.4; python_version >= '3.8'
 spacy!=2.3.1,<2.3.3; python_version < '3.6'  # https://github.com/explosion/spaCy/issues/5729, https://github.com/explosion/spaCy/issues/6454
-spacy; python_version != '2.7'
+spacy; python_version >= '3.6'
 tensorflow<2.0; python_version < '3.8'
 tensorflow>=2.2; python_version >= '3.8'  # https://www.tensorflow.org/install/pip
 torch

--- a/client/verta/requirements.txt
+++ b/client/verta/requirements.txt
@@ -24,7 +24,7 @@ scikit-learn<0.21; python_version < '3.8'  # https://scikit-learn.org/stable/ins
 scikit-learn>=0.22; python_version >= '3.8'
 scipy<1.3; python_version < '3.8'
 scipy>=1.4; python_version >= '3.8'
-spacy!=2.3.1,<2.3.3; python_version == '2.7'  # https://github.com/explosion/spaCy/issues/5729, https://github.com/explosion/spaCy/issues/6454
+spacy!=2.3.1,<2.3.3; python_version < '3.6'  # https://github.com/explosion/spaCy/issues/5729, https://github.com/explosion/spaCy/issues/6454
 spacy; python_version != '2.7'
 tensorflow<2.0; python_version < '3.8'
 tensorflow>=2.2; python_version >= '3.8'  # https://www.tensorflow.org/install/pip


### PR DESCRIPTION
Python 2.7 and 3.5 both need this, according to https://github.com/explosion/spaCy/blob/cdca44a/setup.cfg#L50.
Related to https://github.com/VertaAI/modeldb/pull/1706.