### PR TITLE
Send auth headers without underscore

### DIFF
--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -155,7 +155,7 @@ class Client(object):
             auth.update({
                 _utils._GRPC_PREFIX+'email': email,
                 _utils._GRPC_PREFIX+'developer_key': dev_key,
-                # for nginx support
+                # without underscore, for nginx support
                 # https://www.nginx.com/resources/wiki/start/topics/tutorials/config_pitfalls#missing-disappearing-http-headers
                 _utils._GRPC_PREFIX+'developer-key': dev_key,
             })

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -155,6 +155,9 @@ class Client(object):
             auth.update({
                 _utils._GRPC_PREFIX+'email': email,
                 _utils._GRPC_PREFIX+'developer_key': dev_key,
+                # for nginx support
+                # https://www.nginx.com/resources/wiki/start/topics/tutorials/config_pitfalls#missing-disappearing-http-headers
+                _utils._GRPC_PREFIX+'developer-key': dev_key,
             })
             # save credentials to env for other Verta Client features
             os.environ['VERTA_EMAIL'] = email

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -155,7 +155,7 @@ class Client(object):
             auth.update({
                 _utils._GRPC_PREFIX+'email': email,
                 _utils._GRPC_PREFIX+'developer_key': dev_key,
-                # without underscore, for nginx support
+                # without underscore, for NGINX support
                 # https://www.nginx.com/resources/wiki/start/topics/tutorials/config_pitfalls#missing-disappearing-http-headers
                 _utils._GRPC_PREFIX+'developer-key': dev_key,
             })

--- a/client/verta/verta/deployment/_deployedmodel.py
+++ b/client/verta/verta/deployment/_deployedmodel.py
@@ -75,7 +75,10 @@ class DeployedModel:
             except KeyError:
                 six.raise_from(EnvironmentError("${} not found in environment".format('VERTA_EMAIL')), None)
             try:
-                self._session.headers.update({_utils._GRPC_PREFIX+'developer_key': os.environ['VERTA_DEV_KEY']})
+                self._session.headers.update({
+                    _utils._GRPC_PREFIX+'developer_key': os.environ['VERTA_DEV_KEY'],
+                    _utils._GRPC_PREFIX+'developer-key': os.environ['VERTA_DEV_KEY'],  # see Client.__init__()
+                })
             except KeyError:
                 six.raise_from(EnvironmentError("${} not found in environment".format('VERTA_DEV_KEY')), None)
 


### PR DESCRIPTION
[NGINX silently drops HTTP headers with underscores in them by default](https://www.nginx.com/nginx-wiki/build/dirhtml/start/topics/tutorials/config_pitfalls/#missing-disappearing-http-headers), meaning that an infrastructure setup using NGINX as an intermediary may drop our platform's authentication headers.

...until now.