### PR TITLE
Enable managed versioning for DatasetVersion

### DIFF
--- a/client/verta/verta/_dataset_versioning/dataset_version.py
+++ b/client/verta/verta/_dataset_versioning/dataset_version.py
@@ -156,7 +156,12 @@ class DatasetVersion(entity._ModelDBEntity):
         # create wrapper blob msg so we can reuse the repository system's proto-to-obj
         blob = _VersioningService.Blob()
         blob.dataset.CopyFrom(self._msg.dataset_blob)
-        return commit.blob_msg_to_object(blob)
+        content = commit.blob_msg_to_object(blob)
+
+        # for _Dataset.download()
+        content._set_dataset_version(self)
+
+        return content
 
     def list_components(self):  # from legacy DatasetVersion
         """

--- a/client/verta/verta/_dataset_versioning/dataset_version.py
+++ b/client/verta/verta/_dataset_versioning/dataset_version.py
@@ -469,7 +469,7 @@ class DatasetVersion(entity._ModelDBEntity):
             part_number=part_num,
         )
         data = _utils.proto_to_json(msg)
-        endpoint = "{}://{}/api/v1/dataset-version/dataset/{}/datasetVersion/{}/getUrlForDatasetBlobVersioned".format(
+        endpoint = "{}://{}/api/v1/modeldb/dataset-version/dataset/{}/datasetVersion/{}/getUrlForDatasetBlobVersioned".format(
             self._conn.scheme,
             self._conn.socket,
             self.dataset_id,
@@ -536,7 +536,7 @@ class DatasetVersion(entity._ModelDBEntity):
                 _utils.raise_for_http_error(response)
 
                 # commit part
-                url = "{}://{}/api/v1/dataset-version/commitVersionedDatasetBlobArtifactPart".format(
+                url = "{}://{}/api/v1/modeldb/dataset-version/commitVersionedDatasetBlobArtifactPart".format(
                     self._conn.scheme,
                     self._conn.socket,
                 )
@@ -552,7 +552,7 @@ class DatasetVersion(entity._ModelDBEntity):
             print()
 
             # complete upload
-            url = "{}://{}/api/v1/dataset-version/commitMultipartVersionedDatasetBlobArtifact".format(
+            url = "{}://{}/api/v1/modeldb/dataset-version/commitMultipartVersionedDatasetBlobArtifact".format(
                 self._conn.scheme,
                 self._conn.socket,
             )

--- a/client/verta/verta/_dataset_versioning/dataset_version.py
+++ b/client/verta/verta/_dataset_versioning/dataset_version.py
@@ -124,7 +124,7 @@ class DatasetVersion(entity._ModelDBEntity):
             for component in dataset_blob._components_map.values():
                 if component._internal_versioned_path:
                     with open(component._local_path, 'rb') as f:
-                        self._upload_artifact(blob_path, component.path, f)
+                        self._upload_artifact(component.path, f)
 
         return dataset_version
 
@@ -427,14 +427,12 @@ class DatasetVersion(entity._ModelDBEntity):
 
     # The following properties are for managed
     # TODO: consolidate this with similar method in `_ModelDBEntity`
-    def _get_url_for_artifact(self, blob_path, dataset_component_path, method, part_num=0):
+    def _get_url_for_artifact(self, dataset_component_path, method, part_num=0):
         """
         Obtains a URL to use for accessing stored artifacts.
 
         Parameters
         ----------
-        blob_path : str
-            Path to blob within repo.
         dataset_component_path : str
             Filepath in dataset component blob.
         method : {'GET', 'PUT'}
@@ -444,25 +442,24 @@ class DatasetVersion(entity._ModelDBEntity):
 
         Returns
         -------
