### PR TITLE
Don't tear down client_2.proj and client_3.proj

### DIFF
--- a/client/verta/tests/conftest.py
+++ b/client/verta/tests/conftest.py
@@ -313,12 +313,7 @@ def client_2(host, port, email_2, dev_key_2, created_entities):
 
     client = Client(host, port, email_2, dev_key_2, debug=True)
 
-    yield client
-
-    proj = client._ctx.proj
-    if (proj is not None
-            and proj.id not in {entity.id for entity in created_entities}):
-        proj.delete()
+    return client
 
 
 @pytest.fixture
@@ -329,12 +324,7 @@ def client_3(host, port, email_3, dev_key_3, created_entities):
 
     client = Client(host, port, email_3, dev_key_3, debug=True)
 
-    yield client
-
-    proj = client._ctx.proj
-    if (proj is not None
-            and proj.id not in {entity.id for entity in created_entities}):
-        proj.delete()
+    return client
 
 
 @pytest.fixture


### PR DESCRIPTION
I recently added these teardown steps, and they're causing issues because if `client_2` `get`s `client`'s read-only project, the teardown raises an error since `client_2` can't delete it.

`client_2` and `client_3` are only used in permissions tests, so this is likely to be the case going forward. I'm just going to remove these teardown steps, since new tests are also diligent about using `created_entities` anyway.