### PR TITLE
Constrain pyyaml to <5.4

### DIFF
--- a/client/verta/setup.py
+++ b/client/verta/setup.py
@@ -31,7 +31,7 @@ setup(
         "googleapis-common-protos>=1.5",
         "pathlib2>=2.2",
         "protobuf>=3.8",
-        "pyyaml>=5.1",
+        "pyyaml>=5.1, <5.4",
         "requests>=2.21, <3.0",
     ],
     entry_points={

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -19,7 +19,6 @@ import warnings
 import zipfile
 
 import requests
-import yaml
 from verta._tracking.organization import Organization
 from ._internal_utils._utils import check_unnecessary_params_warning
 


### PR DESCRIPTION
Since https://github.com/yaml/pyyaml/pull/407, `pyyaml` has `Cython` (and therefore gcc) as a build dependency.

We'd like to make our client fully build-from-source-able on systems without gcc, and `pyyaml` is only being used for simple config file reading, so we're constraining the version.