### PR TITLE
VR-9362: Don't unnecessarily reset client._ctx

### DIFF
--- a/client/verta/tests/test_entities.py
+++ b/client/verta/tests/test_entities.py
@@ -220,6 +220,31 @@ class TestEntities:
             finally:
                 shutil.rmtree(_CACHE_DIR, ignore_errors=True)
 
+    def test_context(self, client, strs):
+        strs = iter(strs)
+        def assert_new_run_in_proj():
+            assert client.get_or_create_experiment_run()._msg.project_id == proj.id
+            assert client.create_experiment_run()._msg.project_id == proj.id
+
+        proj = client.create_project()
+        assert_new_run_in_proj()
+
+        client.get_or_create_repository(next(strs)).delete()
+        # client.create_repository(next(strs)).delete()  # method DNE
+        assert_new_run_in_proj()
+
+        client.get_or_create_registered_model().delete()
+        client.create_registered_model().delete()
+        assert_new_run_in_proj()
+
+        client.get_or_create_dataset().delete()
+        client.create_dataset().delete()
+        assert_new_run_in_proj()
+
+        assert client.get_or_create_experiment()._msg.project_id == proj.id
+        assert client.create_experiment()._msg.project_id == proj.id
+        assert_new_run_in_proj()
+
 
 class TestProject:
     def test_create(self, client):

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -1327,7 +1327,7 @@ class Client(object):
         if id is not None:
             dataset = Dataset._get_by_id(self._conn, self._conf, id)
         else:
-            dataset = Dataset._get_by_name(self._conn, self._conf, name, workspace_name)
+            dataset = Dataset._get_by_name(self._conn, self._conf, name, workspace)
 
         if dataset is None:
             raise ValueError("Dataset not found")

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -723,7 +723,7 @@ class Client(object):
         if workspace is None:
             workspace = self._get_personal_workspace()
 
-        ctx = copy.copy(self._ctx)
+        ctx = _Context(self._conn, self._conf)
         ctx.workspace_name = workspace
 
         resource_name = "Registered Model"
@@ -1070,7 +1070,7 @@ class Client(object):
         if workspace is None:
             workspace = self._get_personal_workspace()
 
-        ctx = copy.copy(self._ctx)
+        ctx = _Context(self._conn, self._conf)
         ctx.workspace_name = workspace
 
         return RegisteredModel._create(self._conn, self._conf, ctx, name=name, desc=desc, tags=labels, public_within_org=public_within_org)
@@ -1221,7 +1221,7 @@ class Client(object):
         name = self._set_from_config_if_none(name, "dataset")
         workspace = self._set_from_config_if_none(workspace, "workspace")
 
-        ctx = copy.copy(self._ctx)
+        ctx = _Context(self._conn, self._conf)
         ctx.workspace_name = workspace
 
         resource_name = "Dataset"
@@ -1289,7 +1289,7 @@ class Client(object):
         name = self._set_from_config_if_none(name, "dataset")
         workspace = self._set_from_config_if_none(workspace, "workspace")
 
-        ctx = copy.copy(self._ctx)
+        ctx = _Context(self._conn, self._conf)
         ctx.workspace_name = workspace
         return Dataset._create(self._conn, self._conf, ctx, name=name, desc=desc, tags=tags, attrs=attrs,
                                time_created=time_created, public_within_org=public_within_org)

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -723,8 +723,8 @@ class Client(object):
         if workspace is None:
             workspace = self._get_personal_workspace()
 
-        self._ctx = _Context(self._conn, self._conf)
-        self._ctx.workspace_name = workspace
+        ctx = copy.copy(self._ctx)
+        ctx.workspace_name = workspace
 
         resource_name = "Registered Model"
         param_names = "`desc`, `labels`, or `public_within_org`"
