### PR TITLE
Consolidate client tests' "created entities" fixtures

### DIFF
--- a/client/verta/tests/conftest.py
+++ b/client/verta/tests/conftest.py
@@ -364,7 +364,7 @@ def registered_model(client):
 
 @pytest.fixture
 def created_entities():
-    """Container to track and clean up `RegisteredModel`s created during tests."""
+    """Container to track and clean up ModelDB, Registry, etc. entities created during tests."""
     to_delete = []
 
     yield to_delete

--- a/client/verta/tests/conftest.py
+++ b/client/verta/tests/conftest.py
@@ -356,17 +356,6 @@ def commit(repository):
 
 
 @pytest.fixture
-def created_datasets(client):
-    """Container to track and clean up Datasets created during tests."""
-    created_datasets = []
-
-    yield created_datasets
-
-    for dataset in created_datasets:
-        dataset.delete()
-
-
-@pytest.fixture
 def registered_model(client):
     model = client.get_or_create_registered_model()
     yield model
@@ -374,14 +363,14 @@ def registered_model(client):
 
 
 @pytest.fixture
-def created_registered_models():
+def created_entities():
     """Container to track and clean up `RegisteredModel`s created during tests."""
     to_delete = []
 
     yield to_delete
 
-    for registered_model in to_delete:
-        registered_model.delete()
+    for entity in to_delete:
+        entity.delete()
 
 
 @pytest.fixture
@@ -390,22 +379,13 @@ def model_version(registered_model):
 
 
 @pytest.fixture
-def endpoint(client, created_endpoints):
+def endpoint(client):
     path = _utils.generate_default_name()
     endpoint = client.create_endpoint(path)
-    created_endpoints.append(endpoint)
 
     yield endpoint
 
-
-@pytest.fixture
-def created_endpoints():
-    to_delete = []
-
-    yield to_delete
-
-    for endpoint in to_delete:
-        endpoint.delete()
+    endpoint.delete()
 
 
 @pytest.fixture

--- a/client/verta/tests/test_cli/test_endpoint.py
+++ b/client/verta/tests/test_cli/test_endpoint.py
@@ -18,14 +18,14 @@ pytestmark = pytest.mark.not_oss  # skip if run in oss setup. Applied to entire 
 
 
 class TestList:
-    def test_list_endpoint(self, organization, created_endpoints):
+    def test_list_endpoint(self, organization, created_entities):
         client = Client()
         path = _utils.generate_default_name()
         path2 = _utils.generate_default_name()
         endpoint1 = client.get_or_create_endpoint(path, workspace=organization.name)
         endpoint2 = client.get_or_create_endpoint(path2, workspace=organization.name)
