### PR TITLE
VR-9655: Enable code versioning with manual values, no autocapture

### DIFF
--- a/client/verta/tests/test_log_code.py
+++ b/client/verta/tests/test_log_code.py
@@ -70,7 +70,6 @@ class TestLogGit:
             assert code_version['repo_url'] == _git_utils.get_git_remote_url()
             assert code_version['commit_hash'] == _git_utils.get_git_commit_hash("HEAD")
 
-    @pytest.mark.skipif(not IN_GIT_REPO, reason="not in git repo")
     @pytest.mark.parametrize(
         ("exec_path", "repo_url", "commit_hash"),
         [

--- a/client/verta/tests/test_log_code.py
+++ b/client/verta/tests/test_log_code.py
@@ -36,6 +36,9 @@ class TestLogGit:
             assert len(code_version['filepaths']) == 1
             assert __file__.endswith(code_version['filepaths'][0])
 
+            assert code_version['repo_url'] == _git_utils.get_git_remote_url()
+            assert code_version['commit_hash'] == _git_utils.get_git_commit_hash("HEAD")
+
     def test_log_git_failure(self, client):
         """git mode fails outside git repo"""
         client.set_project()
@@ -63,6 +66,9 @@ class TestLogGit:
             assert 'filepaths' in code_version
             assert len(code_version['filepaths']) == 1
             assert os.path.abspath("conftest.py").endswith(code_version['filepaths'][0])
+
+            assert code_version['repo_url'] == _git_utils.get_git_remote_url()
+            assert code_version['commit_hash'] == _git_utils.get_git_commit_hash("HEAD")
 
     @pytest.mark.skipif(not IN_GIT_REPO, reason="not in git repo")
     @pytest.mark.parametrize(

--- a/client/verta/tests/test_versioning/test_code.py
+++ b/client/verta/tests/test_versioning/test_code.py
@@ -60,11 +60,11 @@ class TestGit:
 
         refs = [arg for arg in (branch, tag, commit_hash) if arg]
         ref = refs[0] if refs else _git_utils.get_git_commit_hash("HEAD")
-        assert code_ver._msg.git.repo == (repo_url or _git_utils.get_git_remote_url())
-        assert code_ver._msg.git.branch == (branch or _git_utils.get_git_branch_name(ref))
-        assert code_ver._msg.git.tag == (tag or _git_utils.get_git_commit_tag(ref))
-        assert code_ver._msg.git.hash == (commit_hash or _git_utils.get_git_commit_hash(ref))
-        assert code_ver._msg.git.is_dirty == _git_utils.get_git_commit_dirtiness(ref)
+        assert code_ver.repo_url == (repo_url or _git_utils.get_git_remote_url())
+        assert code_ver.branch == (branch or _git_utils.get_git_branch_name(ref))
+        assert code_ver.tag == (tag or _git_utils.get_git_commit_tag(ref) or None)  # None if HEAD is not at a tag
+        assert code_ver.commit_hash == (commit_hash or _git_utils.get_git_commit_hash(ref))
+        assert code_ver.is_dirty == _git_utils.get_git_commit_dirtiness(ref)
 
     @hypothesis.given(
         repo_url=st.one_of(st.none(), st.emails()),
@@ -80,10 +80,10 @@ class TestGit:
             autocapture=False,
         )
 
-        assert code_ver._msg.git.repo == (repo_url or "")
-        assert code_ver._msg.git.branch == (branch or "")
-        assert code_ver._msg.git.tag == (tag or "")
-        assert code_ver._msg.git.hash == (commit_hash or "")
+        assert code_ver.repo_url == (repo_url or None)
+        assert code_ver.branch == (branch or None)
+        assert code_ver.tag == (tag or None)
+        assert code_ver.commit_hash == (commit_hash or None)
 
 
 class TestNotebook:

--- a/client/verta/tests/test_versioning/test_code.py
+++ b/client/verta/tests/test_versioning/test_code.py
@@ -25,7 +25,7 @@ class TestGit:
         assert not json_format.MessageToDict(
             code_ver._msg,
             including_default_value_fields=False,
-        ).get('git')
+        ).get('git')  # may be {'git': {}} if fields are manually set to empty
 
     def test_repr(self):
         """Tests that __repr__() executes without error"""

--- a/client/verta/tests/test_versioning/test_code.py
+++ b/client/verta/tests/test_versioning/test_code.py
@@ -45,7 +45,7 @@ class TestGit:
             (None, None, None, None),
             ("git@github.com:VertaAI/modeldb.git", None, None, None),
             ("git@github.com:VertaAI/modeldb.git", _git_utils.get_git_branch_name("HEAD"), None, None),
-            ("git@github.com:VertaAI/modeldb.git", None, _git_utils.get_git_commit_tag("HEAD") or None, None),
+            ("git@github.com:VertaAI/modeldb.git", None, _git_utils.get_git_commit_tag("HEAD") or None, None),  # None if HEAD is not at a tag
             ("git@github.com:VertaAI/modeldb.git", None, None, _git_utils.get_git_commit_hash("HEAD")),
         ],
     )

