### PR TITLE
VR-7698: Keep but deprecate old dataset versioning attributes/methods

### DIFF
--- a/client/verta/docs/tutorials/migrate_dataset.rst
+++ b/client/verta/docs/tutorials/migrate_dataset.rst
@@ -76,6 +76,11 @@ Prefixes are also supported—so long as they end in a slash ``'/'``:
 Tips and tricks
 ---------------
 
+Several attributes of the old ``Dataset`` and ``DatasetVersion`` classes have
+been ported over and are still usable; however, most of them have been
+deprecated and will raise warnings accordingly—with guidance on how to update
+them.
+
 One advantage of this new system is that you can preview the contents of your
 dataset version-to-be before creating it in ModelDB:
 

--- a/client/verta/docs/tutorials/migrate_dataset.rst
+++ b/client/verta/docs/tutorials/migrate_dataset.rst
@@ -73,13 +73,26 @@ Prefixes are also supported—so long as they end in a slash ``'/'``:
         S3("s3://verta-starter/models/")  # all keys that begin with "models/"
     )
 
-Tips and tricks
----------------
+base_path and other attributes
+------------------------------
 
 Several attributes of the old ``Dataset`` and ``DatasetVersion`` classes have
 been ported over and are still usable; however, most of them have been
 deprecated and will raise warnings accordingly—with guidance on how to update
 them.
+
+``dataset_version.base_path`` in particular is no longer available as a direct
+attribute. Instead, to obtain usable paths of particular files, you may
+retrieve them by accessing the components of the dataset version:
+
+.. code-block:: python
+
+    version = dataset.create_version(S3("s3://verta-starter/census-train.csv"))
+    version.list_components()[0].path
+    # s3://verta-starter/census-train.csv
+
+Tips and tricks
+---------------
 
 One advantage of this new system is that you can preview the contents of your
 dataset version-to-be before creating it in ModelDB:
@@ -119,5 +132,5 @@ its versions can be different types themselves:
     dataset.create_version(Path("census-train.csv"))
     dataset.create_version(S3("s3://verta-starter/census-train.csv"))
 
-For the complete functionality, please see the updated
+For complete functionality, please see the updated
 `API reference <../api/api/dataset.html>`__!

--- a/client/verta/verta/_dataset_versioning/dataset.py
+++ b/client/verta/verta/_dataset_versioning/dataset.py
@@ -401,18 +401,16 @@ class Dataset(entity._ModelDBEntity):
     # The following properties are holdovers for backwards compatibility
     @property
     def dataset_type(self):
-        warnings.warn(
-            "this attribute is deprecated and will removed in an upcoming version;"
+        raise AttributeError(
+            "this attribute is no longer supported;"
             " datasets no longer have a specific associated type",
-            category=FutureWarning,
         )
 
     @property
     def _dataset_type(self):
-        warnings.warn(
-            "this attribute is deprecated and will removed in an upcoming version;"
+        raise AttributeError(
+            "this attribute is no longer supported;"
             " datasets no longer have a specific associated type",
-            category=FutureWarning,
         )
 
     @property

--- a/client/verta/verta/_dataset_versioning/dataset.py
+++ b/client/verta/verta/_dataset_versioning/dataset.py
@@ -2,6 +2,8 @@
 
 from __future__ import print_function
 
+import warnings
+
 from ..external import six
 
 from .._protos.public.common import CommonService_pb2 as _CommonCommonService
@@ -66,10 +68,6 @@ class Dataset(entity._ModelDBEntity):
         return self._msg.name
 
     @property
-    def dataset_type(self):
-        return self.__class__.__name__
-
-    @property
     def workspace(self):
         self._refresh_cache()
 
@@ -77,24 +75,6 @@ class Dataset(entity._ModelDBEntity):
             return self._get_workspace_name_by_id(self._msg.workspace_id)
         else:
             return entity._OSS_DEFAULT_WORKSPACE
-
-    @property
-    def desc(self):
-        # for backwards compatibility
-        # TODO: deprecate
-        return self.get_description()
-
-    @property
-    def attrs(self):
-        # for backwards compatibility
-        # TODO: deprecate
-        return self.get_attributes()
-
-    @property
-    def tags(self):
-        # for backwards compatibility
-        # TODO: deprecate
-        return self.get_tags()
 
     @property
     def versions(self):
@@ -417,3 +397,47 @@ class Dataset(entity._ModelDBEntity):
             "DELETE", "/api/v1/modeldb/dataset/deleteDataset", body=msg,
         )
         self._conn.must_response(response)
+
+    # The following properties are holdovers for backwards compatibility
+    @property
+    def dataset_type(self):
+        warnings.warn(
+            "this attribute is deprecated and will removed in an upcoming version;"
+            " datasets no longer have a specific associated type",
+            category=FutureWarning,
+        )
+
+    @property
+    def _dataset_type(self):
+        warnings.warn(
+            "this attribute is deprecated and will removed in an upcoming version;"
+            " datasets no longer have a specific associated type",
+            category=FutureWarning,
+        )
+
+    @property
+    def desc(self):
+        warnings.warn(
+            "this attribute is deprecated and will removed in an upcoming version;"
+            " consider using `get_description()` instead",
+            category=FutureWarning,
+        )
+        return self.get_description()
+
+    @property
+    def attrs(self):
+        warnings.warn(
+            "this attribute is deprecated and will removed in an upcoming version;"
+            " consider using `get_attributes()` instead",
+            category=FutureWarning,
+        )
+        return self.get_attributes()
+
+    @property
+    def tags(self):
+        warnings.warn(
+            "this attribute is deprecated and will removed in an upcoming version;"
+            " consider using `get_tags()` instead",
+            category=FutureWarning,
+        )
+        return self.get_tags()

--- a/client/verta/verta/_dataset_versioning/dataset_version.py
+++ b/client/verta/verta/_dataset_versioning/dataset_version.py
@@ -339,6 +339,9 @@ class DatasetVersion(entity._ModelDBEntity):
         )
         self._conn.must_response(response)
 