-        created_endpoints.append(endpoint1)
-        created_endpoints.append(endpoint2)
+        created_entities.append(endpoint1)
+        created_entities.append(endpoint2)
         runner = CliRunner()
         result = runner.invoke(
             cli,
@@ -37,7 +37,7 @@ class TestList:
         assert path2 in result.output
 
 class TestCreate:
-    def test_create_endpoint(self, client, created_endpoints):
+    def test_create_endpoint(self, client, created_entities):
         endpoint_name = _utils.generate_default_name()
 
         runner = CliRunner()
@@ -51,9 +51,9 @@ class TestCreate:
         endpoint = client.get_endpoint(endpoint_name)
         assert endpoint
 
-        created_endpoints.append(endpoint)
+        created_entities.append(endpoint)
 
-    def test_create_workspace_config(self, client, organization, in_tempdir, created_endpoints):
+    def test_create_workspace_config(self, client, organization, in_tempdir, created_entities):
         client_config = {
             "workspace": organization.name
         }
@@ -76,17 +76,17 @@ class TestCreate:
         endpoint = client.get_endpoint(endpoint_name)
         assert endpoint.workspace == organization.name
 
-        created_endpoints.append(endpoint)
+        created_entities.append(endpoint)
 
 
 class TestGet:
-    def test_get(self, client, created_endpoints, experiment_run, model_for_deployment):
+    def test_get(self, client, created_entities, experiment_run, model_for_deployment):
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
         experiment_run.log_requirements(['scikit-learn'])
 
         path = _utils.generate_default_name()
         endpoint = client.set_endpoint(path)
-        created_endpoints.append(endpoint)
+        created_entities.append(endpoint)
 
         runner = CliRunner()
         result = runner.invoke(
@@ -114,10 +114,10 @@ class TestGet:
 
 
 class TestUpdate:
-    def test_direct_update_endpoint(self, client, created_endpoints, experiment_run, model_for_deployment):
+    def test_direct_update_endpoint(self, client, created_entities, experiment_run, model_for_deployment):
         endpoint_name = _utils.generate_default_name()
         endpoint = client.set_endpoint(endpoint_name)
-        created_endpoints.append(endpoint)
+        created_entities.append(endpoint)
         original_status = endpoint.get_status()
         original_build_ids = get_build_ids(original_status)
 
@@ -135,10 +135,10 @@ class TestUpdate:
 
         assert len(updated_build_ids) - len(updated_build_ids.intersection(original_build_ids)) > 0
 
-    def test_canary_update_endpoint(self, client, created_endpoints, experiment_run, model_for_deployment):
+    def test_canary_update_endpoint(self, client, created_entities, experiment_run, model_for_deployment):
         endpoint_name = _utils.generate_default_name()
         endpoint = client.set_endpoint(endpoint_name)
-        created_endpoints.append(endpoint)
+        created_entities.append(endpoint)
         original_status = endpoint.get_status()
         original_build_ids = get_build_ids(original_status)
 
@@ -167,10 +167,10 @@ class TestUpdate:
 
         assert len(updated_build_ids) - len(updated_build_ids.intersection(original_build_ids)) > 0
 
-    def test_canary_update_endpoint_env_vars(self, client, created_endpoints, experiment_run, model_for_deployment):
+    def test_canary_update_endpoint_env_vars(self, client, created_entities, experiment_run, model_for_deployment):
         endpoint_name = _utils.generate_default_name()
         endpoint = client.set_endpoint(endpoint_name)
-        created_endpoints.append(endpoint)
+        created_entities.append(endpoint)
         original_status = endpoint.get_status()
         original_build_ids = get_build_ids(original_status)
 
@@ -195,14 +195,14 @@ class TestUpdate:
 
         assert len(updated_build_ids) - len(updated_build_ids.intersection(original_build_ids)) > 0
 
-    def test_update_invalid_parameters_error(self, client, created_endpoints, experiment_run):
+    def test_update_invalid_parameters_error(self, client, created_entities, experiment_run):
         error_msg_1 = "--canary-rule, --canary-interval, and --canary-step can only be used alongside --strategy=canary"
         error_msg_2 = "--canary-rule, --canary-interval, and --canary-step must be provided alongside --strategy=canary"
         error_msg_3 = '`env_vars` must be dictionary of str keys and str values'
 
         endpoint_name = _utils.generate_default_name()
         endpoint = client.set_endpoint(endpoint_name)
-        created_endpoints.append(endpoint)
+        created_entities.append(endpoint)
 
         canary_rule = json.dumps({
             "rule": "latency_avg_max",
@@ -276,7 +276,7 @@ class TestUpdate:
         assert result.exception
         assert error_msg_3 in str(result.exception)
 
-    def test_update_from_version(self, client, model_version, created_endpoints):
+    def test_update_from_version(self, client, model_version, created_entities):
         np = pytest.importorskip("numpy")
         sklearn = pytest.importorskip("sklearn")
         from sklearn.linear_model import LogisticRegression
@@ -290,7 +290,7 @@ class TestUpdate:
 
         path = _utils.generate_default_name()
         endpoint = client.set_endpoint(path)
-        created_endpoints.append(endpoint)
+        created_entities.append(endpoint)
 
         runner = CliRunner()
         result = runner.invoke(
@@ -306,7 +306,7 @@ class TestUpdate:
         test_data = np.random.random((4, 12))
         assert np.array_equal(endpoint.get_deployed_model().predict(test_data), classifier.predict(test_data))
 
-    def test_update_from_json_config(self, client, in_tempdir, created_endpoints, experiment_run, model_for_deployment):
+    def test_update_from_json_config(self, client, in_tempdir, created_entities, experiment_run, model_for_deployment):
         json = pytest.importorskip("json")
 
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
@@ -314,7 +314,7 @@ class TestUpdate:
 
         path = _utils.generate_default_name()
         endpoint = client.set_endpoint(path)
-        created_endpoints.append(endpoint)
+        created_entities.append(endpoint)
 
         original_status = endpoint.get_status()
         original_build_ids = get_build_ids(original_status)
@@ -357,10 +357,10 @@ class TestUpdate:
         updated_build_ids = get_build_ids(endpoint.get_status())
         assert len(updated_build_ids) - len(updated_build_ids.intersection(original_build_ids)) > 0
 
-    def test_update_with_resources(self, client, created_endpoints, experiment_run, model_for_deployment):
+    def test_update_with_resources(self, client, created_entities, experiment_run, model_for_deployment):
         endpoint_name = _utils.generate_default_name()
         endpoint = client.set_endpoint(endpoint_name)
-        created_endpoints.append(endpoint)
+        created_entities.append(endpoint)
         original_status = endpoint.get_status()
         original_build_ids = get_build_ids(original_status)
 
@@ -379,13 +379,13 @@ class TestUpdate:
         resources_dict = Resources._from_dict(json.loads(resources))._as_dict()  # config is `cpu`, wire is `cpu_millis`
         assert endpoint.get_update_status()['update_request']['resources'] == resources_dict
 
-    def test_update_autoscaling(self, client, created_endpoints, experiment_run, model_for_deployment):
+    def test_update_autoscaling(self, client, created_entities, experiment_run, model_for_deployment):
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
         experiment_run.log_requirements(['scikit-learn'])
 
         path = _utils.generate_default_name()
         endpoint = client.set_endpoint(path)
-        created_endpoints.append(endpoint)
+        created_entities.append(endpoint)
 
         autoscaling_option = '{"min_replicas": 1, "max_replicas": 4, "min_scale": 0.5, "max_scale": 2.0}'
         cpu_metric = '{"metric": "cpu_utilization", "parameters": [{"name": "target", "value": "0.5"}]}'
@@ -418,7 +418,7 @@ class TestUpdate:
 
 
 class TestDownload:
-    def test_download_context(self, experiment_run, model_for_deployment, registered_model, in_tempdir, created_registered_models, model_version):
+    def test_download_context(self, experiment_run, model_for_deployment, registered_model, in_tempdir, created_entities, model_version):
         np = pytest.importorskip("numpy")
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
         experiment_run.log_requirements(['scikit-learn'])
@@ -463,7 +463,7 @@ class TestDownload:
 
 
 class TestPredict:
-    def test_predict(self, client, experiment_run, created_endpoints):
+    def test_predict(self, client, experiment_run, created_entities):
         np = pytest.importorskip("numpy")
         sklearn = pytest.importorskip("sklearn")
         from sklearn.linear_model import LogisticRegression
@@ -479,7 +479,7 @@ class TestPredict:
 
         path = _utils.generate_default_name()
         endpoint = client.set_endpoint(path)
-        created_endpoints.append(endpoint)
+        created_entities.append(endpoint)
         endpoint.update(experiment_run, DirectUpdateStrategy(), wait=True)
 
         runner = CliRunner()

--- a/client/verta/tests/test_cli/test_registry.py
+++ b/client/verta/tests/test_cli/test_registry.py
@@ -22,7 +22,7 @@ pytestmark = pytest.mark.not_oss  # skip if run in oss setup. Applied to entire 
 
 
 class TestCreate:
-    def test_create_model(self, client, created_registered_models):
+    def test_create_model(self, client, created_entities):
         model_name = RegisteredModel._generate_default_name()
 
         runner = CliRunner()
@@ -36,7 +36,7 @@ class TestCreate:
         registered_model = client.get_registered_model(model_name)
         assert registered_model
 
-        created_registered_models.append(registered_model)
+        created_entities.append(registered_model)
 
     def test_create_version(self, registered_model, in_tempdir, requirements_file):
         LogisticRegression = pytest.importorskip('sklearn.linear_model').LogisticRegression
@@ -181,7 +181,7 @@ class TestCreate:
         assert result.exception
         assert error_message in result.output
 
-    def test_create_workspace_config(self, client, organization, in_tempdir, created_registered_models):
+    def test_create_workspace_config(self, client, organization, in_tempdir, created_entities):
         model_name = _utils.generate_default_name()
         version_name = _utils.generate_default_name()
 
@@ -201,10 +201,10 @@ class TestCreate:
 
         client = Client()
         model = client.get_registered_model(model_name)
-        created_registered_models.append(model)
+        created_entities.append(model)
         assert model.workspace == organization.name
 
-    def test_create_version_with_custom_modules(self, client, registered_model, created_endpoints):
+    def test_create_version_with_custom_modules(self, client, registered_model, created_entities):
         torch = pytest.importorskip("torch")
         np = pytest.importorskip("numpy")
 
@@ -255,7 +255,7 @@ class TestCreate:
 
             path = _utils.generate_default_name()
             endpoint = client.set_endpoint(path)
-            created_endpoints.append(endpoint)
+            created_entities.append(endpoint)
             endpoint.update(model_version, DirectUpdateStrategy(), wait=True)
 
             test_data = torch.rand((4, 4))
@@ -347,17 +347,17 @@ class TestGet:
 
 
 class TestList:
-    def test_list_model(self, created_registered_models):
+    def test_list_model(self, created_entities):
         client = Client()
         model1 = client.get_or_create_registered_model()
-        created_registered_models.append(model1)
+        created_entities.append(model1)
         label = model1._msg.name + "label1"
         model1.add_label(label)
         model1.add_label("label2")
         model2 = client.get_or_create_registered_model()
-        created_registered_models.append(model2)
+        created_entities.append(model2)
         model = client.get_or_create_registered_model()
-        created_registered_models.append(model)
+        created_entities.append(model)
         model.add_label(label)
         runner = CliRunner()
         result = runner.invoke(
@@ -379,12 +379,12 @@ class TestList:
         assert model.name in result.output
         assert model2.name in result.output
 
-    def test_list_version(self, created_registered_models):
+    def test_list_version(self, created_entities):
         client = Client()
         runner = CliRunner()
 
         model1 = client.get_or_create_registered_model()
-        created_registered_models.append(model1)
+        created_entities.append(model1)
         version1_name = "version1"
         version2_name = "version2"
         model1.get_or_create_version(version1_name)
@@ -401,7 +401,7 @@ class TestList:
 
         version2.add_label(label)
         model2 = client.get_or_create_registered_model()
-        created_registered_models.append(model2)
+        created_entities.append(model2)
         version2_1_name = "version2_1"
         version2_2_name = "version2_2"
         version21 = model2.get_or_create_version(version2_1_name)

--- a/client/verta/tests/test_dataset_versioning/test_dataset.py
+++ b/client/verta/tests/test_dataset_versioning/test_dataset.py
@@ -7,11 +7,11 @@ import verta
 
 
 class TestMetadata:
-    def test_description(self, client, created_datasets, strs):
+    def test_description(self, client, created_entities, strs):
         first_desc, second_desc = strs[:2]
 
         dataset = client.create_dataset(desc=first_desc)
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
         assert dataset.get_description() == first_desc
 
         dataset.set_description(second_desc)
@@ -19,11 +19,11 @@ class TestMetadata:
 
         assert client.get_dataset(id=dataset.id).get_description() == second_desc
 
-    def test_tags(self, client, created_datasets, strs):
+    def test_tags(self, client, created_entities, strs):
         tag1, tag2, tag3, tag4 = strs[:4]
 
         dataset = client.create_dataset(tags=[tag1])
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
         assert set(dataset.get_tags()) == {tag1}
 
         dataset.add_tag(tag2)
@@ -38,7 +38,7 @@ class TestMetadata:
 
         assert set(client.get_dataset(id=dataset.id).get_tags()) == {tag1, tag2, tag4}
 
-    def test_attributes(self, client, created_datasets):
+    def test_attributes(self, client, created_entities):
         Attr = collections.namedtuple('Attr', ['key', 'value'])
         attr1 = Attr('key1', {'a': 1})
         attr2 = Attr('key2', ['a', 1])
@@ -46,7 +46,7 @@ class TestMetadata:
         attr4 = Attr('key4', 1)
 
         dataset = client.create_dataset(attrs=dict([attr1]))
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
         assert dataset.get_attributes() == dict([attr1])
 
         dataset.add_attribute(*attr2)
@@ -71,29 +71,29 @@ class TestMetadata:
 
 
 class TestCreateGet:
-    def test_create(self, client, created_datasets):
+    def test_create(self, client, created_entities):
         dataset = client.set_dataset()
         assert dataset
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
 
         name = verta._internal_utils._utils.generate_default_name()
         dataset = client.create_dataset(name)
         assert dataset
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
 
         with pytest.raises(requests.HTTPError, match="already exists"):
             assert client.create_dataset(name)
         with pytest.warns(UserWarning, match="already exists"):
             client.set_dataset(name=dataset.name, time_created=123)
 
-    def test_get(self, client, created_datasets):
+    def test_get(self, client, created_entities):
         name = verta._internal_utils._utils.generate_default_name()
 
         with pytest.raises(ValueError):
             client.get_dataset(name)
 
         dataset = client.set_dataset(name)
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
 
         assert dataset.id == client.get_dataset(dataset.name).id
         assert dataset.id == client.get_dataset(id=dataset.id).id
@@ -101,7 +101,7 @@ class TestCreateGet:
         # Deleting non-existing key:
         dataset.del_attribute("non-existing")
 
-    def test_find(self, client, created_datasets, strs):
+    def test_find(self, client, created_entities, strs):
         name1, name2, name3, name4, tag1, tag2 = (
             s + str(verta._internal_utils._utils.now())
             for s in strs[:6]
@@ -111,7 +111,7 @@ class TestCreateGet:
         dataset2 = client.create_dataset(name2, tags=[tag1])
         dataset3 = client.create_dataset(name3, tags=[tag2])
         dataset4 = client.create_dataset(name4, tags=[tag2])
-        created_datasets.extend([dataset1, dataset2, dataset3, dataset4])
+        created_entities.extend([dataset1, dataset2, dataset3, dataset4])
 
         datasets = client.datasets.find("name == {}".format(name3))
         assert len(datasets) == 1
@@ -121,11 +121,11 @@ class TestCreateGet:
         assert len(datasets) == 2
         assert set(dataset.id for dataset in datasets) == {dataset1.id, dataset2.id}
 
-    def test_repr(self, client, created_datasets):
+    def test_repr(self, client, created_entities):
         description = "this is a cool dataset"
         tags = [u"tag1", u"tag2"]
         dataset = client.set_dataset(desc=description, tags=tags)
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
 
         str_repr = repr(dataset)
 

--- a/client/verta/tests/test_dataset_versioning/test_dataset_version.py
+++ b/client/verta/tests/test_dataset_versioning/test_dataset_version.py
@@ -8,10 +8,10 @@ from verta.dataset import Path, S3
 
 
 class TestMetadata:  # essentially copied from test_dataset.py
-    def test_description(self, client, created_datasets, strs):
+    def test_description(self, client, created_entities, strs):
         first_desc, second_desc = strs[:2]
         dataset = client.create_dataset()
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
 
         version = dataset.create_version(Path("conftest.py"), desc=first_desc)
         assert version.get_description() == first_desc
@@ -21,10 +21,10 @@ class TestMetadata:  # essentially copied from test_dataset.py
 
         assert dataset.get_version(id=version.id).get_description() == second_desc
 
-    def test_tags(self, client, created_datasets, strs):
+    def test_tags(self, client, created_entities, strs):
         tag1, tag2, tag3, tag4 = strs[:4]
         dataset = client.create_dataset()
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
 
         version = dataset.create_version(Path("conftest.py"), tags=[tag1])
         assert set(version.get_tags()) == {tag1}
@@ -41,14 +41,14 @@ class TestMetadata:  # essentially copied from test_dataset.py
 
         assert set(dataset.get_version(id=version.id).get_tags()) == {tag1, tag2, tag4}
 
-    def test_attributes(self, client, created_datasets):
+    def test_attributes(self, client, created_entities):
         Attr = collections.namedtuple('Attr', ['key', 'value'])
         attr1 = Attr('key1', {'a': 1})
         attr2 = Attr('key2', ['a', 1])
         attr3 = Attr('key3', 'a')
         attr4 = Attr('key4', 1)
         dataset = client.create_dataset()
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
 
         version = dataset.create_version(Path("conftest.py"), attrs=dict([attr1]))
         assert version.get_attributes() == dict([attr1])
@@ -73,9 +73,9 @@ class TestMetadata:  # essentially copied from test_dataset.py
         dataset.add_attribute(attr1.key, new_val)
         assert dataset.get_attribute(attr1.key) == new_val
 
-    def test_dataset_and_parent_ids(self, client, created_datasets, with_boto3):
+    def test_dataset_and_parent_ids(self, client, created_entities, with_boto3):
         dataset = client.create_dataset()
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
 
         version1 = dataset.create_version(Path("conftest.py"))
         version2 = dataset.create_version(S3("s3://verta-starter/census-train.csv"))
@@ -85,10 +85,10 @@ class TestMetadata:  # essentially copied from test_dataset.py
 
 
 class TestCreateGet:
-    def test_create_get_path(self, client, created_datasets):
+    def test_create_get_path(self, client, created_entities):
         name = verta._internal_utils._utils.generate_default_name()
         dataset = client.set_dataset(name)
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
         dataset_version = dataset.create_version(Path(["modelapi_hypothesis/"]))
         dataset_version2 = dataset.create_version(Path(["modelapi_hypothesis/api_generator.py"]))
 
@@ -96,10 +96,10 @@ class TestCreateGet:
         assert dataset_version2.id == client.get_dataset_version(id=dataset_version2.id).id
         assert dataset_version2.id == dataset.get_latest_version().id
 
-    def test_get_latest_printing(self, client, created_datasets, capsys):
+    def test_get_latest_printing(self, client, created_entities, capsys):
         name = verta._internal_utils._utils.generate_default_name()
         dataset = client.set_dataset(name)
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
 
         dataset_version = dataset.create_version(Path(["modelapi_hypothesis/"]))
         dataset.get_latest_version()
@@ -107,20 +107,20 @@ class TestCreateGet:
         captured = capsys.readouterr()
         assert "got existing dataset version: {}".format(dataset_version.id) in captured.out
 
-    def test_create_get_s3(self, client, created_datasets, with_boto3):
+    def test_create_get_s3(self, client, created_entities, with_boto3):
         pytest.importorskip("boto3")
 
         name = verta._internal_utils._utils.generate_default_name()
         dataset = client.set_dataset(name)
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
         dataset_version = dataset.create_version(S3(["s3://verta-starter/", "s3://verta-starter/census-test.csv"]))
 
         assert dataset_version.id == dataset.get_version(id=dataset_version.id).id
 
-    def test_find(self, client, created_datasets, strs):  # essentially copied from test_dataset.py
+    def test_find(self, client, created_entities, strs):  # essentially copied from test_dataset.py
         tag1, tag2, tag3 = strs[:3]
         dataset = client.create_dataset()
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
 
         version1 = dataset.create_version(Path("conftest.py"), tags=[tag1])
         version2 = dataset.create_version(Path("conftest.py"), tags=[tag1])
@@ -139,11 +139,11 @@ class TestCreateGet:
         assert len(versions) == 1
         assert set(version.id for version in versions) == {version4.id}
 
-    def test_repr(self, client, created_datasets):  # essentially copied from test_dataset.py
+    def test_repr(self, client, created_entities):  # essentially copied from test_dataset.py
         description = "this is a cool version"
         tags = [u"tag1", u"tag2"]
         dataset = client.create_dataset()
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
         version = dataset.create_version(Path("conftest.py"), desc=description, tags=tags)
 
         str_repr = repr(version)
@@ -162,7 +162,7 @@ class TestCreateGet:
 
 
 class TestLogging:
-    def test_log_get(self, client, experiment_run, created_datasets, strs, with_boto3):
+    def test_log_get(self, client, experiment_run, created_entities, strs, with_boto3):
         """Tests ExperimentRun.log_dataset_version() and ExperimentRun.get_dataset_version()."""
         key1, key2 = strs[:2]
         dataset = client.create_dataset()
@@ -183,14 +183,14 @@ class TestLogging:
 
 @pytest.mark.usefixtures("in_tempdir")
 class TestManagedVersioning:
-    def test_path(self, client, created_datasets):
+    def test_path(self, client, created_entities):
         filename = "tiny1.bin"
         FILE_CONTENTS = os.urandom(2**16)
         with open(filename, 'wb') as f:
             f.write(FILE_CONTENTS)
 
         dataset = client.create_dataset()
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
 
         content = Path(filename, enable_mdb_versioning=True)
         version = dataset.create_version(content)
@@ -199,7 +199,7 @@ class TestManagedVersioning:
         with open(downloaded_filename, 'rb') as f:
             assert f.read() == FILE_CONTENTS
 
-    def test_s3(self, client, created_datasets):
+    def test_s3(self, client, created_entities):
         s3 = pytest.importorskip("boto3").client('s3')
 
         filename = "tiny1.bin"
@@ -214,7 +214,7 @@ class TestManagedVersioning:
         os.remove(filename)
 
         dataset = client.create_dataset()
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
 
         content = S3(s3_key, enable_mdb_versioning=True)
         version = dataset.create_version(content)

--- a/client/verta/tests/test_datasets.py
+++ b/client/verta/tests/test_datasets.py
@@ -54,16 +54,16 @@ def bq_location():
 
 
 class TestBaseDatasets:
-    def test_creation_from_scratch(self, client, created_datasets):
+    def test_creation_from_scratch(self, client, created_entities):
         dataset = Dataset(client._conn, client._conf,
                           dataset_type=_DatasetService.DatasetTypeEnum.PATH)
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
         assert dataset.id
 
-    def test_creation_by_id(self, client, created_datasets):
+    def test_creation_by_id(self, client, created_entities):
         dataset = Dataset(client._conn, client._conf,
                           dataset_type=_DatasetService.DatasetTypeEnum.PATH)
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
         assert dataset.id
 
         same_dataset = Dataset(client._conn, client._conf,
@@ -73,10 +73,10 @@ class TestBaseDatasets:
 
 class TestBaseDatasetVersions:
     @pytest.mark.skip(reason="direct instantiation of info-less DatasetVersion not supported by backend")
-    def test_creation_from_scratch(self, client, created_datasets):
+    def test_creation_from_scratch(self, client, created_entities):
         dataset = Dataset(client._conn, client._conf,
                           dataset_type=_DatasetService.DatasetTypeEnum.PATH)
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
         version = DatasetVersion(client._conn, client._conf,
                                  dataset_id=dataset.id,
                                  dataset_version_info=_DatasetVersionService.PathDatasetVersionInfo(),
@@ -84,10 +84,10 @@ class TestBaseDatasetVersions:
         assert version.id
 
     @pytest.mark.skip(reason="direct instantiation of info-less DatasetVersion not supported by backend")
-    def test_creation_by_id(self, client, created_datasets):
+    def test_creation_by_id(self, client, created_entities):
         dataset = Dataset(client._conn, client._conf,
                           dataset_type=_DatasetService.DatasetTypeEnum.PATH)
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
         version = DatasetVersion(client._conn, client._conf,
                                  dataset_id=dataset.id,
                                  dataset_version_info=_DatasetVersionService.PathDatasetVersionInfo(),
@@ -100,9 +100,9 @@ class TestBaseDatasetVersions:
 
     @pytest.mark.parametrize("tags", [TAG, [TAG]])
     @pytest.mark.skip(reason="api no longer  supported by backend")
-    def test_tags_is_list_of_str(self, client, created_datasets, tags):
+    def test_tags_is_list_of_str(self, client, created_entities, tags):
         dataset = client.set_dataset(tags=tags)
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
         version = dataset.create_version("conftest.py", tags=tags)
 
         endpoint = "{}://{}/api/v1/modeldb/dataset-version/getDatasetVersionTags".format(
@@ -125,16 +125,16 @@ class TestRawDatasetVersions:
 
 
 class TestPathDatasets:
-    def test_creation_from_scratch(self, client, created_datasets):
+    def test_creation_from_scratch(self, client, created_entities):
         dataset = Dataset(client._conn, client._conf,
                           dataset_type=_DatasetService.DatasetTypeEnum.PATH)
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
         assert dataset.id
 
-    def test_creation_by_id(self, client, created_datasets):
+    def test_creation_by_id(self, client, created_entities):
         dataset = Dataset(client._conn, client._conf,
                           dataset_type=_DatasetService.DatasetTypeEnum.PATH)
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
         assert dataset.id
 
         same_dataset = Dataset(client._conn, client._conf,
@@ -143,25 +143,25 @@ class TestPathDatasets:
 
 
 class TestClientDatasetFunctions:
-    def test_creation_from_scratch_client_api(self, client, created_datasets):
+    def test_creation_from_scratch_client_api(self, client, created_entities):
         dataset = client.set_dataset(type="s3")
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
         assert dataset.id
         with pytest.warns(UserWarning, match='.*already exists.*'):
             client.set_dataset(name=dataset.name, desc="new description")
 
-    def test_creation_by_id_client_api(self, client, created_datasets):
+    def test_creation_by_id_client_api(self, client, created_entities):
         dataset = client.set_dataset(type="s3")
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
         assert dataset.id
 
         same_dataset = client.set_dataset(id=dataset.id)
         assert dataset.id == same_dataset.id
         assert dataset.name == same_dataset.name
 
-    def test_get_dataset_client_api(self, client, created_datasets):
+    def test_get_dataset_client_api(self, client, created_entities):
         dataset = client.set_dataset(type="s3")
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
         assert dataset.id
 
         same_dataset = client.get_dataset(id=dataset.id)
@@ -172,30 +172,30 @@ class TestClientDatasetFunctions:
         assert dataset.id == same_dataset.id
         assert dataset.name == same_dataset.name
 
-    def test_find_datasets_by_fuzzy_name(self, client, created_datasets):
+    def test_find_datasets_by_fuzzy_name(self, client, created_entities):
         now = str(_utils.now())
-        created_datasets.append(client.set_dataset(now+" appl"))
-        created_datasets.append(client.set_dataset(now+" Appl"))
-        created_datasets.append(client.set_dataset(now+" Apple"))
+        created_entities.append(client.set_dataset(now+" appl"))
+        created_entities.append(client.set_dataset(now+" Appl"))
+        created_entities.append(client.set_dataset(now+" Apple"))
 
         datasets = client.find_datasets(name=now+" Appl")
         assert len(datasets) == 3
 
     @pytest.mark.skip("See #1285")
-    def test_find_datasets_client_api(self, client, created_datasets):
+    def test_find_datasets_client_api(self, client, created_entities):
         tags = ["test1a-{}".format(_utils.now()), "test1b-{}".format(_utils.now())]
         dataset1 = client.set_dataset(type="big query", tags=tags)
-        created_datasets.append(dataset1)
+        created_entities.append(dataset1)
         assert dataset1.id
 
         single_tag = ["test2-{}".format(_utils.now())]
         dataset2 = client.set_dataset(type="s3", tags=single_tag)
-        created_datasets.append(dataset2)
+        created_entities.append(dataset2)
         assert dataset2.id
 
         # TODO: update once RAW is supported
         # dataset3 = client.set_dataset(type="raw")
-        # created_datasets.append(dataset3)
+        # created_entities.append(dataset3)
         # assert dataset3._dataset_type == _DatasetService.DatasetTypeEnum.RAW
         # assert dataset3.id
 
@@ -237,16 +237,16 @@ class TestClientDatasetFunctions:
 
 
 class TestClientDatasetVersionFunctions:
-    def test_creation_from_scratch(self, client, created_datasets):
+    def test_creation_from_scratch(self, client, created_entities):
         dataset = client.set_dataset(type="local")
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
 
         version = dataset.create_version(__file__)
         assert version.id
 
-    def test_creation_by_id(self, client, created_datasets):
+    def test_creation_by_id(self, client, created_entities):
         dataset = client.set_dataset(type="local")
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
 
         version = dataset.create_version(__file__)
         assert version.id
@@ -254,9 +254,9 @@ class TestClientDatasetVersionFunctions:
         same_version = client.get_dataset_version(id=version.id)
         assert version.id == same_version.id
 
-    def test_get_versions(self, client, created_datasets):
+    def test_get_versions(self, client, created_entities):
         dataset = client.set_dataset(type="local")
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
 
         version1 = dataset.create_version(path=__file__)
         assert version1.id
@@ -273,9 +273,9 @@ class TestClientDatasetVersionFunctions:
         version = dataset.get_latest_version(ascending=True)
         assert version.id == version1.id
 
-    def test_get_latest_printing(self, client, created_datasets, capsys):
+    def test_get_latest_printing(self, client, created_entities, capsys):
         dataset = client.set_dataset(type="local")
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
 
         version = dataset.create_version(path=__file__)
         dataset.get_latest_version(ascending=True)
@@ -283,17 +283,17 @@ class TestClientDatasetVersionFunctions:
         captured = capsys.readouterr()
         assert "got existing dataset version: {}".format(version.id) in captured.out
 
-    def test_dataset_version_info(self, client, created_datasets):
+    def test_dataset_version_info(self, client, created_entities):
         botocore = pytest.importorskip("botocore")
         try:
             s3_dataset = client.set_dataset(type="s3")
-            created_datasets.append(s3_dataset)
+            created_entities.append(s3_dataset)
             s3_version = s3_dataset.create_version("verta-starter", key="census-train.csv")
         except botocore.exceptions.ClientError:
             pytest.skip("insufficient AWS credentials")
 
         local_dataset = client.set_dataset(type="local")
-        created_datasets.append(local_dataset)
+        created_entities.append(local_dataset)
         local_version = local_dataset.create_version(__file__)
 
         for retrieved, version in [(s3_dataset.get_latest_version(), s3_version),
@@ -302,10 +302,10 @@ class TestClientDatasetVersionFunctions:
             assert retrieved.dataset_version_info == version.dataset_version_info
 
     @pytest.mark.skip(reason="functionality removed")
-    def test_reincarnation(self, client, created_datasets):
+    def test_reincarnation(self, client, created_entities):
         """Consecutive identical versions are assigned the same ID."""
         dataset = client.set_dataset(type="local")
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
 
         version1 = dataset.create_version(path=__file__)
         version2 = dataset.create_version(path=__file__)
@@ -333,13 +333,13 @@ class TestBasePath:
         assert dataset_version.dataset_version.path_dataset_version_info.base_path == base_path
         assert dataset_version.dataset_version_info.base_path == base_path
 
-    def test_s3_bucket(self, client, created_datasets):
+    def test_s3_bucket(self, client, created_entities):
         bucket_name = "verta-starter"
 
         botocore = pytest.importorskip("botocore")
         try:
             dataset = client.set_dataset(type="s3")
-            created_datasets.append(dataset)
+            created_entities.append(dataset)
             version = dataset.create_version(bucket_name)
         except botocore.exceptions.ClientError:
             pytest.skip("insufficient AWS credentials")
@@ -350,14 +350,14 @@ class TestBasePath:
         self.assert_base_path(version, bucket_name)
         self.assert_base_path(retrieved, bucket_name)
 
-    def test_s3_obj(self, client, created_datasets):
+    def test_s3_obj(self, client, created_entities):
         bucket_name = "verta-starter"
         obj_name = "census-train.csv"
 
         botocore = pytest.importorskip("botocore")
         try:
             dataset = client.set_dataset(type="s3")
-            created_datasets.append(dataset)
+            created_entities.append(dataset)
             version = dataset.create_version(bucket_name, obj_name)
         except botocore.exceptions.ClientError:
             pytest.skip("insufficient AWS credentials")
@@ -369,11 +369,11 @@ class TestBasePath:
         self.assert_base_path(version, base_path)
         self.assert_base_path(retrieved, base_path)
 
-    def test_local_dir(self, client, created_datasets):
+    def test_local_dir(self, client, created_entities):
         dirpath = "."
 
         dataset = client.set_dataset(type="local")
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
         version = dataset.create_version(dirpath)
 
         retrieved = dataset.get_latest_version()
@@ -383,11 +383,11 @@ class TestBasePath:
         self.assert_base_path(version, base_path)
         self.assert_base_path(retrieved, base_path)
 
-    def test_local_file(self, client, created_datasets):
+    def test_local_file(self, client, created_entities):
         filepath = "conftest.py"
 
         dataset = client.set_dataset(type="local")
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
         version = dataset.create_version(filepath)
 
         retrieved = dataset.get_latest_version()
@@ -400,10 +400,10 @@ class TestBasePath:
 
 class TestPathBasedDatasetVersions:
     @pytest.mark.skip(reason="direct instantiation of info-less DatasetVersion not supported by backend")
-    def test_creation_from_scratch(self, client, created_datasets):
+    def test_creation_from_scratch(self, client, created_entities):
         dataset = Dataset(client._conn, client._conf,
                           dataset_type=_DatasetService.DatasetTypeEnum.PATH)
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
 
         version = DatasetVersion(client._conn, client._conf,
                                  dataset_id=dataset.id,
@@ -412,10 +412,10 @@ class TestPathBasedDatasetVersions:
         assert version.id
 
     @pytest.mark.skip(reason="direct instantiation of info-less DatasetVersion not supported by backend")
-    def test_creation_by_id(self, client, created_datasets):
+    def test_creation_by_id(self, client, created_entities):
         dataset = Dataset(client._conn, client._conf,
                           dataset_type=_DatasetService.DatasetTypeEnum.PATH)
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
 
         version = DatasetVersion(client._conn, client._conf,
                                  dataset_id=dataset.id,
@@ -429,16 +429,16 @@ class TestPathBasedDatasetVersions:
 
 
 class TestQueryDatasets:
-    def test_creation_from_scratch(self, client, created_datasets):
+    def test_creation_from_scratch(self, client, created_entities):
         dataset = Dataset(client._conn, client._conf,
                           dataset_type=_DatasetService.DatasetTypeEnum.DatasetType.QUERY)
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
         assert dataset.id
 
-    def test_creation_by_id(self, client, created_datasets):
+    def test_creation_by_id(self, client, created_entities):
         dataset = Dataset(client._conn, client._conf,
                           dataset_type=_DatasetService.DatasetTypeEnum.DatasetType.QUERY)
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
         assert dataset.id
 
         same_dataset = Dataset(client._conn, client._conf,
@@ -448,10 +448,10 @@ class TestQueryDatasets:
 
 class TestQueryDatasetVersions:
     @pytest.mark.skip(reason="direct instantiation of info-less DatasetVersion not supported by backend")
-    def test_creation_from_scratch(self, client, created_datasets):
+    def test_creation_from_scratch(self, client, created_entities):
         dataset = Dataset(client._conn, client._conf,
                           dataset_type=_DatasetService.DatasetTypeEnum.DatasetType.QUERY)
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
 
         version = DatasetVersion(client._conn, client._conf,
                                  dataset_id=dataset.id,
@@ -460,10 +460,10 @@ class TestQueryDatasetVersions:
         assert version.id
 
     @pytest.mark.skip(reason="direct instantiation of info-less DatasetVersion not supported by backend")
-    def test_creation_by_id(self, client, created_datasets):
+    def test_creation_by_id(self, client, created_entities):
         dataset = Dataset(client._conn, client._conf,
                           dataset_type=_DatasetService.DatasetTypeEnum.QUERY)
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
 
         version = DatasetVersion(client._conn, client._conf,
                                  dataset_id=dataset.id,
@@ -526,21 +526,21 @@ class TestS3DatasetVersionInfo:
 
 
 class TestS3ClientFunctions:
-    def test_s3_dataset_creation(self, client, created_datasets):
+    def test_s3_dataset_creation(self, client, created_entities):
         botocore = pytest.importorskip("botocore")
 
         try:
             dataset = client.set_dataset(type="s3")
-            created_datasets.append(dataset)
+            created_entities.append(dataset)
         except botocore.exceptions.ClientError:
             pytest.skip("insufficient AWS credentials")
 
-    def test_s3_dataset_version_creation(self, client, s3_bucket, created_datasets):
+    def test_s3_dataset_version_creation(self, client, s3_bucket, created_entities):
         botocore = pytest.importorskip("botocore")
 
         try:
             dataset = client.set_dataset(type="s3")
-            created_datasets.append(dataset)
+            created_entities.append(dataset)
             dataset_version = dataset.create_version(s3_bucket)
 
             assert len(dataset_version.dataset_version_info.dataset_part_infos) >= 1
@@ -549,14 +549,14 @@ class TestS3ClientFunctions:
 
 
 class TestFilesystemClientFunctions:
-    def test_filesystem_dataset_creation(self, client, created_datasets):
+    def test_filesystem_dataset_creation(self, client, created_entities):
         dataset = client.set_dataset(type="local")
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
 
-    def test_filesystem_dataset_version_creation(self, client, created_datasets):
+    def test_filesystem_dataset_version_creation(self, client, created_entities):
         dir_name, _ = self.create_dir_with_files(num_files=3)
         dataset = client.set_dataset(type="local")
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
         dataset_version = dataset.create_version(dir_name)
 
         assert len(dataset_version.dataset_version_info.dataset_part_infos) == 3
@@ -576,11 +576,11 @@ class TestFilesystemClientFunctions:
 
 @pytest.mark.skip("dropped support for query datasets, for the time being")
 class TestBigQueryDatasetVersionInfo:
-    def test_big_query_dataset(self, client, created_datasets):
+    def test_big_query_dataset(self, client, created_entities):
         dataset = client.set_dataset(type="big query")
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
 
-    def test_big_query_dataset_version_creation(self, client, bq_query, bq_location, created_datasets):
+    def test_big_query_dataset_version_creation(self, client, bq_query, bq_location, created_entities):
         google = pytest.importorskip("google")
         bigquery = pytest.importorskip("google.cloud.bigquery")
 
@@ -591,7 +591,7 @@ class TestBigQueryDatasetVersionInfo:
                 location=bq_location,
             )
             dataset = client.set_dataset(type="big query")
-            created_datasets.append(dataset)
+            created_entities.append(dataset)
             dataset_version = dataset.create_version(job_id=query_job.job_id, location=bq_location)
 
             assert dataset_version.dataset_version_info.query == bq_query
@@ -601,13 +601,13 @@ class TestBigQueryDatasetVersionInfo:
 
 @pytest.mark.skip("dropped support for query datasets, for the time being")
 class TestRDBMSDatasetVersionInfo:
-    def test_rdbms_dataset(self, client, created_datasets):
+    def test_rdbms_dataset(self, client, created_entities):
         dataset = client.set_dataset(type="postgres")
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
 
-    def test_rdbms_version_creation(self, client, created_datasets):
+    def test_rdbms_version_creation(self, client, created_entities):
         dataset = client.set_dataset(type="postgres")
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
         dataset_version = dataset.create_version(query="SELECT * FROM ner-table",
                                                  db_connection_str="localhost:6543",
                                                  num_records=100)
@@ -618,9 +618,9 @@ class TestRDBMSDatasetVersionInfo:
 
 @pytest.mark.skip("Backend needs to be fixed to preserve `base_path`")
 class TestLogDatasetVersion:
-    def test_log_dataset_version(self, client, created_datasets, experiment_run):
+    def test_log_dataset_version(self, client, created_entities, experiment_run):
         dataset = client.set_dataset(type="local")
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
 
         dataset_version = dataset.create_version(__file__)
         experiment_run.log_dataset_version('train', dataset_version)
@@ -630,9 +630,9 @@ class TestLogDatasetVersion:
         assert path.endswith(__file__)
 
     @pytest.mark.not_oss
-    def test_log_dataset_version_diff_workspaces(self, client, organization, created_datasets, experiment_run):
+    def test_log_dataset_version_diff_workspaces(self, client, organization, created_entities, experiment_run):
         dataset = client.set_dataset(type="local", workspace=organization.name)
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
 
         dataset_version = dataset.create_version(__file__)
         experiment_run.log_dataset_version('train', dataset_version)
@@ -640,9 +640,9 @@ class TestLogDatasetVersion:
         retrieved_dataset_version = experiment_run.get_dataset_version('train')
         assert retrieved_dataset_version.id == dataset_version.id
 
-    def test_log_dataset_version_diff_workspaces_no_access_error(self, client_2, created_datasets, experiment_run):
+    def test_log_dataset_version_diff_workspaces_no_access_error(self, client_2, created_entities, experiment_run):
         dataset = client_2.set_dataset(type="local")
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
 
         dataset_version = dataset.create_version(__file__)
 
@@ -654,9 +654,9 @@ class TestLogDatasetVersion:
         assert "Access Denied" in excinfo_value
 
 
-    def test_overwrite(self, client, created_datasets, experiment_run, s3_bucket):
+    def test_overwrite(self, client, created_entities, experiment_run, s3_bucket):
         dataset = client.set_dataset(type="local")
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
 
         dataset_version = dataset.create_version(__file__)
         experiment_run.log_dataset_version('train', dataset_version)

--- a/client/verta/tests/test_endpoint/test_endpoint.py
+++ b/client/verta/tests/test_endpoint/test_endpoint.py
@@ -24,11 +24,11 @@ pytestmark = pytest.mark.not_oss  # skip if run in oss setup. Applied to entire 
 
 
 class TestEndpoint:
-    def test_create(self, client, created_endpoints):
+    def test_create(self, client, created_entities):
         name = _utils.generate_default_name()
         endpoint = client.set_endpoint(name)
         assert endpoint
-        created_endpoints.append(endpoint)
+        created_entities.append(endpoint)
         name = verta._internal_utils._utils.generate_default_name()
         endpoint = client.create_endpoint(name)
         assert endpoint
@@ -40,44 +40,44 @@ class TestEndpoint:
         with pytest.warns(UserWarning, match='.*already exists.*'):
             client.set_endpoint(path=endpoint.path, description="new description")
 
-    def test_get(self, client, created_endpoints):
+    def test_get(self, client, created_entities):
         name = _utils.generate_default_name()
 
         with pytest.raises(ValueError):
             client.get_endpoint(name)
 
         endpoint = client.set_endpoint(name)
-        created_endpoints.append(endpoint)
+        created_entities.append(endpoint)
 
         assert endpoint.id == client.get_endpoint(endpoint.path).id
         assert endpoint.id == client.get_endpoint(id=endpoint.id).id
 
-    def test_get_by_name(self, client, created_endpoints):
+    def test_get_by_name(self, client, created_entities):
         path = _utils.generate_default_name()
         path2 = _utils.generate_default_name()
         endpoint = client.set_endpoint(path)
-        created_endpoints.append(endpoint)
+        created_entities.append(endpoint)
 
         dummy_endpoint = client.set_endpoint(path2)  # in case get erroneously fetches latest
-        created_endpoints.append(dummy_endpoint)
+        created_entities.append(dummy_endpoint)
 
         assert endpoint.id == client.set_endpoint(endpoint.path).id
 
-    def test_get_by_id(self, client, created_endpoints):
+    def test_get_by_id(self, client, created_entities):
         path = _utils.generate_default_name()
         path2 = _utils.generate_default_name()
         endpoint = client.set_endpoint(path)
-        created_endpoints.append(endpoint)
+        created_entities.append(endpoint)
 
         dummy_endpoint = client.set_endpoint(path2)  # in case get erroneously fetches latest
-        created_endpoints.append(dummy_endpoint)
+        created_entities.append(dummy_endpoint)
 
         assert endpoint.id == client.set_endpoint(id=endpoint.id).id
 
-    def test_list(self, client, organization, created_endpoints):
+    def test_list(self, client, organization, created_entities):
         name = _utils.generate_default_name()
         endpoint = client.set_endpoint(name, workspace=organization.name)
-        created_endpoints.append(endpoint)
+        created_entities.append(endpoint)
 
         endpoints = client.endpoints.with_workspace(organization.name)
         assert len(endpoints) >= 1
@@ -88,10 +88,10 @@ class TestEndpoint:
                 has_new_id = True
         assert has_new_id
 
-    def test_get_status(self, client, created_endpoints):
+    def test_get_status(self, client, created_entities):
         path = verta._internal_utils._utils.generate_default_name()
         endpoint = client.set_endpoint(path)
-        created_endpoints.append(endpoint)
+        created_entities.append(endpoint)
         status = endpoint.get_status()
 
         # Check that some fields exist:
@@ -99,13 +99,13 @@ class TestEndpoint:
         assert status["date_created"]
         assert status["stage_id"]
 
-    def test_repr(self, client, created_endpoints, experiment_run, model_for_deployment):
+    def test_repr(self, client, created_entities, experiment_run, model_for_deployment):
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
         experiment_run.log_requirements(['scikit-learn'])
 
         path = verta._internal_utils._utils.generate_default_name()
         endpoint = client.set_endpoint(path)
-        created_endpoints.append(endpoint)
+        created_entities.append(endpoint)
         str_repr = repr(endpoint)
 
         assert "path: {}".format(endpoint.path) in str_repr
@@ -162,13 +162,13 @@ class TestEndpoint:
         }
         assert retrieved_env_vars == env_vars
 
-    def test_direct_update(self, client, created_endpoints, experiment_run, model_for_deployment):
+    def test_direct_update(self, client, created_entities, experiment_run, model_for_deployment):
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
         experiment_run.log_requirements(['scikit-learn'])
 
         path = verta._internal_utils._utils.generate_default_name()
         endpoint = client.set_endpoint(path)
-        created_endpoints.append(endpoint)
+        created_entities.append(endpoint)
 
         original_status = endpoint.get_status()
         original_build_ids = get_build_ids(original_status)
@@ -178,14 +178,14 @@ class TestEndpoint:
         new_build_ids = get_build_ids(updated_status)
         assert len(new_build_ids) - len(new_build_ids.intersection(original_build_ids)) > 0
 
-    def test_update_wait(self, client, created_endpoints, experiment_run, model_version, model_for_deployment):
+    def test_update_wait(self, client, created_entities, experiment_run, model_version, model_for_deployment):
         """This tests endpoint.update(..., wait=True), including the case of build error"""
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
         experiment_run.log_requirements(['scikit-learn'])
 
         path = verta._internal_utils._utils.generate_default_name()
         endpoint = client.set_endpoint(path)
-        created_endpoints.append(endpoint)
+        created_entities.append(endpoint)
 
         status = endpoint.update(experiment_run, DirectUpdateStrategy(), True)
 
@@ -200,13 +200,13 @@ class TestEndpoint:
         excinfo_value = str(excinfo.value).strip()
         assert "Could not find a version that satisfies the requirement blahblahblah==3.6.0" in excinfo_value
 
-    def test_canary_update(self, client, created_endpoints, experiment_run, model_for_deployment):
+    def test_canary_update(self, client, created_entities, experiment_run, model_for_deployment):
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
         experiment_run.log_requirements(['scikit-learn'])
 
         path = verta._internal_utils._utils.generate_default_name()
         endpoint = client.set_endpoint(path)
-        created_endpoints.append(endpoint)
+        created_entities.append(endpoint)
 
         original_status = endpoint.get_status()
         original_build_ids = get_build_ids(original_status)
@@ -225,14 +225,14 @@ class TestEndpoint:
         new_build_ids = get_build_ids(updated_status)
         assert len(new_build_ids) - len(new_build_ids.intersection(original_build_ids)) > 0
 
-    def test_update_from_json_config(self, client, in_tempdir, created_endpoints, experiment_run, model_for_deployment):
+    def test_update_from_json_config(self, client, in_tempdir, created_entities, experiment_run, model_for_deployment):
         json = pytest.importorskip("json")
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
         experiment_run.log_requirements(['scikit-learn'])
 
         path = verta._internal_utils._utils.generate_default_name()
         endpoint = client.set_endpoint(path)
-        created_endpoints.append(endpoint)
+        created_entities.append(endpoint)
 
         original_status = endpoint.get_status()
         original_build_ids = get_build_ids(original_status)
@@ -267,14 +267,14 @@ class TestEndpoint:
         new_build_ids = get_build_ids(updated_status)
         assert len(new_build_ids) - len(new_build_ids.intersection(original_build_ids)) > 0
 
-    def test_update_from_yaml_config(self, client, in_tempdir, created_endpoints, experiment_run, model_for_deployment):
+    def test_update_from_yaml_config(self, client, in_tempdir, created_entities, experiment_run, model_for_deployment):
         yaml = pytest.importorskip("yaml")
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
         experiment_run.log_requirements(['scikit-learn'])
 
         path = verta._internal_utils._utils.generate_default_name()
         endpoint = client.set_endpoint(path)
-        created_endpoints.append(endpoint)
+        created_entities.append(endpoint)
 
         original_status = endpoint.get_status()
         original_build_ids = get_build_ids(original_status)
@@ -309,13 +309,13 @@ class TestEndpoint:
         new_build_ids = get_build_ids(updated_status)
         assert len(new_build_ids) - len(new_build_ids.intersection(original_build_ids)) > 0
 
-    def test_update_with_parameters(self, client, created_endpoints, experiment_run, model_for_deployment):
+    def test_update_with_parameters(self, client, created_entities, experiment_run, model_for_deployment):
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
         experiment_run.log_requirements(['scikit-learn'])
 
         path = verta._internal_utils._utils.generate_default_name()
         endpoint = client.set_endpoint(path)
-        created_endpoints.append(endpoint)
+        created_entities.append(endpoint)
 
         original_status = endpoint.get_status()
         original_build_ids = get_build_ids(original_status)
@@ -330,10 +330,10 @@ class TestEndpoint:
         new_build_ids = get_build_ids(updated_status)
         assert len(new_build_ids) - len(new_build_ids.intersection(original_build_ids)) > 0
 
-    def test_get_access_token(self, client, created_endpoints):
+    def test_get_access_token(self, client, created_entities):
         path = verta._internal_utils._utils.generate_default_name()
         endpoint = client.set_endpoint(path)
-        created_endpoints.append(endpoint)
+        created_entities.append(endpoint)
         token = endpoint.get_access_token()
 
         assert token is None
@@ -360,7 +360,7 @@ class TestEndpoint:
         }
 
 
-    def test_get_deployed_model(self, client, experiment_run, model_version, model_for_deployment, created_endpoints):
+    def test_get_deployed_model(self, client, experiment_run, model_version, model_for_deployment, created_entities):
         """
         Verifies prediction for a finished deployment, as well as for an endpoint in the middle of being updated.
         """
@@ -375,7 +375,7 @@ class TestEndpoint:
 
         path = verta._internal_utils._utils.generate_default_name()
         endpoint = client.set_endpoint(path)
-        created_endpoints.append(endpoint)
+        created_entities.append(endpoint)
         endpoint.update(experiment_run, DirectUpdateStrategy(), wait=True)
 
         token = verta._internal_utils._utils.generate_default_name()
@@ -398,7 +398,7 @@ class TestEndpoint:
         endpoint.update(model_version, DirectUpdateStrategy(), wait=False)
         endpoint.get_deployed_model().predict([x])  # should succeed, because the endpoint can still service requests
 
-    def test_update_from_model_version(self, client, model_version, created_endpoints):
+    def test_update_from_model_version(self, client, model_version, created_entities):
         np = pytest.importorskip("numpy")
         sklearn = pytest.importorskip("sklearn")
         from sklearn.linear_model import LogisticRegression
@@ -412,13 +412,13 @@ class TestEndpoint:
 
         path = verta._internal_utils._utils.generate_default_name()
         endpoint = client.set_endpoint(path)
-        created_endpoints.append(endpoint)
+        created_entities.append(endpoint)
 
         endpoint.update(model_version, DirectUpdateStrategy(), wait=True)
         test_data = np.random.random((4, 12))
         assert np.array_equal(endpoint.get_deployed_model().predict(test_data), classifier.predict(test_data))
 
-    def test_update_from_json_config_model_version(self, client, in_tempdir, created_endpoints, model_version):
+    def test_update_from_json_config_model_version(self, client, in_tempdir, created_entities, model_version):
         np = pytest.importorskip("numpy")
         json = pytest.importorskip("json")
         sklearn = pytest.importorskip("sklearn")
@@ -433,7 +433,7 @@ class TestEndpoint:
 
         path = verta._internal_utils._utils.generate_default_name()
         endpoint = client.set_endpoint(path)
-        created_endpoints.append(endpoint)
+        created_entities.append(endpoint)
 
         original_status = endpoint.get_status()
         original_build_ids = get_build_ids(original_status)
@@ -470,13 +470,13 @@ class TestEndpoint:
         prediction = endpoint.get_deployed_model().predict(test_data)
         assert np.array_equal(prediction, classifier.predict(test_data))
 
-    def test_update_autoscaling(self, client, created_endpoints, experiment_run, model_for_deployment):
+    def test_update_autoscaling(self, client, created_entities, experiment_run, model_for_deployment):
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
         experiment_run.log_requirements(['scikit-learn'])
 
         path = verta._internal_utils._utils.generate_default_name()
         endpoint = client.set_endpoint(path)
-        created_endpoints.append(endpoint)
+        created_entities.append(endpoint)
 
         autoscaling = Autoscaling(min_replicas=1, max_replicas=2, min_scale=0.5, max_scale=2.0)
         autoscaling.add_metric(CpuUtilizationTarget(0.5))
@@ -498,7 +498,7 @@ class TestEndpoint:
             else:
                 assert metric["parameters"][0]["value"] == "0.7"
 
-    def test_update_with_custom_module(self, client, model_version, created_endpoints):
+    def test_update_with_custom_module(self, client, model_version, created_entities):
         torch = pytest.importorskip("torch")
 
         with sys_path_manager() as sys_path:
@@ -518,7 +518,7 @@ class TestEndpoint:
 
             path = verta._internal_utils._utils.generate_default_name()
             endpoint = client.set_endpoint(path)
-            created_endpoints.append(endpoint)
+            created_entities.append(endpoint)
             endpoint.update(model_version, DirectUpdateStrategy(), wait=True)
 
 
@@ -526,7 +526,7 @@ class TestEndpoint:
             prediction = torch.tensor(endpoint.get_deployed_model().predict(test_data.tolist()))
             assert torch.all(classifier(test_data).eq(prediction))
 
-    def test_update_from_json_config_with_params(self, client, in_tempdir, created_endpoints, experiment_run, model_for_deployment):
+    def test_update_from_json_config_with_params(self, client, in_tempdir, created_entities, experiment_run, model_for_deployment):
         yaml = pytest.importorskip("yaml")
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
         experiment_run.log_requirements(['scikit-learn'])
@@ -534,7 +534,7 @@ class TestEndpoint:
 
         path = verta._internal_utils._utils.generate_default_name()
         endpoint = client.set_endpoint(path)
-        created_endpoints.append(endpoint)
+        created_entities.append(endpoint)
 
 
         original_status = endpoint.get_status()
@@ -586,7 +586,7 @@ class TestEndpoint:
         resources_dict = Resources._from_dict(config_dict["resources"])._as_dict()  # config is `cpu`, wire is `cpu_millis`
         assert endpoint.get_update_status()['update_request']['resources'] == resources_dict
 
-    def test_update_twice(self, client, registered_model, created_endpoints):
+    def test_update_twice(self, client, registered_model, created_entities):
         np = pytest.importorskip("numpy")
         json = pytest.importorskip("json")
         sklearn = pytest.importorskip("sklearn")
@@ -608,7 +608,7 @@ class TestEndpoint:
 
         path = verta._internal_utils._utils.generate_default_name()
         endpoint = client.set_endpoint(path)
-        created_endpoints.append(endpoint)
+        created_entities.append(endpoint)
         endpoint.update(model_version, wait=True)
 
         # updating endpoint
@@ -616,18 +616,18 @@ class TestEndpoint:
         test_data = np.random.random((4, 12))
         assert np.array_equal(endpoint.get_deployed_model().predict(test_data), new_classifier.predict(test_data))
 
-    def test_update_from_run_diff_workspace(self, client, organization, created_endpoints, experiment_run, model_for_deployment):
+    def test_update_from_run_diff_workspace(self, client, organization, created_entities, experiment_run, model_for_deployment):
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
         experiment_run.log_requirements(['scikit-learn'])
 
         path = verta._internal_utils._utils.generate_default_name()
         endpoint = client.create_endpoint(path, workspace=organization.name)
-        created_endpoints.append(endpoint)
+        created_entities.append(endpoint)
 
         endpoint.update(experiment_run, DirectUpdateStrategy(), wait=True)
         assert endpoint.workspace != experiment_run.workspace
 
-    def test_update_from_version_diff_workspace(self, client, model_version, organization, created_endpoints):
+    def test_update_from_version_diff_workspace(self, client, model_version, organization, created_entities):
         np = pytest.importorskip("numpy")
         sklearn = pytest.importorskip("sklearn")
         from sklearn.linear_model import LogisticRegression
@@ -641,18 +641,18 @@ class TestEndpoint:
 
         path = verta._internal_utils._utils.generate_default_name()
         endpoint = client.create_endpoint(path, workspace=organization.name)
-        created_endpoints.append(endpoint)
+        created_entities.append(endpoint)
 
         endpoint.update(model_version, DirectUpdateStrategy(), wait=True)
         assert endpoint.workspace != model_version.workspace
 
-    def test_update_from_run_diff_workspace_no_access_error(self, client_2, created_endpoints, experiment_run, model_for_deployment):
+    def test_update_from_run_diff_workspace_no_access_error(self, client_2, created_entities, experiment_run, model_for_deployment):
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
         experiment_run.log_requirements(['scikit-learn'])
 
         path = verta._internal_utils._utils.generate_default_name()
         endpoint = client_2.create_endpoint(path)
-        created_endpoints.append(endpoint)
+        created_entities.append(endpoint)
 
         with pytest.raises(requests.HTTPError) as excinfo:
             endpoint.update(experiment_run, DirectUpdateStrategy(), wait=True)
@@ -661,7 +661,7 @@ class TestEndpoint:
         assert "403" in excinfo_value
         assert "Access Denied" in excinfo_value
 
-    def test_update_from_version_diff_workspace_no_access_error(self, client_2, model_version, created_endpoints):
+    def test_update_from_version_diff_workspace_no_access_error(self, client_2, model_version, created_entities):
         np = pytest.importorskip("numpy")
         sklearn = pytest.importorskip("sklearn")
         from sklearn.linear_model import LogisticRegression
@@ -675,7 +675,7 @@ class TestEndpoint:
 
         path = verta._internal_utils._utils.generate_default_name()
         endpoint = client_2.create_endpoint(path)
-        created_endpoints.append(endpoint)
+        created_entities.append(endpoint)
 
         with pytest.raises(requests.HTTPError) as excinfo:
             endpoint.update(model_version, DirectUpdateStrategy(), wait=True)

--- a/client/verta/tests/test_model_registry/test_model.py
+++ b/client/verta/tests/test_model_registry/test_model.py
@@ -7,15 +7,15 @@ pytestmark = pytest.mark.not_oss  # skip if run in oss setup. Applied to entire 
 
 
 class TestModel:
-    def test_create(self, client, created_registered_models):
+    def test_create(self, client, created_entities):
         registered_model = client.set_registered_model()
         assert registered_model
-        created_registered_models.append(registered_model)
+        created_entities.append(registered_model)
 
         name = verta._internal_utils._utils.generate_default_name()
         registered_model = client.create_registered_model(name)
         assert registered_model
-        created_registered_models.append(registered_model)
+        created_entities.append(registered_model)
         with pytest.raises(requests.HTTPError) as excinfo:
             assert client.create_registered_model(name)
         excinfo_value = str(excinfo.value).strip()
@@ -24,33 +24,33 @@ class TestModel:
         with pytest.warns(UserWarning, match='.*already exists.*'):
             client.set_registered_model(name=registered_model.name, desc="new description")
 
-    def test_get(self, client, created_registered_models):
+    def test_get(self, client, created_entities):
         name = verta._internal_utils._utils.generate_default_name()
 
         with pytest.raises(ValueError):
             client.get_registered_model(name)
 
         registered_model = client.set_registered_model(name)
-        created_registered_models.append(registered_model)
+        created_entities.append(registered_model)
 
         assert registered_model.id == client.get_registered_model(registered_model.name).id
         assert registered_model.id == client.get_registered_model(id=registered_model.id).id
 
-    def test_get_by_name(self, client, created_registered_models):
+    def test_get_by_name(self, client, created_entities):
         registered_model = client.set_registered_model()
-        created_registered_models.append(registered_model)
+        created_entities.append(registered_model)
 
         dummy_model = client.set_registered_model()  # in case get erroneously fetches latest
-        created_registered_models.append(dummy_model)
+        created_entities.append(dummy_model)
 
         assert registered_model.id == client.set_registered_model(registered_model.name).id
 
-    def test_get_by_id(self, client, created_registered_models):
+    def test_get_by_id(self, client, created_entities):
         registered_model = client.set_registered_model()
-        created_registered_models.append(registered_model)
+        created_entities.append(registered_model)
 
         dummy_model = client.set_registered_model()  # in case get erroneously fetches latest
-        created_registered_models.append(dummy_model)
+        created_entities.append(dummy_model)
 
         assert registered_model.id == client.set_registered_model(id=registered_model.id).id
 
@@ -62,10 +62,10 @@ class TestModel:
         assert str(registered_model.id) in repr
         assert str(registered_model.get_labels()) in repr
 
-    def test_find(self, client, created_registered_models):
+    def test_find(self, client, created_entities):
         name = verta._internal_utils._utils.generate_default_name()
         registered_model = client.set_registered_model(name)
-        created_registered_models.append(registered_model)
+        created_entities.append(registered_model)
 
         find = client.registered_models.find(["name == '{}'".format(name)])
         assert len(find) == 1
@@ -75,16 +75,16 @@ class TestModel:
         tag_name = name + "_new_tag"
         registered_models = {name + "1": client.set_registered_model(name + "1", labels=[tag_name, "tag2"]),
                              name + "2": client.set_registered_model(name + "2", labels=[tag_name])}
-        created_registered_models.extend(registered_models.values())
+        created_entities.extend(registered_models.values())
         find = client.registered_models.find(["labels == \"{}\"".format(tag_name)])
         assert len(find) == 2
         for item in find:
             assert item._msg == registered_models[item._msg.name]._msg
 
-    def test_labels(self, client, created_registered_models):
+    def test_labels(self, client, created_entities):
         registered_model = client.set_registered_model(labels=["tag1", "tag2"])
         assert registered_model
-        created_registered_models.append(registered_model)
+        created_entities.append(registered_model)
 
         assert registered_model is not None
         registered_model.add_label("tag3")
@@ -99,9 +99,9 @@ class TestModel:
         registered_model.add_labels(["tag2", "tag4", "tag1", "tag5"]) # some tags already exist
         assert registered_model.get_labels() == ["tag1", "tag2", "tag3", "tag4", "tag5"]
 
-    def test_description(self, client, created_registered_models):
+    def test_description(self, client, created_entities):
         desc = "description"
         registered_model = client.get_or_create_registered_model()
-        created_registered_models.append(registered_model)
+        created_entities.append(registered_model)
         registered_model.set_description(desc)
         assert desc == registered_model.get_description()

--- a/client/verta/tests/test_model_registry/test_model_version.py
+++ b/client/verta/tests/test_model_registry/test_model_version.py
@@ -49,9 +49,9 @@ class TestMDBIntegration:
         assert model_for_deployment['model'].get_params() == model_version.get_model().get_params()
         assert np.array_equal(model_version.get_artifact("some-artifact"), artifact)
 
-    def test_from_run_diff_workspaces(self, client, experiment_run, organization, created_registered_models):
+    def test_from_run_diff_workspaces(self, client, experiment_run, organization, created_entities):
         registered_model = client.create_registered_model(workspace=organization.name)
-        created_registered_models.append(registered_model)
+        created_entities.append(registered_model)
 
         model_version = registered_model.create_version_from_run(
             run_id=experiment_run.id,
@@ -60,9 +60,9 @@ class TestMDBIntegration:
 
         assert model_version.workspace != experiment_run.workspace
 
-    def test_from_run_diff_workspaces_no_access_error(self, experiment_run, client_2, created_registered_models):
+    def test_from_run_diff_workspaces_no_access_error(self, experiment_run, client_2, created_entities):
         registered_model = client_2.create_registered_model()
-        created_registered_models.append(registered_model)
+        created_entities.append(registered_model)
 
         with pytest.raises(requests.HTTPError) as excinfo:
             model_version = registered_model.create_version_from_run(
@@ -90,7 +90,7 @@ class TestModelVersion:
         version = registered_model.set_version(name=name)
 
         assert registered_model.set_version(name=version.name).id == version.id
-        
+
     def test_get_by_name(self, registered_model):
         model_version = registered_model.get_or_create_version(name="my version")
         retrieved_model_version = registered_model.get_version(name=model_version.name)
@@ -125,9 +125,9 @@ class TestModelVersion:
         assert "model" in repr
         assert "coef" in repr
 
-    def test_get_by_client(self, client, created_registered_models):
+    def test_get_by_client(self, client, created_entities):
         registered_model = client.set_registered_model()
-        created_registered_models.append(registered_model)
+        created_entities.append(registered_model)
         model_version = registered_model.get_or_create_version(name="my version")
 
         retrieved_model_version_by_id = client.get_registered_model_version(model_version.id)
@@ -267,9 +267,9 @@ class TestModelVersion:
 
         assert "environment was not previously set" in str(excinfo.value)
 
-    def test_labels(self, client, created_registered_models):
+    def test_labels(self, client, created_entities):
         registered_model = client.set_registered_model()
-        created_registered_models.append(registered_model)
+        created_entities.append(registered_model)
         model_version = registered_model.get_or_create_version(name="my version")
 
         model_version.add_label("tag1")
@@ -286,29 +286,29 @@ class TestModelVersion:
         model_version.add_labels(["tag2", "tag4", "tag1", "tag5"])
         assert model_version.get_labels() == ["tag1", "tag2", "tag3", "tag4", "tag5"]
 
-    def test_description(self, client, created_registered_models):
+    def test_description(self, client, created_entities):
         desc = "description"
         registered_model = client.get_or_create_registered_model()
-        created_registered_models.append(registered_model)
+        created_entities.append(registered_model)
         model_version = registered_model.get_or_create_version(name="my version")
         model_version.set_description(desc)
         assert desc == model_version.get_description()
 
-    def test_list_from_client(self, client, created_registered_models):
+    def test_list_from_client(self, client, created_entities):
         """
         At some point, backend API was unexpectedly changed to require model ID
         in /model_versions/find, which broke client.registered_model_versions.
 
         """
         registered_model = client.create_registered_model()
-        created_registered_models.append(registered_model)
+        created_entities.append(registered_model)
 
         len(client.registered_model_versions)
 
-    def test_find(self, client, created_registered_models):
+    def test_find(self, client, created_entities):
         name = "registered_model_test"
         registered_model = client.set_registered_model()
-        created_registered_models.append(registered_model)
+        created_entities.append(registered_model)
         model_version = registered_model.get_or_create_version(name=name)
 
         find_result = registered_model.versions.find(["version == '{}'".format(name)])

--- a/client/verta/tests/test_organization.py
+++ b/client/verta/tests/test_organization.py
@@ -38,7 +38,7 @@ class TestOrganization:
 
         org.delete()
 
-    def test_create_same_name_diff_workspace(self, client, organization, created_endpoints, created_registered_models, created_datasets):
+    def test_create_same_name_diff_workspace(self, client, organization, created_entities, created_entities, created_entities):
         # creating some entities:
         project_name = _utils.generate_default_name()
         exp_name = _utils.generate_default_name()
@@ -55,13 +55,13 @@ class TestOrganization:
         repository = client.get_or_create_repository(name=repository_name)
 
         dataset = client.create_dataset(dataset_name)
-        created_datasets.append(dataset)
+        created_entities.append(dataset)
         model = client.create_registered_model(name=model_name)
         version = model.create_version(name=version_name)
-        created_registered_models.append(model)
+        created_entities.append(model)
 
         endpoint = client.create_endpoint(path=endpoint_path)
-        created_endpoints.append(endpoint)
+        created_entities.append(endpoint)
 
         # create entities with same name, but different workspace:
         new_model = client.create_registered_model(name=model_name, workspace=organization.name)
@@ -78,10 +78,10 @@ class TestOrganization:
         new_repository = client.get_or_create_repository(name=repository_name, workspace=organization.name)
 
         new_dataset = client.create_dataset(dataset_name, workspace=organization.name)
-        created_datasets.append(new_dataset)
+        created_entities.append(new_dataset)
 
-        # created_endpoints.append(new_endpoint)  TODO: uncomment after VR-6053
-        created_registered_models.append(new_model)
+        # created_entities.append(new_endpoint)  TODO: uncomment after VR-6053
+        created_entities.append(new_model)
 
         assert model.id != new_model.id
         assert version.id != new_version.id


### PR DESCRIPTION
The client tests currently have three distinct fixtures to collect and clean up datasets, registered models, endpoints.
This used to be necessary because deletion used to require directly making DELETE requests.

Now that MDB and registry entities all expose a `delete()` method, these fixtures can be combined into a single `created_entities()` 