### PR TITLE
Cj/revert workspace column name

### DIFF
--- a/backend/src/main/java/ai/verta/modeldb/ModelDBConstants.java
+++ b/backend/src/main/java/ai/verta/modeldb/ModelDBConstants.java
@@ -119,6 +119,7 @@ public interface ModelDBConstants {
   String VALUE = "value";
   String WORKSPACE = "workspace";
   String LEGACY_WORKSPACE_ID = "legacy_workspace_id";
+  String LEGACY_WORKSPACE_ID_PROPERTY = "legacyWorkspaceId";
   String WORKSPACE_ID = "workspace_id";
   String WORKSPACE_NAME = "workspace_name";
   String WORKSPACE_TYPE = "workspace_type";

--- a/backend/src/main/java/ai/verta/modeldb/entities/DatasetEntity.java
+++ b/backend/src/main/java/ai/verta/modeldb/entities/DatasetEntity.java
@@ -92,7 +92,7 @@ public class DatasetEntity {
   @Column(name = "workspace_id")
   private Long workspaceId;
 
-  @Column(name = "legacy_workspace_id")
+  @Column(name = "workspace")
   private String legacy_workspace_id;
 
   @Column(name = "workspace_type")

--- a/backend/src/main/java/ai/verta/modeldb/entities/ProjectEntity.java
+++ b/backend/src/main/java/ai/verta/modeldb/entities/ProjectEntity.java
@@ -123,7 +123,7 @@ public class ProjectEntity {
   @Column(name = "workspace_id")
   private Long workspaceId;
 
-  @Column(name = "legacy_workspace_id")
+  @Column(name = "workspace")
   private String legacy_workspace_id;
 
   @Column(name = "workspace_type")

--- a/backend/src/main/java/ai/verta/modeldb/entities/versioning/RepositoryEntity.java
+++ b/backend/src/main/java/ai/verta/modeldb/entities/versioning/RepositoryEntity.java
@@ -99,10 +99,10 @@ public class RepositoryEntity {
   @Column(name = "date_updated")
   private Long date_updated;
 
-  @Column(name = "workspace_id")
+  @Column(name = "workspace_service_id")
   private Long workspaceId;
 
-  @Column(name = "legacy_workspace_id")
+  @Column(name = "workspace_id")
   private String legacyWorkspaceId;
 
   @Column(name = "workspace_type", columnDefinition = "varchar")

--- a/backend/src/main/java/ai/verta/modeldb/utils/RdbmsUtils.java
+++ b/backend/src/main/java/ai/verta/modeldb/utils/RdbmsUtils.java
@@ -2162,8 +2162,7 @@ public class RdbmsUtils {
             builder.equal(
                 entityRoot.get(ModelDBConstants.WORKSPACE_TYPE),
                 workspacePredicates.get(1).getValue().getNumberValue());
-        Predicate privatePredicate =
-            builder.and(builder.and(privateWorkspacePredicate, privateWorkspaceTypePredicate);
+        Predicate privatePredicate = builder.and(privateWorkspacePredicate, privateWorkspaceTypePredicate);
 
         finalPredicatesList.add(privatePredicate);
       }

--- a/backend/src/main/java/ai/verta/modeldb/utils/RdbmsUtils.java
+++ b/backend/src/main/java/ai/verta/modeldb/utils/RdbmsUtils.java
@@ -2157,12 +2157,16 @@ public class RdbmsUtils {
             builder.equal(
                 entityRoot.get(ModelDBConstants.WORKSPACE),
                 workspacePredicates.get(0).getValue().getStringValue());
+        Predicate privateLegacyWorkspaceIdPredicate =
+                builder.equal(
+                        entityRoot.get(ModelDBConstants.LEGACY_WORKSPACE_ID),
+                        workspacePredicates.get(0).getValue().getStringValue());
         Predicate privateWorkspaceTypePredicate =
             builder.equal(
                 entityRoot.get(ModelDBConstants.WORKSPACE_TYPE),
                 workspacePredicates.get(1).getValue().getNumberValue());
         Predicate privatePredicate =
-            builder.and(privateWorkspacePredicate, privateWorkspaceTypePredicate);
+            builder.and(builder.and(privateWorkspacePredicate, privateLegacyWorkspaceIdPredicate), privateWorkspaceTypePredicate);
 
         finalPredicatesList.add(privatePredicate);
       }

--- a/backend/src/main/java/ai/verta/modeldb/utils/RdbmsUtils.java
+++ b/backend/src/main/java/ai/verta/modeldb/utils/RdbmsUtils.java
@@ -2152,7 +2152,6 @@ public class RdbmsUtils {
     if (userInfo != null) {
       List<KeyValueQuery> workspacePredicates =
           ModelDBUtils.getKeyValueQueriesByWorkspace(roleService, userInfo, workspaceName);
-      LOGGER.info("workspacePredicates: " + workspacePredicates);
       if (workspacePredicates.size() > 0) {
         Predicate privateWorkspacePredicate =
             builder.equal(

--- a/backend/src/main/java/ai/verta/modeldb/utils/RdbmsUtils.java
+++ b/backend/src/main/java/ai/verta/modeldb/utils/RdbmsUtils.java
@@ -2124,6 +2124,7 @@ public class RdbmsUtils {
     }
 
     if (predicate.getKey().equalsIgnoreCase(ModelDBConstants.WORKSPACE)
+        || predicate.getKey().equalsIgnoreCase(ModelDBConstants.LEGACY_WORKSPACE_ID)
         || predicate.getKey().equalsIgnoreCase(ModelDBConstants.WORKSPACE_ID)
         || predicate.getKey().equalsIgnoreCase(ModelDBConstants.WORKSPACE_NAME)
         || predicate.getKey().equalsIgnoreCase(ModelDBConstants.WORKSPACE_TYPE)) {

--- a/backend/src/main/java/ai/verta/modeldb/utils/RdbmsUtils.java
+++ b/backend/src/main/java/ai/verta/modeldb/utils/RdbmsUtils.java
@@ -2156,7 +2156,7 @@ public class RdbmsUtils {
       if (workspacePredicates.size() > 0) {
         Predicate privateWorkspacePredicate =
             builder.equal(
-                entityRoot.get(ModelDBConstants.WORKSPACE),
+                entityRoot.get(ModelDBConstants.LEGACY_WORKSPACE_ID),
                 workspacePredicates.get(0).getValue().getStringValue());
         Predicate privateWorkspaceTypePredicate =
             builder.equal(

--- a/backend/src/main/java/ai/verta/modeldb/utils/RdbmsUtils.java
+++ b/backend/src/main/java/ai/verta/modeldb/utils/RdbmsUtils.java
@@ -2152,21 +2152,18 @@ public class RdbmsUtils {
     if (userInfo != null) {
       List<KeyValueQuery> workspacePredicates =
           ModelDBUtils.getKeyValueQueriesByWorkspace(roleService, userInfo, workspaceName);
+      LOGGER.info("workspacePredicates: " + workspacePredicates);
       if (workspacePredicates.size() > 0) {
         Predicate privateWorkspacePredicate =
             builder.equal(
                 entityRoot.get(ModelDBConstants.WORKSPACE),
                 workspacePredicates.get(0).getValue().getStringValue());
-        Predicate privateLegacyWorkspaceIdPredicate =
-                builder.equal(
-                        entityRoot.get(ModelDBConstants.LEGACY_WORKSPACE_ID),
-                        workspacePredicates.get(0).getValue().getStringValue());
         Predicate privateWorkspaceTypePredicate =
             builder.equal(
                 entityRoot.get(ModelDBConstants.WORKSPACE_TYPE),
                 workspacePredicates.get(1).getValue().getNumberValue());
         Predicate privatePredicate =
-            builder.and(builder.and(privateWorkspacePredicate, privateLegacyWorkspaceIdPredicate), privateWorkspaceTypePredicate);
+            builder.and(builder.and(privateWorkspacePredicate, privateWorkspaceTypePredicate);
 
         finalPredicatesList.add(privatePredicate);
       }

--- a/backend/src/main/java/ai/verta/modeldb/versioning/CommitDAORdbImpl.java
+++ b/backend/src/main/java/ai/verta/modeldb/versioning/CommitDAORdbImpl.java
@@ -918,6 +918,7 @@ public class CommitDAORdbImpl implements CommitDAO {
         }
 
         if (predicate.getKey().equalsIgnoreCase(ModelDBConstants.WORKSPACE)
+            || predicate.getKey().equalsIgnoreCase(ModelDBConstants.LEGACY_WORKSPACE_ID)
             || predicate.getKey().equalsIgnoreCase(ModelDBConstants.WORKSPACE_ID)
             || predicate.getKey().equalsIgnoreCase(ModelDBConstants.WORKSPACE_NAME)
             || predicate.getKey().equalsIgnoreCase(ModelDBConstants.WORKSPACE_TYPE)) {

--- a/backend/src/main/java/ai/verta/modeldb/versioning/FindRepositoriesQuery.java
+++ b/backend/src/main/java/ai/verta/modeldb/versioning/FindRepositoriesQuery.java
@@ -169,7 +169,7 @@ public class FindRepositoriesQuery {
           && workspaceDTO.getWorkspaceId() != null
           && !workspaceDTO.getWorkspaceId().isEmpty()) {
         whereClauseList.add(
-            alias + "." + ModelDBConstants.WORKSPACE_ID + " = :" + ModelDBConstants.WORKSPACE_ID);
+            alias + "." + ModelDBConstants.LEGACY_WORKSPACE_ID_PROPERTY + " = :" + ModelDBConstants.LEGACY_WORKSPACE_ID_PROPERTY);
         parametersMap.put(ModelDBConstants.WORKSPACE_ID, workspaceDTO.getWorkspaceId());
         whereClauseList.add(
             alias

--- a/backend/src/main/java/ai/verta/modeldb/versioning/FindRepositoriesQuery.java
+++ b/backend/src/main/java/ai/verta/modeldb/versioning/FindRepositoriesQuery.java
@@ -170,7 +170,7 @@ public class FindRepositoriesQuery {
           && !workspaceDTO.getWorkspaceId().isEmpty()) {
         whereClauseList.add(
             alias + "." + ModelDBConstants.LEGACY_WORKSPACE_ID_PROPERTY + " = :" + ModelDBConstants.LEGACY_WORKSPACE_ID_PROPERTY);
-        parametersMap.put(ModelDBConstants.WORKSPACE_ID, workspaceDTO.getWorkspaceId());
+        parametersMap.put(ModelDBConstants.LEGACY_WORKSPACE_ID_PROPERTY, workspaceDTO.getWorkspaceId());
         whereClauseList.add(
             alias
                 + "."

--- a/backend/src/main/java/ai/verta/modeldb/versioning/RepositoryDAORdbImpl.java
+++ b/backend/src/main/java/ai/verta/modeldb/versioning/RepositoryDAORdbImpl.java
@@ -1201,12 +1201,14 @@ public class RepositoryDAORdbImpl implements RepositoryDAO {
               .build();
         }
 
+        LOGGER.info("Validating predicates...");
         for (KeyValueQuery predicate : request.getPredicatesList()) {
           // Validate if current user has access to the entity or not where predicate key has an id
           LOGGER.info("Validating predicate: " + predicate);
           RdbmsUtils.validatePredicates(
               ModelDBConstants.REPOSITORY, accessibleResourceIds, predicate, roleService);
         }
+        LOGGER.info("Predicate validation complete.  Building query.");
 
         FindRepositoriesQuery findRepositoriesQuery =
             new FindRepositoriesQuery.FindRepositoriesHQLQueryBuilder(

--- a/backend/src/main/java/ai/verta/modeldb/versioning/RepositoryDAORdbImpl.java
+++ b/backend/src/main/java/ai/verta/modeldb/versioning/RepositoryDAORdbImpl.java
@@ -1385,7 +1385,7 @@ public class RepositoryDAORdbImpl implements RepositoryDAO {
           finalPredicatesList.add(
               builder.not(
                   builder.and(
-                      repositoryRoot.get(ModelDBConstants.WORKSPACE_ID).in(orgIds),
+                      repositoryRoot.get(ModelDBConstants.LEGACY_WORKSPACE_ID).in(orgIds),
                       builder.equal(
                           repositoryRoot.get(ModelDBConstants.WORKSPACE_TYPE),
                           WorkspaceType.ORGANIZATION_VALUE))));

--- a/backend/src/main/java/ai/verta/modeldb/versioning/RepositoryDAORdbImpl.java
+++ b/backend/src/main/java/ai/verta/modeldb/versioning/RepositoryDAORdbImpl.java
@@ -1399,7 +1399,7 @@ public class RepositoryDAORdbImpl implements RepositoryDAO {
           if (workspacePredicates.size() > 0) {
             Predicate privateWorkspacePredicate =
                 builder.equal(
-                    repositoryRoot.get(ModelDBConstants.WORKSPACE_ID),
+                    repositoryRoot.get(ModelDBConstants.LEGACY_WORKSPACE_ID),
                     workspacePredicates.get(0).getValue().getStringValue());
             Predicate privateWorkspaceTypePredicate =
                 builder.equal(

--- a/backend/src/main/java/ai/verta/modeldb/versioning/RepositoryDAORdbImpl.java
+++ b/backend/src/main/java/ai/verta/modeldb/versioning/RepositoryDAORdbImpl.java
@@ -1,5 +1,6 @@
 package ai.verta.modeldb.versioning;
 
+import static ai.verta.modeldb.ModelDBConstants.LEGACY_WORKSPACE_ID_PROPERTY;
 import static ai.verta.modeldb.metadata.IDTypeEnum.IDType.VERSIONING_REPOSITORY;
 
 import ai.verta.common.KeyValueQuery;
@@ -1202,6 +1203,7 @@ public class RepositoryDAORdbImpl implements RepositoryDAO {
 
         for (KeyValueQuery predicate : request.getPredicatesList()) {
           // Validate if current user has access to the entity or not where predicate key has an id
+          LOGGER.info("Validating predicate: " + predicate);
           RdbmsUtils.validatePredicates(
               ModelDBConstants.REPOSITORY, accessibleResourceIds, predicate, roleService);
         }
@@ -1215,6 +1217,8 @@ public class RepositoryDAORdbImpl implements RepositoryDAO {
                 .setPageLimit(request.getPageLimit())
                 .setPageNumber(request.getPageNumber())
                 .build();
+
+        LOGGER.info("findRepositoriesQuery: " + findRepositoriesQuery);
         List<RepositoryEntity> repositoryEntities =
             findRepositoriesQuery.getFindRepositoriesHQLQuery().list();
         Long totalRecords =
@@ -1385,7 +1389,7 @@ public class RepositoryDAORdbImpl implements RepositoryDAO {
           finalPredicatesList.add(
               builder.not(
                   builder.and(
-                      repositoryRoot.get("legacyWorkspaceId").in(orgIds),
+                      repositoryRoot.get(LEGACY_WORKSPACE_ID_PROPERTY).in(orgIds),
                       builder.equal(
                           repositoryRoot.get(ModelDBConstants.WORKSPACE_TYPE),
                           WorkspaceType.ORGANIZATION_VALUE))));
@@ -1395,11 +1399,10 @@ public class RepositoryDAORdbImpl implements RepositoryDAO {
           List<KeyValueQuery> workspacePredicates =
               ModelDBUtils.getKeyValueQueriesByWorkspace(
                   roleService, currentLoginUserInfo, workspaceName);
-          LOGGER.info("workspacePredicates: " + workspacePredicates);
           if (workspacePredicates.size() > 0) {
             Predicate privateWorkspacePredicate =
                 builder.equal(
-                    repositoryRoot.get("legacyWorkspaceId"),
+                    repositoryRoot.get(LEGACY_WORKSPACE_ID_PROPERTY),
                     workspacePredicates.get(0).getValue().getStringValue());
             Predicate privateWorkspaceTypePredicate =
                 builder.equal(

--- a/backend/src/main/java/ai/verta/modeldb/versioning/RepositoryDAORdbImpl.java
+++ b/backend/src/main/java/ai/verta/modeldb/versioning/RepositoryDAORdbImpl.java
@@ -1385,7 +1385,7 @@ public class RepositoryDAORdbImpl implements RepositoryDAO {
           finalPredicatesList.add(
               builder.not(
                   builder.and(
-                      repositoryRoot.get(ModelDBConstants.WORKSPACE_ID).in(orgIds),
+                      repositoryRoot.get("legacyWorkspaceId").in(orgIds),
                       builder.equal(
                           repositoryRoot.get(ModelDBConstants.WORKSPACE_TYPE),
                           WorkspaceType.ORGANIZATION_VALUE))));

--- a/backend/src/main/java/ai/verta/modeldb/versioning/RepositoryDAORdbImpl.java
+++ b/backend/src/main/java/ai/verta/modeldb/versioning/RepositoryDAORdbImpl.java
@@ -1385,7 +1385,7 @@ public class RepositoryDAORdbImpl implements RepositoryDAO {
           finalPredicatesList.add(
               builder.not(
                   builder.and(
-                      repositoryRoot.get(ModelDBConstants.LEGACY_WORKSPACE_ID).in(orgIds),
+                      repositoryRoot.get(ModelDBConstants.WORKSPACE_ID).in(orgIds),
                       builder.equal(
                           repositoryRoot.get(ModelDBConstants.WORKSPACE_TYPE),
                           WorkspaceType.ORGANIZATION_VALUE))));
@@ -1395,10 +1395,11 @@ public class RepositoryDAORdbImpl implements RepositoryDAO {
           List<KeyValueQuery> workspacePredicates =
               ModelDBUtils.getKeyValueQueriesByWorkspace(
                   roleService, currentLoginUserInfo, workspaceName);
+          LOGGER.info("workspacePredicates: " + workspacePredicates);
           if (workspacePredicates.size() > 0) {
             Predicate privateWorkspacePredicate =
                 builder.equal(
-                    repositoryRoot.get(ModelDBConstants.LEGACY_WORKSPACE_ID),
+                    repositoryRoot.get(ModelDBConstants.WORKSPACE_ID),
                     workspacePredicates.get(0).getValue().getStringValue());
             Predicate privateWorkspaceTypePredicate =
                 builder.equal(

--- a/backend/src/main/java/ai/verta/modeldb/versioning/RepositoryDAORdbImpl.java
+++ b/backend/src/main/java/ai/verta/modeldb/versioning/RepositoryDAORdbImpl.java
@@ -1399,7 +1399,7 @@ public class RepositoryDAORdbImpl implements RepositoryDAO {
           if (workspacePredicates.size() > 0) {
             Predicate privateWorkspacePredicate =
                 builder.equal(
-                    repositoryRoot.get(ModelDBConstants.LEGACY_WORKSPACE_ID),
+                    repositoryRoot.get(ModelDBConstants.WORKSPACE),
                     workspacePredicates.get(0).getValue().getStringValue());
             Predicate privateWorkspaceTypePredicate =
                 builder.equal(

--- a/backend/src/main/java/ai/verta/modeldb/versioning/RepositoryDAORdbImpl.java
+++ b/backend/src/main/java/ai/verta/modeldb/versioning/RepositoryDAORdbImpl.java
@@ -1398,7 +1398,7 @@ public class RepositoryDAORdbImpl implements RepositoryDAO {
           if (workspacePredicates.size() > 0) {
             Predicate privateWorkspacePredicate =
                 builder.equal(
-                    repositoryRoot.get(ModelDBConstants.WORKSPACE_ID),
+                    repositoryRoot.get(ModelDBConstants.LEGACY_WORKSPACE_ID),
                     workspacePredicates.get(0).getValue().getStringValue());
             Predicate privateWorkspaceTypePredicate =
                 builder.equal(

--- a/backend/src/main/java/ai/verta/modeldb/versioning/RepositoryDAORdbImpl.java
+++ b/backend/src/main/java/ai/verta/modeldb/versioning/RepositoryDAORdbImpl.java
@@ -1399,7 +1399,7 @@ public class RepositoryDAORdbImpl implements RepositoryDAO {
           if (workspacePredicates.size() > 0) {
             Predicate privateWorkspacePredicate =
                 builder.equal(
-                    repositoryRoot.get(ModelDBConstants.WORKSPACE),
+                    repositoryRoot.get("legacyWorkspaceId"),
                     workspacePredicates.get(0).getValue().getStringValue());
             Predicate privateWorkspaceTypePredicate =
                 builder.equal(

--- a/backend/src/main/resources/liquibase/db-changelog-2.0.xml
+++ b/backend/src/main/resources/liquibase/db-changelog-2.0.xml
@@ -282,4 +282,18 @@
     <changeSet id="db_version_2.12" author="cory">
         <tagDatabase tag="db_version_2.12"/>
     </changeSet>
+
+    <changeSet id="rename-legacy-workspace-id-to-workspace-on-dataset" author="cory">
+        <preConditions onFail="MARK_RAN">
+            <columnExists tableName="dataset" columnName="legacy_workspace_id"/>
+        </preConditions>
+        <renameColumn tableName="dataset" oldColumnName="legacy_workspace_id" newColumnName="workspace" columnDataType="VARCHAR(255)"/>
+        <rollback>
+            <renameColumn tableName="dataset" oldColumnName="workspace" newColumnName="legacy_workspace_id" columnDataType="VARCHAR(255)"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet id="db_version_2.13" author="cory">
+        <tagDatabase tag="db_version_2.13"/>
+    </changeSet>
 </databaseChangeLog>

--- a/backend/src/main/resources/liquibase/db-changelog-2.0.xml
+++ b/backend/src/main/resources/liquibase/db-changelog-2.0.xml
@@ -269,4 +269,14 @@
         <tagDatabase tag="db_version_2.11"/>
     </changeSet>
 
+    <changeSet id="rename-legacy-workspace-id-to-workspace-on-project" author="cory">
+        <preConditions onFail="MARK_RAN">
+            <columnExists tableName="project" columnName="legacy_workspace_id"/>
+        </preConditions>
+        <renameColumn tableName="project" oldColumnName="legacy_workspace_id" newColumnName="workspace" columnDataType="VARCHAR(255)"/>
+        <rollback>
+            <renameColumn tableName="project" oldColumnName="workspace" newColumnName="legacy_workspace_id" columnDataType="VARCHAR(255)"/>
+        </rollback>
+    </changeSet>
+
 </databaseChangeLog>

--- a/backend/src/main/resources/liquibase/db-changelog-2.0.xml
+++ b/backend/src/main/resources/liquibase/db-changelog-2.0.xml
@@ -296,4 +296,33 @@
     <changeSet id="db_version_2.13" author="cory">
         <tagDatabase tag="db_version_2.13"/>
     </changeSet>
+
+    <changeSet id="rename-workspace-id-to-workspace-service-id-on-repository" author="cory">
+        <preConditions onFail="MARK_RAN">
+            <columnExists tableName="repository" columnName="workspace_id"/>
+        </preConditions>
+        <renameColumn tableName="repository" oldColumnName="workspace_id" newColumnName="workspace_service_id" columnDataType="int8"/>
+        <rollback>
+            <renameColumn tableName="repository" oldColumnName="workspace_service_id" newColumnName="workspace_id" columnDataType="int8"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet id="db_version_2.14" author="cory">
+        <tagDatabase tag="db_version_2.14"/>
+    </changeSet>
+
+    <changeSet id="rename-legacy-workspace-id-to-workspace-id-on-repository" author="cory">
+        <preConditions onFail="MARK_RAN">
+            <columnExists tableName="repository" columnName="legacy_workspace_id"/>
+        </preConditions>
+        <renameColumn tableName="repository" oldColumnName="legacy_workspace_id" newColumnName="workspace_id" columnDataType="VARCHAR(255)"/>
+        <rollback>
+            <renameColumn tableName="repository" oldColumnName="workspace_id" newColumnName="legacy_workspace_id" columnDataType="VARCHAR(255)"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet id="db_version_2.15" author="cory">
+        <tagDatabase tag="db_version_2.15"/>
+    </changeSet>
+
 </databaseChangeLog>

--- a/backend/src/main/resources/liquibase/db-changelog-2.0.xml
+++ b/backend/src/main/resources/liquibase/db-changelog-2.0.xml
@@ -279,4 +279,7 @@
         </rollback>
     </changeSet>
 
+    <changeSet id="db_version_2.12" author="cory">
+        <tagDatabase tag="db_version_2.12"/>
+    </changeSet>
 </databaseChangeLog>

--- a/backend/src/test/java/ai/verta/modeldb/CollaboratorTest.java
+++ b/backend/src/test/java/ai/verta/modeldb/CollaboratorTest.java
@@ -20,7 +20,7 @@ import ai.verta.uac.AddCollaboratorRequest;
 import ai.verta.uac.CollaboratorServiceGrpc;
 import ai.verta.uac.CollaboratorServiceGrpc.CollaboratorServiceBlockingStub;
 import ai.verta.uac.GetCollaborator;
-import ai.verta.uac.GetCollaboratorResponse;
+import ai.verta.uac.GetCollaboratorResponseItem;
 import ai.verta.uac.GetUser;
 import ai.verta.uac.RemoveCollaborator;
 import ai.verta.uac.UACServiceGrpc;
@@ -544,7 +544,7 @@ public class CollaboratorTest {
       GetCollaborator.Response getCollaboratorResponse =
           collaboratorServiceStub.getProjectCollaborators(getCollaboratorRequest);
 
-      List<GetCollaboratorResponse> sharedUserList = getCollaboratorResponse.getSharedUsersList();
+      List<GetCollaboratorResponseItem> sharedUserList = getCollaboratorResponse.getSharedUsersList();
       LOGGER.info(
           "Founded collaborator users count : " + getCollaboratorResponse.getSharedUsersCount());
       assertEquals(
@@ -829,7 +829,7 @@ public class CollaboratorTest {
       GetCollaborator.Response getCollaboratorResponse =
           collaboratorServiceStub.getRepositoryCollaborators(getCollaboratorRequest);
 
-      List<GetCollaboratorResponse> sharedUserList = getCollaboratorResponse.getSharedUsersList();
+      List<GetCollaboratorResponseItem> sharedUserList = getCollaboratorResponse.getSharedUsersList();
       LOGGER.info(
           "Found collaborator users count : " + getCollaboratorResponse.getSharedUsersCount());
       assertEquals(

--- a/backend/src/test/java/ai/verta/modeldb/ExperimentTest.java
+++ b/backend/src/test/java/ai/verta/modeldb/ExperimentTest.java
@@ -747,15 +747,22 @@ public class ExperimentTest {
       assertEquals(Status.INVALID_ARGUMENT.getCode(), status.getCode());
     }
 
-    try {
-      experimentServiceStub.updateExperimentNameOrDescription(
+    UpdateExperimentNameOrDescription.Response updateExperimentNameOrDescriptionResponse = experimentServiceStub.updateExperimentNameOrDescription(
           UpdateExperimentNameOrDescription.newBuilder().setId(experiment.getId()).build());
-      fail();
-    } catch (StatusRuntimeException ex) {
-      Status status = Status.fromThrowable(ex);
-      LOGGER.warn("Error Code : " + status.getCode() + " Description : " + status.getDescription());
-      assertEquals(Status.INVALID_ARGUMENT.getCode(), status.getCode());
-    }
+    LOGGER.info("UpdateExperimentNameOrDescription Response : " + updateExperimentNameOrDescriptionResponse.getExperiment());
+    assertFalse(
+            "Experiment name is empty",
+            updateExperimentNameOrDescriptionResponse.getExperiment().getName().isEmpty());
+    assertEquals(
+            "Experiment description not match with expected experiment name",
+            experiment.getDescription(),
+            updateExperimentNameOrDescriptionResponse.getExperiment().getDescription());
+    assertNotEquals(
+            "Experiment date_updated field not update on database",
+            experiment.getDateUpdated(),
+            updateExperimentNameOrDescriptionResponse.getExperiment().getDateUpdated());
+    experiment = response.getExperiment();
+
 
     LOGGER.info("Update Experiment Name & Description test stop................................");
   }

--- a/backend/src/test/java/ai/verta/modeldb/ProjectTest.java
+++ b/backend/src/test/java/ai/verta/modeldb/ProjectTest.java
@@ -529,17 +529,17 @@ public class ProjectTest {
       LOGGER.info("Project Created Successfully");
       projects.add(response.getProject());
 
-      createProjectRequest = getCreateProjectRequest("");
+      projectName = "";
+      createProjectRequest = getCreateProjectRequest(projectName);
       createProjectRequest = createProjectRequest.toBuilder().build();
-      try {
-        projectServiceStub.createProject(createProjectRequest);
-        fail();
-      } catch (StatusRuntimeException e) {
-        Status status = Status.fromThrowable(e);
-        LOGGER.warn(
-            "Error Code : " + status.getCode() + " Description : " + status.getDescription());
-        assertEquals(Status.INVALID_ARGUMENT.getCode(), status.getCode());
-      }
+      response = projectServiceStub.createProject(createProjectRequest);
+      projectShortName = projectName;
+      projectShortName = ModelDBUtils.convertToProjectShortName(projectShortName);
+      assertFalse(response.getProject().getName().isEmpty());
+      assertFalse(response.getProject().getShortName().isEmpty());
+      LOGGER.info("Project Created Successfully");
+      projects.add(response.getProject());
+
     } finally {
       for (Project project : projects) {
         // Delete all data related to project
@@ -552,43 +552,6 @@ public class ProjectTest {
     }
 
     LOGGER.info("Create Project with MD5 logic test stop................................");
-  }
-
-  @Test
-  public void b_projectCreateNegativeTest() {
-    LOGGER.info("Create Project Negative test start................................");
-
-    List<KeyValue> metadataList = new ArrayList<>();
-    for (int count = 0; count < 5; count++) {
-      Value stringValue =
-          Value.newBuilder()
-              .setStringValue(
-                  "attribute_" + count + "_" + Calendar.getInstance().getTimeInMillis() + "_value")
-              .build();
-      KeyValue keyValue =
-          KeyValue.newBuilder()
-              .setKey("attribute_" + count + "_" + Calendar.getInstance().getTimeInMillis())
-              .setValue(stringValue)
-              .build();
-      metadataList.add(keyValue);
-    }
-
-    CreateProject request =
-        CreateProject.newBuilder()
-            .setDescription("This is a project description.")
-            .addTags("tag_" + Calendar.getInstance().getTimeInMillis())
-            .addTags("tag_" + +Calendar.getInstance().getTimeInMillis())
-            .addAllAttributes(metadataList)
-            .build();
-
-    try {
-      projectServiceStub.createProject(request);
-      fail();
-    } catch (StatusRuntimeException e) {
-      Status status = Status.fromThrowable(e);
-      LOGGER.warn("Error Code : " + status.getCode() + " Description : " + status.getDescription());
-      assertEquals(Status.INVALID_ARGUMENT.getCode(), status.getCode());
-    }
   }
 
   @Test

--- a/backend/src/test/java/ai/verta/modeldb/RepositoryTest.java
+++ b/backend/src/test/java/ai/verta/modeldb/RepositoryTest.java
@@ -332,7 +332,7 @@ public class RepositoryTest {
           Assert.fail();
         }
       } catch (StatusRuntimeException e) {
-        assertEquals(Code.PERMISSION_DENIED, e.getStatus().getCode());
+        assertEquals(Code.INVALID_ARGUMENT, e.getStatus().getCode());
       }
       try {
         versioningServiceBlockingStubClient2.getRepository(

--- a/backend/src/test/java/ai/verta/modeldb/utils/ModelDBUtilsTest.java
+++ b/backend/src/test/java/ai/verta/modeldb/utils/ModelDBUtilsTest.java
@@ -6,7 +6,7 @@ import ai.verta.common.TernaryEnum.Ternary;
 import ai.verta.modeldb.CollaboratorUserInfo;
 import ai.verta.modeldb.authservice.AuthService;
 import ai.verta.modeldb.authservice.RoleService;
-import ai.verta.uac.GetCollaboratorResponse;
+import ai.verta.uac.GetCollaboratorResponseItem;
 import ai.verta.uac.Organization;
 import ai.verta.uac.Team;
 import ai.verta.uac.UserInfo;
@@ -38,18 +38,18 @@ public class ModelDBUtilsTest {
     final CollaboratorType readWrite = CollaboratorType.READ_WRITE;
 
     final Ternary aTrue = Ternary.TRUE;
-    List<GetCollaboratorResponse> collaboratorList =
+    List<GetCollaboratorResponseItem> collaboratorList =
         Arrays.asList(
-            GetCollaboratorResponse.newBuilder()
+              GetCollaboratorResponseItem.newBuilder()
                 .setAuthzEntityType(EntitiesTypes.USER)
                 .setVertaId(USER_ID)
                 .setCollaboratorType(readWrite)
                 .build(),
-            GetCollaboratorResponse.newBuilder()
+              GetCollaboratorResponseItem.newBuilder()
                 .setAuthzEntityType(EntitiesTypes.ORGANIZATION)
                 .setVertaId(ORG_ID)
                 .build(),
-            GetCollaboratorResponse.newBuilder()
+              GetCollaboratorResponseItem.newBuilder()
                 .setAuthzEntityType(EntitiesTypes.TEAM)
                 .setCanDeploy(aTrue)
                 .setVertaId(TEAM_ID)


### PR DESCRIPTION
Reverts the column name change for `Project.legacy_workspace_id` back to `Project.workspace` to avoid unwanted side effects.
Reverts `Dataset.legacy_workspace_id` to `Dataset.workspace`
Reverts `Repository.legacy_workspace_id` to `Repository.workspace_id`
Fixes some broken HQL queries resulting from these changes.