### PR TITLE
VR-9745: Consolidate client test teardowns

### DIFF
--- a/client/verta/tests/conftest.py
+++ b/client/verta/tests/conftest.py
@@ -343,27 +343,27 @@ def model_for_deployment(strs):
 
 
 @pytest.fixture
-def repository(client):
+def repository(client, created_entities):
     name = _utils.generate_default_name()
     repo = client.get_or_create_repository(name)
+    created_entities.append(repo)
 
-    yield repo
-
-    repo.delete()
+    return repo
 
 
 @pytest.fixture
 def commit(repository):
     commit = repository.get_commit()
 
-    yield commit
+    return commit
 
 
 @pytest.fixture
-def registered_model(client):
+def registered_model(client, created_entities):
     model = client.get_or_create_registered_model()
-    yield model
-    model.delete()
+    created_entities.append(model)
+
+    return model
 
 
 @pytest.fixture
@@ -383,19 +383,19 @@ def model_version(registered_model):
 
 
 @pytest.fixture
-def endpoint(client):
+def endpoint(client, created_entities):
     path = _utils.generate_default_name()
     endpoint = client.create_endpoint(path)
+    created_entities.append(endpoint)
 
-    yield endpoint
-
-    endpoint.delete()
+    return endpoint
 
 
 @pytest.fixture
-def organization(client):
+def organization(client, created_entities):
     workspace_name = _utils.generate_default_name()
     org = client._create_organization(workspace_name)
+    created_entities.append(org)
 
     yield org
 
@@ -404,8 +404,6 @@ def organization(client):
     if proj is not None:
         proj.delete()
         client._ctx.proj = None
-
-    org.delete()
 
 
 @pytest.fixture

--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -162,6 +162,18 @@ class Connection:
     def is_html_response(response):
         return response.text.strip().endswith("</html>")
 
+    def _set_default_workspace(self, name):
+        msg = Workspace_pb2.GetWorkspaceByName(name=name)
+        response = self.make_proto_request("GET", "/api/v1/uac-proxy/workspace/getWorkspaceByName", params=msg)
+        workspace = self.must_proto_response(response, Workspace_pb2.Workspace)
+
+        response = self.make_proto_request("GET", "/api/v1/uac-proxy/uac/getCurrentUser")
+        user_info = self.must_proto_response(response, UACService_pb2.UserInfo)
+
+        msg = UACService_pb2.UpdateUser(info=user_info, default_workspace_id=workspace.id)
+        response = self.make_proto_request("POST", "/api/v1/uac-proxy/uac/updateUser", body=msg)
+        raise_for_http_error(response)
+
     def is_workspace(self, workspace_name):
         msg = Workspace_pb2.GetWorkspaceByName(name=workspace_name)
         response = self.make_proto_request("GET", "/api/v1/uac-proxy/workspace/getWorkspaceByName", params=msg)


### PR DESCRIPTION
Test teardowns have been running into issues attempting to delete an entity after its workspace has already been deleted, throwing a `403`.

This slight restructuring of the fixtures:

- uses `created_entities` in individual entity fixtures, ensuring that `created_entities` is torn down _last_, and is the one and only fixture where things are deleted
- ensures that `created_entities` deletes orgs _last_, to avoid the out-of-order `403`s that have been occurring.