### PR TITLE
Add project_dockerfile example

### DIFF
--- a/project_dockerfile/create_dockerfile.py
+++ b/project_dockerfile/create_dockerfile.py
@@ -1,0 +1,69 @@
+HOST="https://socure.app.verta.ai"
+
+# Create dockerfile for project
+from verta import Client
+client = Client(HOST)
+
+repo = client.get_or_create_repository("My repo")
+master = repo.get_commit()
+
+env = master.get("project1/environment")
+version = "{}.{}".format(env._msg.python.version.major, env._msg.python.version.minor)
+
+requirements = ""
+if env._msg.python.requirements:
+    requirements = "\n".join([
+                env._req_spec_msg_to_str(req_spec_msg)
+                for req_spec_msg
+                in sorted(
+                    env._msg.python.requirements,
+                    key=lambda req_spec_msg: req_spec_msg.library,
+                )
+    ])
+
+constraints = ""
+if env._msg.python.constraints:
+    constraints = "\n".join([
+                env._req_spec_msg_to_str(req_spec_msg)
+                for req_spec_msg
+                in sorted(
+                    env._msg.python.constraints,
+                    key=lambda req_spec_msg: req_spec_msg.library,
+                )
+    ])
+
+code = master.get("project1/code")
+code_repo = code._msg.git.repo
+code_ref = code._msg.git.hash
+# Uncomment if you want to use a branch instead of a locked commit
+# code_ref = code._msg.git.branch
+
+dockerfile = """
+FROM python:{version}
+COPY requirements.txt requirements.txt
+COPY constraints.txt constraints.txt
+RUN pip install -r requirements.txt -c constraints.txt
+COPY code_repo /code_repo
+CMD ["python", "/code_repo/project_dockerfile/train.py"]
+""".format(version=version)
+
+build_script = """#!/bin/bash
+
+set -xe
+
+git clone {code_repo} code_repo || true
+cd code_repo
+git fetch
+git checkout {code_ref}
+cd ..
+docker build -t example-image .
+""".format(code_repo=code_repo, code_ref=code_ref)
+
+with open("requirements.txt", "w") as f:
+    f.write(requirements)
+with open("constraints.txt", "w") as f:
+    f.write(constraints)
+with open("Dockerfile", "w") as f:
+    f.write(dockerfile)
+with open("build.sh", "w") as f:
+    f.write(build_script)

--- a/project_dockerfile/save_repository.py
+++ b/project_dockerfile/save_repository.py
@@ -1,0 +1,27 @@
+HOST="https://socure.app.verta.ai"
+
+# Save project details in a repository
+from verta import Client
+
+client = Client(HOST)
+
+repo = client.get_or_create_repository("My repo")
+master = repo.get_commit()
+print(master)
+
+from verta.environment import Python
+master.update(
+    "project1/environment",
+    Python(
+        requirements=["verta", "sklearn"],
+        constraints=Python.read_pip_environment(), # Ensure all transient dependencies stay the same
+    ),
+)
+master.save("Adding local python environment")
+
+from verta.code import Git
+master.update(
+    "project1/code",
+    Git(),
+)
+master.save("Adding code repo")

--- a/project_dockerfile/train.py
+++ b/project_dockerfile/train.py
@@ -1,0 +1,1 @@
+print("training")


### PR DESCRIPTION
```
~/temp/ctx () [engine-dev/demo]$ python /Users/conrado/workspace/modeldb/project_dockerfile/create_dockerfile.py 
set email from environment
set developer key from environment
connection successfully established
set existing Repository: My repo from personal workspace
~/temp/ctx () [engine-dev/demo]$ ./build.sh 
+ git clone git@github.com:VertaAI/modeldb.git code_repo
fatal: destination path 'code_repo' already exists and is not an empty directory.
+ true
+ cd code_repo
+ git fetch
remote: Enumerating objects: 13, done.
remote: Counting objects: 100% (13/13), done.
remote: Compressing objects: 100% (6/6), done.
remote: Total 13 (delta 7), reused 13 (delta 7), pack-reused 0
Unpacking objects: 100% (13/13), done.
From github.com:VertaAI/modeldb
 + c885aa88...f5a1656b cm/project_dockerfile -> origin/cm/project_dockerfile  (forced update)
   3e9077a6..754bc2c1  hackathon             -> origin/hackathon
+ git checkout f5a1656beab01eaf37fabbe94bda53a8334ca513
Warning: you are leaving 1 commit behind, not connected to
any of your branches:

  c885aa88 Add project_dockerfile example

If you want to keep it by creating a new branch, this may be a good time
to do so with:

 git branch <new-branch-name> c885aa88

HEAD is now at f5a1656b Add project_dockerfile example
+ cd ..
+ docker build -t example-image .
Sending build context to Docker daemon  66.86MB
Step 1/6 : FROM python:3.7
 ---> be890676aead
Step 2/6 : COPY requirements.txt requirements.txt
 ---> Using cache
 ---> 86c7b0b76c43
Step 3/6 : COPY constraints.txt constraints.txt
 ---> Using cache
 ---> 758dbe2cc4e1
Step 4/6 : RUN pip install -r requirements.txt -c constraints.txt
 ---> Using cache
 ---> 978023319ae0
Step 5/6 : COPY code_repo /code_repo
 ---> 808138fe82d3
Step 6/6 : CMD ["python", "/code_repo/project_dockerfile/train.py"]
 ---> Running in 61a1d57d7769
Removing intermediate container 61a1d57d7769
 ---> ed56c9481818
Successfully built ed56c9481818
Successfully tagged example-image:latest
~/temp/ctx () [engine-dev/demo]$ docker run --rm example-image:latest
training
```