### PR TITLE
Remove write lock in addOrUpdateKeyValueProperties

### DIFF
--- a/backend/src/main/java/ai/verta/modeldb/metadata/MetadataDAO.java
+++ b/backend/src/main/java/ai/verta/modeldb/metadata/MetadataDAO.java
@@ -32,7 +32,7 @@ public interface MetadataDAO {
 
   boolean deleteProperty(IdentificationType id, String key);
 
-  void addOrUpdateKeyValueProperties(AddKeyValuePropertiesRequest request);
+  void addKeyValueProperties(AddKeyValuePropertiesRequest request);
 
   List<KeyValueStringProperty> getKeyValueProperties(GetKeyValuePropertiesRequest request);
 

--- a/backend/src/main/java/ai/verta/modeldb/metadata/MetadataDAORdbImpl.java
+++ b/backend/src/main/java/ai/verta/modeldb/metadata/MetadataDAORdbImpl.java
@@ -369,11 +369,12 @@ public class MetadataDAORdbImpl implements MetadataDAO {
             KeyValuePropertyMappingEntity.createId(
                 request.getId(), keyValue.getKey(), request.getPropertyName());
         KeyValuePropertyMappingEntity existingEntity =
-            session.get(KeyValuePropertyMappingEntity.class, id0, LockMode.PESSIMISTIC_WRITE);
+            session.get(KeyValuePropertyMappingEntity.class, id0);
         if (existingEntity == null) {
           existingEntity = new KeyValuePropertyMappingEntity(id0, keyValue.getValue());
           session.saveOrUpdate(existingEntity);
         } else {
+          session.lock(existingEntity, LockMode.PESSIMISTIC_WRITE);
           existingEntity.setValue(keyValue.getValue());
           session.update(existingEntity);
         }

--- a/backend/src/main/java/ai/verta/modeldb/metadata/MetadataDAORdbImpl.java
+++ b/backend/src/main/java/ai/verta/modeldb/metadata/MetadataDAORdbImpl.java
@@ -361,7 +361,7 @@ public class MetadataDAORdbImpl implements MetadataDAO {
   }
 
   @Override
-  public void addOrUpdateKeyValueProperties(AddKeyValuePropertiesRequest request) {
+  public void addKeyValueProperties(AddKeyValuePropertiesRequest request) {
     try (Session session = ModelDBHibernateUtil.getSessionFactory().openSession()) {
       Transaction transaction = session.beginTransaction();
       for (KeyValueStringProperty keyValue : request.getKeyValuePropertyList()) {

--- a/backend/src/main/java/ai/verta/modeldb/metadata/MetadataDAORdbImpl.java
+++ b/backend/src/main/java/ai/verta/modeldb/metadata/MetadataDAORdbImpl.java
@@ -374,7 +374,6 @@ public class MetadataDAORdbImpl implements MetadataDAO {
           existingEntity = new KeyValuePropertyMappingEntity(id0, keyValue.getValue());
           session.saveOrUpdate(existingEntity);
         } else {
-          session.lock(existingEntity, LockMode.PESSIMISTIC_WRITE);
           existingEntity.setValue(keyValue.getValue());
           session.update(existingEntity);
         }

--- a/backend/src/main/java/ai/verta/modeldb/metadata/MetadataServiceImpl.java
+++ b/backend/src/main/java/ai/verta/modeldb/metadata/MetadataServiceImpl.java
@@ -177,7 +177,7 @@ public class MetadataServiceImpl extends MetadataServiceImplBase {
         throw StatusProto.toStatusRuntimeException(status);
       }
 
-      metadataDAO.addOrUpdateKeyValueProperties(request);
+      metadataDAO.addKeyValueProperties(request);
       responseObserver.onNext(AddKeyValuePropertiesRequest.Response.newBuilder().build());
       responseObserver.onCompleted();
     } catch (Exception e) {


### PR DESCRIPTION
https://vertaai.atlassian.net/browse/VR-8467

This lock will always fail to acquire since this code path is only ever used to add new properties, never for update.  

The method name was changed to reflect this.