--- a/client/verta/tests/test_versioning/test_code.py
+++ b/client/verta/tests/test_versioning/test_code.py
@@ -1,9 +1,20 @@
 import pytest
+import hypothesis
+import hypothesis.strategies as st
 
 from google.protobuf import json_format
 
 import verta.code
 from verta._internal_utils import _git_utils
+
+
+# check if in git repo
+try:
+    _git_utils.get_git_repo_root_dir()
+except OSError:
+    IN_GIT_REPO = False
+else:
+    IN_GIT_REPO = True
 
 
 class TestGit:
@@ -14,7 +25,7 @@ class TestGit:
         assert not json_format.MessageToDict(
             code_ver._msg,
             including_default_value_fields=False,
-        )
+        ).get('git')
 
     def test_repr(self):
         """Tests that __repr__() executes without error"""
@@ -26,6 +37,50 @@ class TestGit:
         code_ver = verta.code.Git()
 
         assert code_ver.__repr__()
+
+    @pytest.mark.skipif(not IN_GIT_REPO, reason="not in git repo")
+    @pytest.mark.parametrize(
+        ("repo_url", "branch", "tag", "commit_hash"),
+        [
+            (None, None, None, None),
+            ("git@github.com:VertaAI/modeldb.git", None, None, None),
+            ("git@github.com:VertaAI/modeldb.git", _git_utils.get_git_branch_name("HEAD"), None, None),
+            ("git@github.com:VertaAI/modeldb.git", None, _git_utils.get_git_commit_tag("HEAD") or None, None),
+            ("git@github.com:VertaAI/modeldb.git", None, None, _git_utils.get_git_commit_hash("HEAD")),
+        ],
+    )
+    def test_autocapture(self, repo_url, branch, tag, commit_hash):
+        code_ver = verta.code.Git(
+            repo_url=repo_url,
+            branch=branch, tag=tag, commit_hash=commit_hash,
+        )
+
+        refs = [arg for arg in (branch, tag, commit_hash) if arg]
+        ref = refs[0] if refs else _git_utils.get_git_commit_hash("HEAD")
+        assert code_ver._msg.git.repo == (repo_url or _git_utils.get_git_remote_url())
+        assert code_ver._msg.git.branch == (branch or _git_utils.get_git_branch_name(ref))
+        assert code_ver._msg.git.tag == (tag or _git_utils.get_git_commit_tag(ref))
+        assert code_ver._msg.git.hash == (commit_hash or _git_utils.get_git_commit_hash(ref))
+        assert code_ver._msg.git.is_dirty == _git_utils.get_git_commit_dirtiness(ref)
+
+    @hypothesis.given(
+        repo_url=st.one_of(st.none(), st.emails()),
+        branch=st.one_of(st.none(), st.text()),
+        tag=st.one_of(st.none(), st.text()),
+        commit_hash=st.one_of(st.none(), st.text()),
+    )
+    def test_user_no_autocapture(self, repo_url, branch, tag, commit_hash):
+        """Like test_no_autocapture, but with the public `autocapture` param."""
+        code_ver = verta.code.Git(
+            repo_url=repo_url,
+            branch=branch, tag=tag, commit_hash=commit_hash,
+            autocapture=False,
+        )
+
+        assert code_ver._msg.git.repo == (repo_url or "")
+        assert code_ver._msg.git.branch == (branch or "")
+        assert code_ver._msg.git.tag == (tag or "")
+        assert code_ver._msg.git.hash == (commit_hash or "")
 
 
 class TestNotebook:

