### PR TITLE
Revert "VR-8143 VR-8144 VR-8145 Send empty names/paths instead of creating custom"

### DIFF
--- a/client/verta/verta/_tracking/entity.py
+++ b/client/verta/verta/_tracking/entity.py
@@ -135,7 +135,7 @@ class _ModelDBEntity(object):
     @classmethod
     def _create(cls, conn, conf, *args, **kwargs):
         if 'name' in kwargs and kwargs['name'] is None:
-            kwargs['name'] = ""
+            kwargs['name'] = cls._generate_default_name()
 
         msg = cls._create_proto(conn, *args, **kwargs)
         if msg:

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -863,8 +863,8 @@ class Client(object):
             return Endpoint._get_by_id(self._conn, self._conf, workspace, id)
         else:
             return Endpoint._get_or_create_by_name(self._conn, path,
-                                            lambda name: Endpoint._get_by_path(self._conn, self._conf, workspace, path),
-                                            lambda name: Endpoint._create(self._conn, self._conf, workspace, public_within_org, path, description),
+                                            lambda path: Endpoint._get_by_path(self._conn, self._conf, workspace, path),
+                                            lambda path: Endpoint._create(self._conn, self._conf, workspace, public_within_org, path, description),
                                             lambda: check_unnecessary_params_warning(
                                                  resource_name,
                                                  "path {}".format(path),

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -863,8 +863,8 @@ class Client(object):
             return Endpoint._get_by_id(self._conn, self._conf, workspace, id)
         else:
             return Endpoint._get_or_create_by_name(self._conn, path,
-                                            lambda path: Endpoint._get_by_path(self._conn, self._conf, workspace, path),
-                                            lambda path: Endpoint._create(self._conn, self._conf, workspace, public_within_org, path, description),
+                                            lambda name: Endpoint._get_by_path(self._conn, self._conf, workspace, path),
+                                            lambda name: Endpoint._create(self._conn, self._conf, workspace, public_within_org, path, description),
                                             lambda: check_unnecessary_params_warning(
                                                  resource_name,
                                                  "path {}".format(path),

--- a/client/verta/verta/endpoint/_endpoint.py
+++ b/client/verta/verta/endpoint/_endpoint.py
@@ -88,7 +88,7 @@ class Endpoint(object):
         return data['date_updated']
 
     @classmethod
-    def _create(cls, conn, conf, workspace, public_within_org, path=None, description=None):
+    def _create(cls, conn, conf, workspace, public_within_org, path, description=None):
         endpoint_json = cls._create_json(conn, workspace, public_within_org, path, description)
         if endpoint_json:
             endpoint = cls(conn, conf, workspace, endpoint_json['id'])
@@ -158,12 +158,9 @@ class Endpoint(object):
 
     @classmethod
     def _get_json_by_path(cls, conn, workspace, path):
-        if path is None:
-            return None
         endpoints = cls._get_endpoints(conn, workspace)
         if not path.startswith('/'):
             path = '/' + path
-        # FIXME: ask the backend to implement an API to query by path
         for endpoint in endpoints:
             creator_request = endpoint['creator_request']
             if creator_request['path'] == path:


### PR DESCRIPTION
Reverts https://github.com/VertaAI/modeldb/pull/1718

Introduces too high a degree of uncertainty to be published in the Client for now
(will cause client errors with older builds of MDB)