-        response_msg : `_VersioningService.GetUrlForBlobVersioned.Response`
+        response_msg : `_DatasetVersionService.GetUrlForDatasetBlobVersioned.Response`
             Backend response.
 
         """
         if method.upper() not in ("GET", "PUT"):
             raise ValueError("`method` must be one of {'GET', 'PUT'}")
 
-        Message = _VersioningService.GetUrlForBlobVersioned
+        Message = _DatasetVersionService.GetUrlForDatasetBlobVersioned
         msg = Message(
-            location=path_to_location(blob_path),
             path_dataset_component_blob_path=dataset_component_path,
             method=method,
             part_number=part_num,
         )
         data = _utils.proto_to_json(msg)
-        endpoint = "{}://{}/api/v1/modeldb/versioning/repositories/{}/commits/{}/getUrlForBlobVersioned".format(
+        endpoint = "{}://{}/api/v1/dataset-version/dataset/{}/datasetVersion/{}/getUrlForDatasetBlobVersioned".format(
             self._conn.scheme,
             self._conn.socket,
-            self._repo.id,
+            self.dataset_id,
             self.id,
         )
         response = _utils.make_request("POST", endpoint, self._conn, json=data)
@@ -483,14 +480,12 @@ class DatasetVersion(entity._ModelDBEntity):
         return response_msg
 
     # TODO: consolidate this with similar method in `Commit`
-    def _upload_artifact(self, blob_path, dataset_component_path, file_handle, part_size=64*(10**6)):
+    def _upload_artifact(self, dataset_component_path, file_handle, part_size=64*(10**6)):
         """
         Uploads `file_handle` to ModelDB artifact store.
 
         Parameters
         ----------
-        blob_path : str
-            Path to blob within repo.
         dataset_component_path : str
             Filepath in dataset component blob.
         file_handle : file-like
@@ -502,7 +497,7 @@ class DatasetVersion(entity._ModelDBEntity):
         file_handle.seek(0)
 
         # check if multipart upload ok
-        url_for_artifact = self._get_url_for_artifact(blob_path, dataset_component_path, "PUT", part_num=1)
+        url_for_artifact = self._get_url_for_artifact(dataset_component_path, "PUT", part_num=1)
 
         print("uploading {} to ModelDB".format(dataset_component_path))
         if url_for_artifact.multipart_upload_ok:
@@ -512,7 +507,7 @@ class DatasetVersion(entity._ModelDBEntity):
                 print("uploading part {}".format(part_num), end='\r')
 
                 # get presigned URL
-                url = self._get_url_for_artifact(blob_path, dataset_component_path, "PUT", part_num=part_num).url
+                url = self._get_url_for_artifact(dataset_component_path, "PUT", part_num=part_num).url
 
                 # wrap file part into bytestream to avoid OverflowError
                 #     Passing a bytestring >2 GB (num bytes > max val of int32) directly to
@@ -528,16 +523,14 @@ class DatasetVersion(entity._ModelDBEntity):
                 _utils.raise_for_http_error(response)
 
                 # commit part