--- a/client/verta/tests/test_versioning/test_code.py
+++ b/client/verta/tests/test_versioning/test_code.py
@@ -9,9 +9,13 @@ from verta._internal_utils import _git_utils
 
 
 # check if in git repo
+import subprocess
 try:
-    _git_utils.get_git_repo_root_dir()
-except OSError:
+    print(subprocess.check_output(
+        ["git", "rev-parse", "--show-toplevel"],
+        stderr=subprocess.STDOUT,
+    ))
+except:
     IN_GIT_REPO = False
 else:
     IN_GIT_REPO = True

--- a/client/verta/tests/test_versioning/test_code.py
+++ b/client/verta/tests/test_versioning/test_code.py
@@ -9,13 +9,9 @@ from verta._internal_utils import _git_utils
 
 
 # check if in git repo
-import subprocess
 try:
-    print(subprocess.check_output(
-        ["git", "rev-parse", "--show-toplevel"],
-        stderr=subprocess.STDOUT,
-    ))
-except:
+    _git_utils.get_git_repo_root_dir()
+except OSError:
     IN_GIT_REPO = False
 else:
     IN_GIT_REPO = True

--- a/client/verta/tests/test_versioning/test_code.py
+++ b/client/verta/tests/test_versioning/test_code.py
@@ -43,9 +43,12 @@ class TestGit:
         ("repo_url", "branch", "tag", "commit_hash"),
         [
             (None, None, None, None),
+            (None, _git_utils.get_git_branch_name("HEAD"), None, None),
+            (None, None, _git_utils.get_git_commit_tag("HEAD") or None, None),  # None if HEAD is not at a tag
+            (None, None, None, _git_utils.get_git_commit_hash("HEAD")),
             ("git@github.com:VertaAI/modeldb.git", None, None, None),
             ("git@github.com:VertaAI/modeldb.git", _git_utils.get_git_branch_name("HEAD"), None, None),
-            ("git@github.com:VertaAI/modeldb.git", None, _git_utils.get_git_commit_tag("HEAD") or None, None),  # None if HEAD is not at a tag
+            ("git@github.com:VertaAI/modeldb.git", None, _git_utils.get_git_commit_tag("HEAD") or None, None),
             ("git@github.com:VertaAI/modeldb.git", None, None, _git_utils.get_git_commit_hash("HEAD")),
         ],
     )

--- a/client/verta/verta/_tracking/entity.py
+++ b/client/verta/verta/_tracking/entity.py
@@ -13,7 +13,6 @@ from .._protos.public.modeldb import CommonService_pb2 as _CommonService
 
 from ..external import six
 
