### PR TITLE
VR-9734: Enable passing PySpark model to run.log_model()

### DIFF
--- a/client/verta/verta/_internal_utils/_artifact_utils.py
+++ b/client/verta/verta/_internal_utils/_artifact_utils.py
@@ -282,7 +282,7 @@ def serialize_model(model):
                 bytestream = zip_dir(spark_model_dir)
             finally:
                 shutil.rmtree(temp_dir)
-            # TODO: see if more info would be needed to handle in model service
+            # TODO: see if more info would be needed to deserialize in model service
             return bytestream, "zip", "pyspark"
     for class_obj in model.__class__.__mro__:
         module_name = class_obj.__module__

--- a/client/verta/verta/_internal_utils/_artifact_utils.py
+++ b/client/verta/verta/_internal_utils/_artifact_utils.py
@@ -463,12 +463,12 @@ def zip_dir(dirpath):
 
     os.path.expanduser(dirpath)
 
-    tempf = tempfile.NamedTemporaryFile(suffix=".zip")
-    with zipfile.ZipFile(tempf, 'w') as zipf:
-        for root, _, files in os.walk(dirpath):
-            for filename in files:
-                filepath = os.path.join(root, filename)
-                zipf.write(filepath, os.path.relpath(filepath, dirpath))
-    tempf.seek(0)
+    with tempfile.NamedTemporaryFile(suffix=".zip") as tempf:
+        with zipfile.ZipFile(tempf, 'w') as zipf:
+            for root, _, files in os.walk(dirpath):
+                for filename in files:
+                    filepath = os.path.join(root, filename)
+                    zipf.write(filepath, os.path.relpath(filepath, dirpath))
 
-    return tempf
+        tempf.seek(0)
+        return tempf

--- a/client/verta/verta/_internal_utils/_artifact_utils.py
+++ b/client/verta/verta/_internal_utils/_artifact_utils.py
@@ -3,6 +3,7 @@
 import hashlib
 import os
 import tempfile
+import zipfile
 
 import cloudpickle
 
@@ -437,3 +438,37 @@ def calc_sha256(bytestream, chunk_size=CHUNK_SIZE):
         reset_stream(bytestream)  # reset cursor to beginning as a courtesy
 
     return checksum.hexdigest()
+
+
+def zip_dir(dirpath):
+    """
+    ZIPs a directory.
+
+    Parameters
+    ----------
+    dirpath : str
+        Directory path.
+
+    Returns
+    -------
+    tempf : :class:`tempfile.NamedTemporaryFile`
+        ZIP file handle.
+
+    """
+    e_msg = "{} is not a directory".format(str(dirpath))
+    if not isinstance(dirpath, six.string_types):
+        raise TypeError(e_msg)
+    if not os.path.isdir(dirpath):
+        raise ValueError(e_msg)
+
+    os.path.expanduser(dirpath)
+
+    tempf = tempfile.NamedTemporaryFile(suffix=".zip")
+    with zipfile.ZipFile(tempf, 'w') as zipf:
+        for root, _, files in os.walk(dirpath):
+            for filename in files:
+                filepath = os.path.join(root, filename)
+                zipf.write(filepath, os.path.relpath(filepath, dirpath))
+    tempf.seek(0)
+
+    return tempf

--- a/client/verta/verta/_internal_utils/_artifact_utils.py
+++ b/client/verta/verta/_internal_utils/_artifact_utils.py
@@ -282,6 +282,7 @@ def serialize_model(model):
                 bytestream = zip_dir(spark_model_dir)
             finally:
                 shutil.rmtree(temp_dir)
+            # TODO: see if more info would be needed to handle in model service
             return bytestream, "zip", "pyspark"
     for class_obj in model.__class__.__mro__:
         module_name = class_obj.__module__

--- a/client/verta/verta/_internal_utils/_artifact_utils.py
+++ b/client/verta/verta/_internal_utils/_artifact_utils.py
@@ -252,8 +252,8 @@ def serialize_model(model):
         try:  # attempt to deserialize
             reset_stream(model)  # reset cursor to beginning in case user forgot
             model = deserialize_model(model.read())
-        except pickle.UnpicklingError:  # unrecognized model
-            bytestream, _ = ensure_bytestream(model)  # pass along file-like
+        except:  # unrecognized model
+            bytestream = model
             method = None
             model_type = "custom"
         finally:

--- a/client/verta/verta/_internal_utils/_artifact_utils.py
+++ b/client/verta/verta/_internal_utils/_artifact_utils.py
@@ -252,7 +252,7 @@ def serialize_model(model):
         try:  # attempt to deserialize
             reset_stream(model)  # reset cursor to beginning in case user forgot
             model = deserialize_model(model.read())
-        except:  # unrecognized model
+        except (TypeError, pickle.UnpicklingError):  # unrecognized model
             bytestream = model
             method = None
             model_type = "custom"

