### PR TITLE
VR-9732: Remove "file:" prefix from path datasets

### DIFF
--- a/client/verta/tests/test_versioning/test_dataset.py
+++ b/client/verta/tests/test_versioning/test_dataset.py
@@ -1,7 +1,7 @@
+import itertools
 import os
 import shutil
 import pathlib2
-import tempfile
 
 import pytest
 from .. import utils
@@ -434,6 +434,20 @@ class TestPath:
 
         with pytest.raises(ValueError):
             dataset.add("test_versioning/test_dataset.py")
+
+    def test_file_scheme(self):
+        filepaths = list(map(os.path.abspath, os.listdir(".")))
+        prefixes = itertools.cycle({"file://", "file:", ""})
+        prefixed_filepaths = (
+            prefix + filepath
+            for prefix, filepath
+            in zip(prefixes, filepaths)
+        )
+
+        dataset1 = verta.dataset.Path(filepaths)
+        dataset2 = verta.dataset.Path(prefixed_filepaths)
+
+        assert set(dataset1.list_paths()) == set(dataset2.list_paths())
 
 
 @pytest.mark.usefixtures("with_boto3", "in_tempdir")

--- a/client/verta/verta/_internal_utils/_file_utils.py
+++ b/client/verta/verta/_internal_utils/_file_utils.py
@@ -103,10 +103,16 @@ def remove_prefix_dir(path, prefix_dir):
         prefix_dir += '/'
 
     if path.startswith(prefix_dir):
-        path = path[len(prefix_dir):]
+        path = remove_prefix(path, prefix_dir)
         path = path.lstrip('/')  # remove leading slashes, e.g. for "s3:"
 
     return path
+
+
+def remove_prefix(s, prefix):
+    if s.startswith(prefix):
+        return s[len(prefix):]
+    return s
 
 
 def walk_files(dirpath):

--- a/client/verta/verta/dataset/_path.py
+++ b/client/verta/verta/dataset/_path.py
@@ -121,6 +121,16 @@ class Path(_dataset._Dataset):
         """
         Removes the "file" scheme from `path`, if present.
 
+        Parameters
+        ----------
+        path : str
+            Filepath.
+
+        Returns
+        -------
+        str
+            `path` without "file" scheme.
+
         References
         ----------
         .. [1] https://en.wikipedia.org/wiki/File_URI_scheme

--- a/client/verta/verta/dataset/_path.py
+++ b/client/verta/verta/dataset/_path.py
@@ -62,9 +62,7 @@ class Path(_dataset._Dataset):
             paths = [paths]
         paths = map(os.path.expanduser, paths)
 
-        # remove "file:" scheme
-        paths = map(lambda path: _file_utils.remove_prefix(path, "file://"), paths)
-        paths = map(lambda path: _file_utils.remove_prefix(path, "file:"), paths)
+        paths = map(self._remove_file_scheme, paths)
 
         filepaths = _file_utils.flatten_file_trees(paths)
         components = list(map(self._file_to_component, filepaths))
@@ -117,6 +115,21 @@ class Path(_dataset._Dataset):
             last_modified=_utils.timestamp_to_ms(os.stat(filepath).st_mtime),
             md5=self._hash_file(filepath),
         )
+
+    @staticmethod
+    def _remove_file_scheme(path):
+        """
+        Removes the "file" scheme from `path`, if present.
+
+        References
+        ----------
+        .. [1] https://en.wikipedia.org/wiki/File_URI_scheme
+
+        """
+        path = _file_utils.remove_prefix(path, "file://")
+        path = _file_utils.remove_prefix(path, "file:")
+
+        return path
 
     # TODO: move to _file_utils.calc_md5()
     def _hash_file(self, filepath):

--- a/client/verta/verta/dataset/_path.py
+++ b/client/verta/verta/dataset/_path.py
@@ -62,6 +62,10 @@ class Path(_dataset._Dataset):
             paths = [paths]
         paths = map(os.path.expanduser, paths)
 
+        # remove "file:" scheme
+        paths = map(lambda path: _file_utils.remove_prefix(path, "file://"), paths)
+        paths = map(lambda path: _file_utils.remove_prefix(path, "file:"), paths)
+
         filepaths = _file_utils.flatten_file_trees(paths)
         components = list(map(self._file_to_component, filepaths))
 


### PR DESCRIPTION
There's actually an [entire Wikipedia article](https://en.wikipedia.org/wiki/File_URI_scheme) dedicated to explaining what the number of slashes after `file:` means.

I spent way too long trying to find a smart or stdlib way to do this, and there doesn't seem to be one! I think this works.