### PR TITLE
Fixes downloading more than one artifact from ER details

### DIFF
--- a/webapp/client/src/features/artifactManager/store/actions.ts
+++ b/webapp/client/src/features/artifactManager/store/actions.ts
@@ -61,7 +61,7 @@ const loadArtifactUrl = (
     case 'experiment':
       return ServiceFactory.getExperimentsService()
         .loadArtifactUrl(entityId, artifact)
-        .then(res => {
+        .then((res) => {
           const success = action(loadArtifactUrlActionTypes.SUCCESS, {
             key: artifact.key,
             url: res,
@@ -74,7 +74,7 @@ const loadArtifactUrl = (
           );
           return success;
         })
-        .catch(error => {
+        .catch((error) => {
           const failure = action(
             loadArtifactUrlActionTypes.FAILURE,
             normalizeError(error)
@@ -85,7 +85,7 @@ const loadArtifactUrl = (
     case 'experimentRun':
       return ServiceFactory.getExperimentRunsService()
         .loadArtifactUrl(entityId, artifact)
-        .then(res => {
+        .then((res) => {
           const success = action(loadArtifactUrlActionTypes.SUCCESS, {
             key: artifact.key,
             url: res,
@@ -98,7 +98,7 @@ const loadArtifactUrl = (
           );
           return success;
         })
-        .catch(error => {
+        .catch((error) => {
           const failure = action(
             loadArtifactUrlActionTypes.FAILURE,
             normalizeError(error)
@@ -109,7 +109,7 @@ const loadArtifactUrl = (
     case 'project':
       return ServiceFactory.getProjectsService()
         .loadArtifactUrl(entityId, artifact)
-        .then(res => {
+        .then((res) => {
           const success = action(loadArtifactUrlActionTypes.SUCCESS, {
             key: artifact.key,
             url: res,
@@ -122,7 +122,7 @@ const loadArtifactUrl = (
           );
           return success;
         })
-        .catch(error => {
+        .catch((error) => {
           const failure = action(
             loadArtifactUrlActionTypes.FAILURE,
             normalizeError(error)
@@ -246,7 +246,7 @@ export const loadDatasetVersion = (
 
   await ServiceFactory.getDatasetVersionsService()
     .loadDatasetVersion(workspaceName, datasetVersionId, datasetId)
-    .then(datasetVersion => {
+    .then((datasetVersion) => {
       dispatch(
         action(loadDatasetVersionActionTypes.SUCCESS, {
           datasetVersionId,
@@ -254,7 +254,7 @@ export const loadDatasetVersion = (
         })
       );
     })
-    .catch(error => {
+    .catch((error) => {
       dispatch(
         action(loadDatasetVersionActionTypes.FAILURE, {
           datasetVersionId,
@@ -279,7 +279,7 @@ export const deleteArtifact = (
     .then(() => {
       dispatch(action(deleteArtifactActionTypes.SUCCESS, { experimentRunId }));
     })
-    .catch(error => {
+    .catch((error) => {
       dispatch(
         action(deleteArtifactActionTypes.FAILURE, {
           experimentRunId,

--- a/webapp/client/src/features/artifactManager/store/hooks/useDownloadArtifact.tsx
+++ b/webapp/client/src/features/artifactManager/store/hooks/useDownloadArtifact.tsx
@@ -37,6 +37,7 @@ const useDownloadArtifact = (props: ILocalProps) => {
         downloadArtifact(props.entityType, props.entityId, props.artifact)
       );
     },
+    reset: () => dispatch(reset()),
   };
 };
 

--- a/webapp/client/src/features/experimentRuns/view/ModelRecord/shared/Artifacts/Artifact.tsx
+++ b/webapp/client/src/features/experimentRuns/view/ModelRecord/shared/Artifacts/Artifact.tsx
@@ -70,9 +70,11 @@ const Artifact = ({
         label: artifact.key,
         title: artifact.key,
       }}
-      isShowPreloader={actions.some(action => action && action.isShowPreloader)}
+      isShowPreloader={actions.some(
+        (action) => action && action.isShowPreloader
+      )}
       actions={actions
-        .map(action => action && action.content)
+        .map((action) => action && action.content)
         .filter((x): x is JSX.Element => Boolean(x))}
     />
   );
@@ -90,7 +92,7 @@ const useDownloadArtifactAction = ({
   if (!checkArtifactWithPath(artifact)) {
     return undefined;
   }
-  const { downloadArtifact, downloadingArtifact } = useDownloadArtifact({
+  const { downloadArtifact, downloadingArtifact, reset } = useDownloadArtifact({
     artifact,
     entityId,
     entityType,
@@ -99,6 +101,7 @@ const useDownloadArtifactAction = ({
   React.useEffect(() => {
     if (downloadingArtifact.isSuccess) {
       toastSuccess(<span>The artifact is downloaded</span>);
+      reset();
     }
   }, [downloadingArtifact.isSuccess]);
   React.useEffect(() => {
@@ -108,6 +111,7 @@ const useDownloadArtifactAction = ({
           artifactErrorMessages.artifact_download
         }: ${communicationErrorToString(downloadingArtifact.error)}`
       );
+      reset();
     }
   }, [downloadingArtifact.error]);
 
@@ -148,7 +152,7 @@ const useDeleteArtifactAction = ({
             cancelButtonText="Cancel"
             confirmButtonText="Delete"
           >
-            {withConfirmAction => (
+            {(withConfirmAction) => (
               <Action
                 iconType="delete"
                 onClick={withConfirmAction(() =>


### PR DESCRIPTION
On the ER details we were not resetting the artifact store after a download and thus the first artifact loaded would be always be downloaded until user left or reloaded the page