### PR TITLE
Fix pylint filters for Python 2

### DIFF
--- a/client/verta/.pylintrc
+++ b/client/verta/.pylintrc
@@ -282,7 +282,7 @@ ignored-classes=optparse.Values,
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=verta._protos
+ignored-modules=verta._protos.*
 
 # Show a hint with possible names when a member name was not found. The aspect
 # of finding the hint is based on edit distance.

--- a/client/verta/.pylintrc
+++ b/client/verta/.pylintrc
@@ -277,7 +277,8 @@ ignore-on-opaque-inference=yes
 ignored-classes=optparse.Values,
                 thread._local,
                 _thread._local,
-                # pylint mistakes Paths for PurePaths, which client doesn't use
+            # In Python 2, pylint mistakes pathlib2's Path for PurePath.
+            # The client doesn't use PurePath anyway, so ignore.
                 PurePath,
 
 # List of module names for which member attributes should not be checked

--- a/client/verta/.pylintrc
+++ b/client/verta/.pylintrc
@@ -277,6 +277,8 @@ ignore-on-opaque-inference=yes
 ignored-classes=optparse.Values,
                 thread._local,
                 _thread._local,
+                # pylint mistakes Paths for PurePaths, which client doesn't use
+                PurePath,
 
 # List of module names for which member attributes should not be checked
 # (useful for modules/projects where namespaces are manipulated during runtime


### PR DESCRIPTION
https://github.com/VertaAI/modeldb/pull/1697 worked for Python 3, but not for Python 2.
This fixes that.