### PR TITLE
Disable linter's import errors for optional libraries

### DIFF
--- a/client/verta/verta/integrations/sklearn/__init__.py
+++ b/client/verta/verta/integrations/sklearn/__init__.py
@@ -25,7 +25,7 @@ Examples
 
 from ...external import six
 
-from sklearn import (
+from sklearn import (  # pylint: disable=import-error
     linear_model,
     tree,
     svm,

--- a/client/verta/verta/integrations/tensorflow/__init__.py
+++ b/client/verta/verta/integrations/tensorflow/__init__.py
@@ -5,7 +5,7 @@ from ...external import six
 import numbers
 import os
 
-import tensorflow as tf
+import tensorflow as tf  # pylint: disable=import-error
 from tensorflow.core.framework.summary_pb2 import Summary  # pylint: disable=import-error, no-name-in-module
 from tensorflow.core.util.event_pb2 import Event  # pylint: disable=import-error, no-name-in-module
 from tensorflow.compat.v1 import summary  # pylint: disable=import-error

--- a/client/verta/verta/integrations/torch/__init__.py
+++ b/client/verta/verta/integrations/torch/__init__.py
@@ -2,7 +2,7 @@
 
 from ...external import six
 
-import torch
+import torch  # pylint: disable=import-error
 
 from ..._internal_utils import _utils
 

--- a/client/verta/verta/integrations/xgboost/__init__.py
+++ b/client/verta/verta/integrations/xgboost/__init__.py
@@ -2,7 +2,7 @@
 
 from ...external import six
 
-import xgboost as xgb
+import xgboost as xgb  # pylint: disable=import-error
 
 from ..._internal_utils import _utils
 


### PR DESCRIPTION
pylint complains when the code tries to import a library that isn't installed in the linting environment.