+    def list_components(self):  # from legacy DatasetVersion
+        return self.get_content().list_components()
+
     # The following properties are holdovers for backwards compatibility
     @property
     def desc(self):
@@ -399,5 +402,18 @@ class DatasetVersion(entity._ModelDBEntity):
         version_info_oneof = self._msg.WhichOneof('dataset_version_info')
         return getattr(self._msg, version_info_oneof)
 
-    # TODO: base_path
-    # TODO: list_components
+    @property
+    def base_path(self):  # copied from legacy DatasetVersion
+        warnings.warn(
+            "this attribute is deprecated and will removed in an upcoming version;"
+            " consider checking individual files' base paths"
+            " with `get_content().list_components()` instead",
+            category=FutureWarning,
+        )
+        components = self.get_content().list_components()
+        base_paths = set(component.base_path for component in components)
+
+        if len(base_paths) == 1:
+            return base_paths.pop()
+        else:  # shouldn't happen: DVs don't have an interface to have different base paths
+            raise AttributeError("multiple base paths among components: {}".format(base_paths))

--- a/client/verta/verta/_dataset_versioning/dataset_version.py
+++ b/client/verta/verta/_dataset_versioning/dataset_version.py
@@ -2,6 +2,8 @@
 
 from __future__ import print_function
 
+import warnings
+
 from ..external import six
 
 from .._protos.public.common import CommonService_pb2 as _CommonCommonService
@@ -336,3 +338,66 @@ class DatasetVersion(entity._ModelDBEntity):
             "DELETE", "/api/v1/modeldb/dataset-version/deleteDatasetVersion", body=msg,
         )
         self._conn.must_response(response)
+
+    # The following properties are holdovers for backwards compatibility
+    @property
+    def desc(self):
+        warnings.warn(
+            "this attribute is deprecated and will removed in an upcoming version;"
+            " consider using `get_description()` instead",
+            category=FutureWarning,
+        )
+        return self.get_description()
+
+    @property
+    def attrs(self):
+        warnings.warn(
+            "this attribute is deprecated and will removed in an upcoming version;"
+            " consider using `get_attributes()` instead",
+            category=FutureWarning,
+        )
+        return self.get_attributes()
+
+    @property
+    def tags(self):
+        warnings.warn(
+            "this attribute is deprecated and will removed in an upcoming version;"
+            " consider using `get_tags()` instead",
+            category=FutureWarning,
+        )
+        return self.get_tags()
+
+    @property
+    def _dataset_type(self):
+        warnings.warn(
+            "this attribute is deprecated and will removed in an upcoming version;"
+            " consider checking `get_content()` instead",
+            category=FutureWarning,
+        )
+        # enum value for PATH, which is currently the only supported type
+        # https://github.com/VertaAI/modeldb/blob/af5e3a7/protos/protos/public/modeldb/DatasetService.proto#L32
+        return 1
+
+    @property
+    def dataset_version(self):
+        warnings.warn(
+            "this attribute is deprecated and will removed in an upcoming version;"
+            " interfacing directly with the internal protobuf structure is not recommended",
+            category=FutureWarning,
+        )
+        self._refresh_cache()
+        return self._msg
+
+    @property
+    def dataset_version_info(self):
+        warnings.warn(
+            "this attribute is deprecated and will removed in an upcoming version;"
+            " consider using `get_content()` instead",
+            category=FutureWarning,
+        )
+        self._refresh_cache()
+        version_info_oneof = self._msg.WhichOneof('dataset_version_info')
+        return getattr(self._msg, version_info_oneof)
+
+    # TODO: base_path
+    # TODO: list_components