--- a/client/verta/verta/_internal_utils/_artifact_utils.py
+++ b/client/verta/verta/_internal_utils/_artifact_utils.py
@@ -463,12 +463,12 @@ def zip_dir(dirpath):
 
     os.path.expanduser(dirpath)
 
-    with tempfile.NamedTemporaryFile(suffix=".zip") as tempf:
-        with zipfile.ZipFile(tempf, 'w') as zipf:
-            for root, _, files in os.walk(dirpath):
-                for filename in files:
-                    filepath = os.path.join(root, filename)
-                    zipf.write(filepath, os.path.relpath(filepath, dirpath))
+    tempf = tempfile.NamedTemporaryFile(suffix=".zip")
+    with zipfile.ZipFile(tempf, 'w') as zipf:
+        for root, _, files in os.walk(dirpath):
+            for filename in files:
+                filepath = os.path.join(root, filename)
+                zipf.write(filepath, os.path.relpath(filepath, dirpath))
 
-        tempf.seek(0)
-        return tempf
+    tempf.seek(0)
+    return tempf

--- a/client/verta/verta/_tracking/experimentrun.py
+++ b/client/verta/verta/_tracking/experimentrun.py
@@ -1422,14 +1422,9 @@ class ExperimentRun(_DeployableEntity):
         _artifact_utils.validate_key(key)
         _utils.validate_flat_key(key)
 
-        try:
-            extension = _artifact_utils.get_file_ext(artifact)
-        except (TypeError, ValueError):
-            extension = None
-
         # zip if `artifact` is directory path
         if isinstance(artifact, six.string_types) and os.path.isdir(artifact):
-            tempf = tempfile.TemporaryFile()
+            tempf = tempfile.NamedTemporaryFile(suffix=".zip")
 
             with zipfile.ZipFile(tempf, 'w') as zipf:
                 for root, _, files in os.walk(artifact):
@@ -1439,7 +1434,11 @@ class ExperimentRun(_DeployableEntity):
             tempf.seek(0)
 
             artifact = tempf
-            extension = 'zip'
+
+        try:
+            extension = _artifact_utils.get_file_ext(artifact)
+        except (TypeError, ValueError):
+            extension = None
 
         self._log_artifact(key, artifact, _CommonCommonService.ArtifactTypeEnum.BLOB, extension, overwrite=overwrite)
 

--- a/client/verta/verta/_tracking/experimentrun.py
+++ b/client/verta/verta/_tracking/experimentrun.py
@@ -1187,15 +1187,10 @@ class ExperimentRun(_DeployableEntity):
             self._log_artifact("train_data", train_data, _CommonCommonService.ArtifactTypeEnum.DATA, 'csv')
 
     def log_tf_saved_model(self, export_dir):
-        with tempfile.TemporaryFile() as tempf:
-            with zipfile.ZipFile(tempf, 'w') as zipf:
-                for root, _, files in os.walk(export_dir):
-                    for filename in files:
-                        filepath = os.path.join(root, filename)
-                        zipf.write(filepath, os.path.relpath(filepath, export_dir))
-            tempf.seek(0)
-            # TODO: change _log_artifact() to not read file into memory
-            self._log_artifact("tf_saved_model", tempf, _CommonCommonService.ArtifactTypeEnum.BLOB, 'zip')
+        tempf = _artifact_utils.zip_dir(export_dir)
+
+        # TODO: change _log_artifact() to not read file into memory
+        self._log_artifact("tf_saved_model", tempf, _CommonCommonService.ArtifactTypeEnum.BLOB, 'zip')
 
     def log_model(self, model, custom_modules=None, model_api=None, artifacts=None, overwrite=False):
         """

--- a/client/verta/verta/_tracking/experimentrun.py
+++ b/client/verta/verta/_tracking/experimentrun.py
@@ -1424,16 +1424,7 @@ class ExperimentRun(_DeployableEntity):
 
         # zip if `artifact` is directory path
         if isinstance(artifact, six.string_types) and os.path.isdir(artifact):
-            tempf = tempfile.NamedTemporaryFile(suffix=".zip")
-
-            with zipfile.ZipFile(tempf, 'w') as zipf:
-                for root, _, files in os.walk(artifact):
-                    for filename in files:
-                        filepath = os.path.join(root, filename)
-                        zipf.write(filepath, os.path.relpath(filepath, artifact))
-            tempf.seek(0)
-
-            artifact = tempf
+            artifact = _artifact_utils.zip_dir(artifact)
 
         try:
             extension = _artifact_utils.get_file_ext(artifact)


### PR DESCRIPTION
It works for `model_version.log_model()` too!
But _not_ for `log_artifact()` (the specialized model-object-handling logic is only in the `log_model()` path).