-from ..code import _git
 from .._internal_utils import (
     _artifact_utils,
     _git_utils,
@@ -304,6 +303,7 @@ class _ModelDBEntity(object):
             if exec_path:
                 msg.code_version.git_snapshot.filepaths.append(exec_path)
 
+            from ..code import _git  # avoid Python 2 top-level circular import
             code_ver = _git.Git(repo_url=repo_url, commit_hash=commit_hash, autocapture=autocapture)
             msg.code_version.git_snapshot.repo = code_ver.repo_url or ""
             msg.code_version.git_snapshot.hash = code_ver.commit_hash or ""

--- a/client/verta/verta/_tracking/entity.py
+++ b/client/verta/verta/_tracking/entity.py
@@ -379,8 +379,8 @@ class _ModelDBEntity(object):
             Either:
                 - a dictionary containing Git snapshot information with at most the following items:
                     - **filepaths** (*list of str*)
-                    - **repo** (*str*) – Remote repository URL
-                    - **hash** (*str*) – Commit hash
+                    - **repo_url** (*str*) – Remote repository URL
+                    - **commit_hash** (*str*) – Commit hash
                     - **is_dirty** (*bool*)
                 - a `ZipFile <https://docs.python.org/3/library/zipfile.html#zipfile.ZipFile>`_
                   containing Python source code files

--- a/client/verta/verta/_tracking/entity.py
+++ b/client/verta/verta/_tracking/entity.py
@@ -13,6 +13,7 @@ from .._protos.public.modeldb import CommonService_pb2 as _CommonService
 
 from ..external import six
 
+from ..code import _git
 from .._internal_utils import (
     _artifact_utils,
     _git_utils,
@@ -164,7 +165,7 @@ class _ModelDBEntity(object):
     def _create_proto_internal(cls, conn, ctx, name, desc=None, tags=None, attrs=None, date_created=None, **kwargs):  # recommended params
         raise NotImplementedError
 
-    def log_code(self, exec_path=None, repo_url=None, commit_hash=None, overwrite=False):
+    def log_code(self, exec_path=None, repo_url=None, commit_hash=None, overwrite=False, autocapture=True):
         """
         Logs the code version.
 
@@ -185,6 +186,8 @@ class _ModelDBEntity(object):
             make its best effort to find it.
         overwrite : bool, default False
             Whether to allow overwriting a code version.
+        autocapture : bool, default True
+            Whether to enable the automatic capturing behavior of parameters above.
 
         Examples
         --------
@@ -237,13 +240,16 @@ class _ModelDBEntity(object):
                 # training_pipeline.py        2019-05-31 10:34:44          964
 
         """
-        if self._conf.use_git:
+        if self._conf.use_git and not autocapture:
             # verify Git
             try:
                 repo_root_dir = _git_utils.get_git_repo_root_dir()
             except OSError:
                 # don't halt execution
-                print("unable to locate git repository; you may be in an unsupported environment")
+                print(
+                    "unable to locate git repository; you may be in an unsupported environment"
+                    " consider using `autocapture=False` to manually enter values"
+                )
                 return
                 # six.raise_from(OSError("failed to locate git repository; please check your working directory"),
                 #                None)
@@ -251,19 +257,20 @@ class _ModelDBEntity(object):
         elif repo_url is not None or commit_hash is not None:
             raise ValueError("`repo_url` and `commit_hash` can only be set if `use_git` was set to True in the Client")
 
-        if exec_path is None:
-            # find dynamically
-            try:
-                exec_path = _utils.get_notebook_filepath()
-            except (ImportError, OSError):  # notebook not found
+        if autocapture:
+            if exec_path is None:
+                # find dynamically
                 try:
-                    exec_path = _utils.get_script_filepath()
-                except OSError:  # script not found
-                    print("unable to find code file; skipping")
-        else:
-            exec_path = os.path.expanduser(exec_path)
-            if not os.path.isfile(exec_path):
-                raise ValueError("`exec_path` \"{}\" must be a valid filepath".format(exec_path))
+                    exec_path = _utils.get_notebook_filepath()
+                except (ImportError, OSError):  # notebook not found
+                    try:
+                        exec_path = _utils.get_script_filepath()
+                    except OSError:  # script not found
+                        print("unable to find code file; skipping")
+            else:
+                exec_path = os.path.expanduser(exec_path)
+                if not os.path.isfile(exec_path):
+                    raise ValueError("`exec_path` \"{}\" must be a valid filepath".format(exec_path))
 
         # TODO: remove this circular dependency
         from .project import Project
@@ -287,33 +294,23 @@ class _ModelDBEntity(object):
                 raise ValueError("`overwrite=True` is currently only supported for ExperimentRun")
 
         if self._conf.use_git:
-            try:
-                # adjust `exec_path` to be relative to repo root
-                exec_path = os.path.relpath(exec_path, _git_utils.get_git_repo_root_dir())
-            except OSError as e:
-                print("{}; logging absolute path to file instead")
-                exec_path = os.path.abspath(exec_path)
-            msg.code_version.git_snapshot.filepaths.append(exec_path)
+            if autocapture:
+                try:
+                    # adjust `exec_path` to be relative to repo root
+                    exec_path = os.path.relpath(exec_path, _git_utils.get_git_repo_root_dir())
+                except OSError as e:
+                    print("{}; logging absolute path to file instead".format(e))
+                    exec_path = os.path.abspath(exec_path)
+            if exec_path:
+                msg.code_version.git_snapshot.filepaths.append(exec_path)
 
-            try:
-                msg.code_version.git_snapshot.repo = repo_url or _git_utils.get_git_remote_url()
-            except OSError as e:
-                print("{}; skipping".format(e))
-
-            try:
-                msg.code_version.git_snapshot.hash = commit_hash or _git_utils.get_git_commit_hash()
-            except OSError as e:
-                print("{}; skipping".format(e))
-
-            try:
-                is_dirty = _git_utils.get_git_commit_dirtiness(commit_hash)
-            except OSError as e:
-                print("{}; skipping".format(e))
+            code_ver = _git.Git(repo_url=repo_url, commit_hash=commit_hash, autocapture=autocapture)
+            msg.code_version.git_snapshot.repo = code_ver.repo_url or ""
+            msg.code_version.git_snapshot.hash = code_ver.commit_hash or ""
+            if code_ver.is_dirty:
+                msg.code_version.git_snapshot.is_dirty = _CommonCommonService.TernaryEnum.TRUE
             else:
-                if is_dirty:
-                    msg.code_version.git_snapshot.is_dirty = _CommonCommonService.TernaryEnum.TRUE
-                else:
-                    msg.code_version.git_snapshot.is_dirty = _CommonCommonService.TernaryEnum.FALSE
+                msg.code_version.git_snapshot.is_dirty = _CommonCommonService.TernaryEnum.FALSE
         else:  # log code as Artifact
             if exec_path is None:
                 # don't halt execution

--- a/client/verta/verta/_tracking/entity.py
+++ b/client/verta/verta/_tracking/entity.py
@@ -186,7 +186,7 @@ class _ModelDBEntity(object):
         overwrite : bool, default False
             Whether to allow overwriting a code version.
         autocapture : bool, default True
-            Whether to enable the automatic capturing behavior of parameters above.
+            Whether to enable the automatic capturing behavior of parameters above in git mode.
 
         Examples
         --------
@@ -253,8 +253,11 @@ class _ModelDBEntity(object):
                 # six.raise_from(OSError("failed to locate git repository; please check your working directory"),
                 #                None)
             print("Git repository successfully located at {}".format(repo_root_dir))
-        elif repo_url is not None or commit_hash is not None:
-            raise ValueError("`repo_url` and `commit_hash` can only be set if `use_git` was set to True in the Client")
+        if not self._conf.use_git:
+            if repo_url is not None or commit_hash is not None:
+                raise ValueError("`repo_url` and `commit_hash` can only be set if `use_git` was set to True in the Client")
+            if not autocapture:  # user passed `False`
+                raise ValueError("`autocapture` is only applicable if `use_git` was set to True in the Client")
 
         if autocapture:
             if exec_path is None:

--- a/client/verta/verta/_tracking/entity.py
+++ b/client/verta/verta/_tracking/entity.py
@@ -239,7 +239,7 @@ class _ModelDBEntity(object):
                 # training_pipeline.py        2019-05-31 10:34:44          964
 
         """
-        if self._conf.use_git and not autocapture:
+        if self._conf.use_git and autocapture:
             # verify Git
             try:
                 repo_root_dir = _git_utils.get_git_repo_root_dir()

--- a/client/verta/verta/_tracking/entity.py
+++ b/client/verta/verta/_tracking/entity.py
@@ -246,8 +246,8 @@ class _ModelDBEntity(object):
             except OSError:
                 # don't halt execution
                 print(
-                    "unable to locate git repository; you may be in an unsupported environment"
-                    " consider using `autocapture=False` to manually enter values"
+                    "unable to locate git repository; you may be in an unsupported environment;\n"
+                    "    consider using `autocapture=False` to manually enter values"
                 )
                 return
                 # six.raise_from(OSError("failed to locate git repository; please check your working directory"),

--- a/client/verta/verta/code/_git.py
+++ b/client/verta/verta/code/_git.py
@@ -46,7 +46,7 @@ class Git(_code._Code):
 
     """
     def __init__(self, repo_url=None, branch=None, tag=None, commit_hash=None, autocapture=True, _autocapture=True):
-        # TODO: switch all similar blobs from _autocapture to _autocapture so they have the same API
+        # TODO: switch all similar blobs from _autocapture to autocapture so they have the same API
         if _autocapture is False:
             autocapture = False
 

--- a/client/verta/verta/code/_git.py
+++ b/client/verta/verta/code/_git.py
@@ -22,7 +22,7 @@ class Git(_code._Code):
         Commit tag. If not provided, it will automatically be determined.
     commit_hash : str, optional
         Commit hash. If not provided, it will automatically be determined.
-    _autocapture : bool, default True
+    autocapture : bool, default True
         Whether to enable the automatic capturing behavior of parameters above.
 
     Raises
@@ -45,25 +45,38 @@ class Git(_code._Code):
         )
 
     """
-    def __init__(self, repo_url=None, branch=None, tag=None, commit_hash=None, _autocapture=True):
-        passed_in_refs = [arg for arg in (branch, tag, commit_hash) if arg is not None]
-        if len(passed_in_refs) > 1:
-            raise ValueError("cannot specify more than one of `branch`, `tag`, and `commit_hash`")
-        elif len(passed_in_refs) == 1:
-            ref = passed_in_refs[0]
-        elif _autocapture:
-            ref = _git_utils.get_git_commit_hash()
+    def __init__(self, repo_url=None, branch=None, tag=None, commit_hash=None, autocapture=True, _autocapture=True):
+        # TODO: switch all similar blobs from _autocapture to _autocapture so they have the same API
+        if _autocapture is False:
+            autocapture = False
+
+        if autocapture:
+            # need a unique commit ref, so only one of these params is allowed
+            passed_in_refs = [arg for arg in (branch, tag, commit_hash) if arg is not None]
+            if len(passed_in_refs) > 1:
+                raise ValueError("cannot specify more than one of `branch`, `tag`, and `commit_hash`")
+            elif len(passed_in_refs) == 1:
+                ref = passed_in_refs[0]
+            else:
+                ref = _git_utils.get_git_commit_hash()
         else:
+            # user can pass whatever they like
             ref = None
 
         super(Git, self).__init__()
 
-        if ref is not None:
+        if autocapture and ref:
             self._msg.git.repo = repo_url or _git_utils.get_git_remote_url()
             self._msg.git.branch = branch or _git_utils.get_git_branch_name(ref)
             self._msg.git.tag = tag or _git_utils.get_git_commit_tag(ref)
             self._msg.git.hash = _git_utils.get_git_commit_hash(ref)  # use full commit hash
             self._msg.git.is_dirty = _git_utils.get_git_commit_dirtiness(ref)
+        else:
+            self._msg.git.repo = repo_url or ""
+            self._msg.git.branch = branch or ""
+            self._msg.git.tag = tag or ""
+            self._msg.git.hash = commit_hash or ""
+            # self._msg.git.is_dirty  # TODO: expose as param
 
     def __repr__(self):
         lines = ["Git Version"]

--- a/client/verta/verta/code/_git.py
+++ b/client/verta/verta/code/_git.py
@@ -41,7 +41,7 @@ class Git(_code._Code):
     commit_hash : str or None
         Commit hash.
     is_dirty : bool
-        Whether git status is dirty relative to the captured commit.
+        Whether git status was dirty relative to the captured commit.
 
     Examples
     --------

--- a/client/verta/verta/code/_git.py
+++ b/client/verta/verta/code/_git.py
@@ -30,6 +30,19 @@ class Git(_code._Code):
     OSError
         If git information cannot automatically be determined.
 
+    Attributes
+    ----------
+    repo_url : str or None
+        Remote repository URL.
+    branch : str or None
+        Branch name.
+    tag : str or None
+        Commit tag.
+    commit_hash : str or None
+        Commit hash.
+    is_dirty : bool
+        Whether git status is dirty relative to the captured commit.
+
     Examples
     --------
     .. code-block:: python
@@ -93,3 +106,23 @@ class Git(_code._Code):
         blob_msg.code.CopyFrom(self._msg)
 
         return blob_msg
+
+    @property
+    def repo_url(self):
+        return self._msg.git.repo or None
+
+    @property
+    def branch(self):
+        return self._msg.git.branch or None
+
+    @property
+    def tag(self):
+        return self._msg.git.tag or None
+
+    @property
+    def commit_hash(self):
+        return self._msg.git.hash or None
+
+    @property
+    def is_dirty(self):
+        return self._msg.git.is_dirty


### PR DESCRIPTION
`Git(autocapture=True)` (default, current behavior) will check the local git env for info about the current commit.  
`Git(autocapture=False)` will not check for anything, instead directly passing user-input values as the git version.
`log_code(autocapture=True)` in git mode is the same as `Git(autocapture=True)`.  
`log_code(autocapture=False)` in git mode is the same as `Git(autocapture=False)`.  
`log_code(autocapture)` isn't applicable to non-git mode, because the client needs to be able to find a notebook file.

---
For `Git()`: change `_autocapture` to `autocapture`, and add logic to allow user to selectively pass in arguments.
For `log_code()`: add `autocapture`