--- a/client/verta/verta/_dataset_versioning/dataset_version.py
+++ b/client/verta/verta/_dataset_versioning/dataset_version.py
@@ -134,6 +134,13 @@ class DatasetVersion(entity._ModelDBEntity):
         blob.dataset.CopyFrom(self._msg.dataset_blob)
         return commit.blob_msg_to_object(blob)
 
+    def list_components(self):  # from legacy DatasetVersion
+        """
+        Shorthand for ``get_content().list_components()``.
+
+        """
+        return self.get_content().list_components()
+
     def set_description(self, desc):
         """
         Sets the description of this dataset version.
@@ -338,9 +345,6 @@ class DatasetVersion(entity._ModelDBEntity):
             "DELETE", "/api/v1/modeldb/dataset-version/deleteDatasetVersion", body=msg,
         )
         self._conn.must_response(response)
-
-    def list_components(self):  # from legacy DatasetVersion
-        return self.get_content().list_components()
 
     # The following properties are holdovers for backwards compatibility
     @property

--- a/client/verta/verta/_dataset_versioning/dataset_version.py
+++ b/client/verta/verta/_dataset_versioning/dataset_version.py
@@ -404,16 +404,8 @@ class DatasetVersion(entity._ModelDBEntity):
 
     @property
     def base_path(self):  # copied from legacy DatasetVersion
-        warnings.warn(
-            "this attribute is deprecated and will removed in an upcoming version;"
-            " consider checking individual files' base paths"
-            " with `get_content().list_components()` instead",
-            category=FutureWarning,
+        raise AttributeError(
+            "this attribute is no longer supported;"
+            " considering accessing the paths of specific components"
+            " using `list_components()[i].path` instead",
         )
-        components = self.get_content().list_components()
-        base_paths = set(component.base_path for component in components)
-
-        if len(base_paths) == 1:
-            return base_paths.pop()
-        else:  # shouldn't happen: DVs don't have an interface to have different base paths
-            raise AttributeError("multiple base paths among components: {}".format(base_paths))

--- a/client/verta/verta/_dataset_versioning/dataset_version.py
+++ b/client/verta/verta/_dataset_versioning/dataset_version.py
@@ -389,7 +389,7 @@ class DatasetVersion(entity._ModelDBEntity):
     def dataset_version(self):
         warnings.warn(
             "this attribute is deprecated and will removed in an upcoming version;"
-            " interfacing directly with the internal protobuf structure is not recommended",
+            " interfacing directly with the internal protobuf structure is not supported",
             category=FutureWarning,
         )
         self._refresh_cache()

--- a/client/verta/verta/_dataset_versioning/dataset_version.py
+++ b/client/verta/verta/_dataset_versioning/dataset_version.py
@@ -407,7 +407,7 @@ class DatasetVersion(entity._ModelDBEntity):
         return getattr(self._msg, version_info_oneof)
 
     @property
-    def base_path(self):  # copied from legacy DatasetVersion
+    def base_path(self):
         raise AttributeError(
             "this attribute is no longer supported;"
             " considering accessing the paths of specific components"

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -863,8 +863,8 @@ class Client(object):
             return Endpoint._get_by_id(self._conn, self._conf, workspace, id)
         else:
             return Endpoint._get_or_create_by_name(self._conn, path,
-                                            lambda name: Endpoint._get_by_path(self._conn, self._conf, workspace, path),
-                                            lambda name: Endpoint._create(self._conn, self._conf, workspace, public_within_org, path, description),
+                                            lambda path: Endpoint._get_by_path(self._conn, self._conf, workspace, path),
+                                            lambda path: Endpoint._create(self._conn, self._conf, workspace, public_within_org, path, description),
                                             lambda: check_unnecessary_params_warning(
                                                  resource_name,
                                                  "path {}".format(path),


### PR DESCRIPTION
Not complete backwards-compatibility as suggested by the ticket, but gives pointers toward updating code that are more informative than "Attribute does not exist! Scour the docs to find its replacement"