-                url = "{}://{}/api/v1/modeldb/versioning/commitVersionedBlobArtifactPart".format(
+                url = "{}://{}/api/v1/dataset-version/commitVersionedDatasetBlobArtifactPart".format(
                     self._conn.scheme,
                     self._conn.socket,
                 )
-                msg = _VersioningService.CommitVersionedBlobArtifactPart(
-                    commit_sha=self.id,
-                    location=path_to_location(blob_path),
+                msg = _DatasetVersionService.CommitVersionedDatasetBlobArtifactPart(
+                    dataset_version_id=self.id,
                     path_dataset_component_blob_path=dataset_component_path,
                 )
-                msg.repository_id.repo_id = self._repo.id
                 msg.artifact_part.part_number = part_num
                 msg.artifact_part.etag = response.headers['ETag']
                 data = _utils.proto_to_json(msg)
@@ -546,16 +539,14 @@ class DatasetVersion(entity._ModelDBEntity):
             print()
 
             # complete upload
-            url = "{}://{}/api/v1/modeldb/versioning/commitMultipartVersionedBlobArtifact".format(
+            url = "{}://{}/api/v1/dataset-version/commitMultipartVersionedDatasetBlobArtifact".format(
                 self._conn.scheme,
                 self._conn.socket,
             )
-            msg = _VersioningService.CommitMultipartVersionedBlobArtifact(
-                commit_sha=self.id,
-                location=path_to_location(blob_path),
+            msg = _DatasetVersionService.CommitMultipartVersionedDatasetBlobArtifact(
+                dataset_version_id=self.id,
                 path_dataset_component_blob_path=dataset_component_path,
             )
-            msg.repository_id.repo_id = self._repo.id
             data = _utils.proto_to_json(msg)
             response = _utils.make_request("POST", url, self._conn, json=data)
             _utils.raise_for_http_error(response)

--- a/client/verta/verta/_dataset_versioning/dataset_version.py
+++ b/client/verta/verta/_dataset_versioning/dataset_version.py
@@ -110,11 +110,22 @@ class DatasetVersion(entity._ModelDBEntity):
         msg = Message(dataset_id=dataset.id, description=desc, tags=tags, attributes=attrs, time_created=time_updated,
                       dataset_blob=dataset_blob._as_proto().dataset)
 
+        # prepare ModelDB-versionend components for upload (after Dataset Version creation)
+        if dataset_blob._mdb_versioned:
+            dataset_blob._prepare_components_to_upload()
+
         endpoint = "/api/v1/modeldb/dataset-version/createDatasetVersion"
         response = conn.make_proto_request("POST", endpoint, body=msg)
         dataset_version = conn.must_proto_response(response, Message.Response).dataset_version
-
         print("created new Dataset Version: {} for {}".format(dataset_version.version, dataset.name))
+
+        # upload ModelDB-versioned components
+        if dataset_blob._mdb_versioned:
+            for component in dataset_blob._components_map.values():
+                if component._internal_versioned_path:
+                    with open(component._local_path, 'rb') as f:
+                        self._upload_artifact(blob_path, component.path, f)
+
         return dataset_version
 
     def get_content(self):
@@ -413,3 +424,155 @@ class DatasetVersion(entity._ModelDBEntity):
             " considering accessing the paths of specific components"
             " using `list_components()[i].path` instead",
         )
+
+    # The following properties are for managed
+    # TODO: consolidate this with similar method in `_ModelDBEntity`
+    def _get_url_for_artifact(self, blob_path, dataset_component_path, method, part_num=0):
+        """
+        Obtains a URL to use for accessing stored artifacts.
+
+        Parameters
+        ----------
+        blob_path : str
+            Path to blob within repo.
+        dataset_component_path : str
+            Filepath in dataset component blob.
+        method : {'GET', 'PUT'}
+            HTTP method to request for the generated URL.
+        part_num : int, optional
+            If using Multipart Upload, number of part to be uploaded.
+
+        Returns
+        -------
+        response_msg : `_VersioningService.GetUrlForBlobVersioned.Response`
+            Backend response.
+
+        """
+        if method.upper() not in ("GET", "PUT"):
+            raise ValueError("`method` must be one of {'GET', 'PUT'}")
+
+        Message = _VersioningService.GetUrlForBlobVersioned
+        msg = Message(
+            location=path_to_location(blob_path),
+            path_dataset_component_blob_path=dataset_component_path,
+            method=method,
+            part_number=part_num,
+        )
+        data = _utils.proto_to_json(msg)
+        endpoint = "{}://{}/api/v1/modeldb/versioning/repositories/{}/commits/{}/getUrlForBlobVersioned".format(
+            self._conn.scheme,
+            self._conn.socket,
+            self._repo.id,
+            self.id,
+        )
+        response = _utils.make_request("POST", endpoint, self._conn, json=data)
+        _utils.raise_for_http_error(response)
+
+        response_msg = _utils.json_to_proto(response.json(), Message.Response)
+
+        url = response_msg.url
+        # accommodate port-forwarded NFS store
+        if 'https://localhost' in url[:20]:
+            url = 'http' + url[5:]
+        if 'localhost%3a' in url[:20]:
+            url = url.replace('localhost%3a', 'localhost:')
+        if 'localhost%3A' in url[:20]:
+            url = url.replace('localhost%3A', 'localhost:')
+        response_msg.url = url
+
+        return response_msg
+
+    # TODO: consolidate this with similar method in `Commit`
+    def _upload_artifact(self, blob_path, dataset_component_path, file_handle, part_size=64*(10**6)):
+        """
+        Uploads `file_handle` to ModelDB artifact store.
+
+        Parameters
+        ----------
+        blob_path : str
+            Path to blob within repo.
+        dataset_component_path : str
+            Filepath in dataset component blob.
+        file_handle : file-like
+            Artifact to be uploaded.
+        part_size : int, default 64 MB
+            If using multipart upload, number of bytes to upload per part.
+
+        """
+        file_handle.seek(0)
+
+        # check if multipart upload ok
+        url_for_artifact = self._get_url_for_artifact(blob_path, dataset_component_path, "PUT", part_num=1)
+
+        print("uploading {} to ModelDB".format(dataset_component_path))
+        if url_for_artifact.multipart_upload_ok:
+            # TODO: parallelize this
+            file_parts = iter(lambda: file_handle.read(part_size), b'')
+            for part_num, file_part in enumerate(file_parts, start=1):
+                print("uploading part {}".format(part_num), end='\r')
+
+                # get presigned URL
+                url = self._get_url_for_artifact(blob_path, dataset_component_path, "PUT", part_num=part_num).url
+
+                # wrap file part into bytestream to avoid OverflowError
+                #     Passing a bytestring >2 GB (num bytes > max val of int32) directly to
+                #     ``requests`` will overwhelm CPython's SSL lib when it tries to sign the
+                #     payload. But passing a buffered bytestream instead of the raw bytestring
+                #     indicates to ``requests`` that it should perform a streaming upload via
+                #     HTTP/1.1 chunked transfer encoding and avoid this issue.
+                #     https://github.com/psf/requests/issues/2717
+                part_stream = six.BytesIO(file_part)
+
+                # upload part
+                response = _utils.make_request("PUT", url, self._conn, data=part_stream)
+                _utils.raise_for_http_error(response)
+
+                # commit part
+                url = "{}://{}/api/v1/modeldb/versioning/commitVersionedBlobArtifactPart".format(
+                    self._conn.scheme,
+                    self._conn.socket,
+                )
+                msg = _VersioningService.CommitVersionedBlobArtifactPart(
+                    commit_sha=self.id,
+                    location=path_to_location(blob_path),
+                    path_dataset_component_blob_path=dataset_component_path,
+                )
+                msg.repository_id.repo_id = self._repo.id
+                msg.artifact_part.part_number = part_num
+                msg.artifact_part.etag = response.headers['ETag']
+                data = _utils.proto_to_json(msg)
+                response = _utils.make_request("POST", url, self._conn, json=data)
+                _utils.raise_for_http_error(response)
+            print()
+
+            # complete upload
+            url = "{}://{}/api/v1/modeldb/versioning/commitMultipartVersionedBlobArtifact".format(
+                self._conn.scheme,
+                self._conn.socket,
+            )
+            msg = _VersioningService.CommitMultipartVersionedBlobArtifact(
+                commit_sha=self.id,
+                location=path_to_location(blob_path),
+                path_dataset_component_blob_path=dataset_component_path,
+            )
+            msg.repository_id.repo_id = self._repo.id
+            data = _utils.proto_to_json(msg)
+            response = _utils.make_request("POST", url, self._conn, json=data)
+            _utils.raise_for_http_error(response)
+        else:
+            # upload full artifact
+            if url_for_artifact.fields:
+                # if fields were returned by backend, make a POST request and supply them as form fields
+                response = _utils.make_request(
+                    "POST", url_for_artifact.url, self._conn,
+                    # requests uses the `files` parameter for sending multipart/form-data POSTs.
+                    #     https://stackoverflow.com/a/12385661/8651995
+                    # the file contents must be the final form field
+                    #     https://docs.aws.amazon.com/AmazonS3/latest/dev/HTTPPOSTForms.html#HTTPPOSTFormFields
+                    files=list(url_for_artifact.fields.items()) + [('file', file_handle)],
+                )
+            else:
+                response = _utils.make_request("PUT", url_for_artifact.url, self._conn, data=file_handle)
+            _utils.raise_for_http_error(response)
+
+        print("upload complete")


### PR DESCRIPTION
Summary of changes:

- copy artifact upload methods from `Commit` to `DatasetVersion`
- overwrite `_create()` in `DatasetVersion` to perform the file preparation and upload steps (simplified from `Commit`)
- add helper methods to dataset blob so that `download()` can handle both `Commit` and `DatasetVersion` sources