@@ -735,8 +735,8 @@ class Client(object):
                                                   param_names, params)
         else:
             registered_model = RegisteredModel._get_or_create_by_name(self._conn, name,
-                                                                  lambda name: RegisteredModel._get_by_name(self._conn, self._conf, name, self._ctx.workspace_name),
-                                                                  lambda name: RegisteredModel._create(self._conn, self._conf, self._ctx, name=name, desc=desc, tags=labels, public_within_org=public_within_org),
+                                                                  lambda name: RegisteredModel._get_by_name(self._conn, self._conf, name, ctx.workspace_name),
+                                                                  lambda name: RegisteredModel._create(self._conn, self._conf, ctx, name=name, desc=desc, tags=labels, public_within_org=public_within_org),
                                                                   lambda: check_unnecessary_params_warning(
                                                                       resource_name,
                                                                       "name {}".format(name),
@@ -769,13 +769,10 @@ class Client(object):
         if workspace is None:
             workspace = self._get_personal_workspace()
 
-        self._ctx = _Context(self._conn, self._conf)
-        self._ctx.workspace_name = workspace
-
         if id is not None:
             registered_model = RegisteredModel._get_by_id(self._conn, self._conf, id)
         else:
-            registered_model =  RegisteredModel._get_by_name(self._conn, self._conf, name, self._ctx.workspace_name)
+            registered_model =  RegisteredModel._get_by_name(self._conn, self._conf, name, workspace)
 
         if registered_model is None:
             raise ValueError("Registered model not found")
@@ -1073,12 +1070,10 @@ class Client(object):
         if workspace is None:
             workspace = self._get_personal_workspace()
 
-        self._ctx = _Context(self._conn, self._conf)
-        self._ctx.workspace_name = workspace
+        ctx = copy.copy(self._ctx)
+        ctx.workspace_name = workspace
 
-        self._ctx.registered_model = RegisteredModel._create(self._conn, self._conf, self._ctx, name=name, desc=desc, tags=labels, public_within_org=public_within_org)
-
-        return self._ctx.registered_model
+        return RegisteredModel._create(self._conn, self._conf, ctx, name=name, desc=desc, tags=labels, public_within_org=public_within_org)
 
 
     def create_endpoint(self, path, description=None, workspace=None, public_within_org=False):
@@ -1226,8 +1221,8 @@ class Client(object):
         name = self._set_from_config_if_none(name, "dataset")
         workspace = self._set_from_config_if_none(workspace, "workspace")
 
-        self._ctx = _Context(self._conn, self._conf)
-        self._ctx.workspace_name = workspace
+        ctx = copy.copy(self._ctx)
+        ctx.workspace_name = workspace
 
         resource_name = "Dataset"
         param_names = "`desc`, `tags`, `attrs`, `time_created`, or `public_within_org`"
@@ -1238,8 +1233,8 @@ class Client(object):
                                                   param_names, params)
         else:
             dataset = Dataset._get_or_create_by_name(self._conn, name,
-                                                        lambda name: Dataset._get_by_name(self._conn, self._conf, name, self._ctx.workspace_name),
-                                                        lambda name: Dataset._create(self._conn, self._conf, self._ctx, name=name, desc=desc, tags=tags, attrs=attrs, time_created=time_created, public_within_org=public_within_org),
+                                                        lambda name: Dataset._get_by_name(self._conn, self._conf, name, ctx.workspace_name),
+                                                        lambda name: Dataset._create(self._conn, self._conf, ctx, name=name, desc=desc, tags=tags, attrs=attrs, time_created=time_created, public_within_org=public_within_org),
                                                         lambda: check_unnecessary_params_warning(
                                                          resource_name,
                                                          "name {}".format(name),
@@ -1294,9 +1289,9 @@ class Client(object):
         name = self._set_from_config_if_none(name, "dataset")
         workspace = self._set_from_config_if_none(workspace, "workspace")
 
-        self._ctx = _Context(self._conn, self._conf)
-        self._ctx.workspace_name = workspace
-        return Dataset._create(self._conn, self._conf, self._ctx, name=name, desc=desc, tags=tags, attrs=attrs,
+        ctx = copy.copy(self._ctx)
+        ctx.workspace_name = workspace
+        return Dataset._create(self._conn, self._conf, ctx, name=name, desc=desc, tags=tags, attrs=attrs,
                                time_created=time_created, public_within_org=public_within_org)
 
     def get_dataset(self, name=None, workspace=None, id=None):
@@ -1329,13 +1324,10 @@ class Client(object):
             raise ValueError("must specify either `name` or `id`")
         workspace = self._set_from_config_if_none(workspace, "workspace")
 
-        self._ctx = _Context(self._conn, self._conf)
-        self._ctx.workspace_name = workspace
-
         if id is not None:
             dataset = Dataset._get_by_id(self._conn, self._conf, id)
         else:
-            dataset = Dataset._get_by_name(self._conn, self._conf, name, self._ctx.workspace_name)
+            dataset = Dataset._get_by_name(self._conn, self._conf, name, workspace_name)
 
         if dataset is None:
             raise ValueError("Dataset not found")
@@ -1362,8 +1354,6 @@ class Client(object):
         :class:`~verta._dataset_versioning.dataset_version.DatasetVersion`
 
         """
-        self._ctx = _Context(self._conn, self._conf)
-
         dataset_version = DatasetVersion._get_by_id(self._conn, self._conf, id)
 
         if dataset_version is None:


### PR DESCRIPTION
## Problem

As far as I can tell and recall, the main purpose of [`Context`](https://github.com/VertaAI/modeldb/blob/master/client/verta/verta/_tracking/context.py) was to track client state between `set_project()`, `set_experiment()`, and `set_experiment_run()`: If I set a project that's in a particular workspace, subsequent experiment and experiment run calls should use that same project and workspace where applicable.

This caused a problem when we started copy&pasting the code from `set_project()` to new methods for registered models and datasets, because that logic resets the context:
```python
proj = client.set_project()
assert client.set_experiment_run()._msg.project_id == proj.id  # ✅

client.set_dataset()
assert client.set_experiment_run()._msg.project_id == proj.id  # 🙅🏼‍♂️
```

## Solution

This PR changes the non-project methods to simply not overwrite `client._ctx`.

## Why it works

I'm confident this is safe: the client doesn't need to track state for registered models because `RegisteredModelVersion`s are created from `RegisteredModel`s not `Client`, and similar for datasets and dataset versions (and I believe this is a better design going forward anyway).

Moreover, it's my opinion that setting `workspace` for registered models / datasets should not be designed to carry over for other entities (which is the current behavior anyway, since every method is overwriting `_ctx.workspace_name`).

Also, tests pass like they've never passed before.