### PR TITLE
Set the created column value to true

### DIFF
--- a/backend/src/main/resources/liquibase/db-changelog-2.0.xml
+++ b/backend/src/main/resources/liquibase/db-changelog-2.0.xml
@@ -332,10 +332,10 @@
             </not>
         </preConditions>
         <addColumn tableName="project">
-            <column name="created" type="boolean" defaultValueBoolean="false"/>
+            <column name="created" type="boolean" defaultValue="false"/>
         </addColumn>
         <update tableName="project">
-            <column name="created" valueBoolean="true"/>
+            <column name="created" value="true"/>
         </update>
         <rollback>
             <dropColumn tableName="project" columnName="created"/>

--- a/backend/src/main/resources/liquibase/db-changelog-2.0.xml
+++ b/backend/src/main/resources/liquibase/db-changelog-2.0.xml
@@ -332,10 +332,10 @@
             </not>
         </preConditions>
         <addColumn tableName="project">
-            <column name="created" type="boolean" defaultValue="false"/>
+            <column name="created" type="boolean" defaultValueBoolean="false"/>
         </addColumn>
         <update tableName="project">
-            <column name="created" value="true"/>
+            <column name="created" valueBoolean="true"/>
         </update>
         <rollback>
             <dropColumn tableName="project" columnName="created"/>
@@ -344,6 +344,17 @@
 
     <changeSet id="db_version_2.16" author="cory">
         <tagDatabase tag="db_version_2.16"/>
+    </changeSet>
+
+    <changeSet id="set-created-true-on-project-for-existing-projects" author="cory">
+        <update tableName="project">
+            <column name="created" valueBoolean="true"/>
+            <where>created=false AND deleted=false</where>
+        </update>
+    </changeSet>
+
+    <changeSet id="db_version_2.17" author="cory">
+        <tagDatabase tag="db_version_2.17"/>
     </changeSet>
 
 </databaseChangeLog>


### PR DESCRIPTION
The original value migration did not apply due to liquibase syntax.  This migration will properly update all existing projects to have `created=true`