### PR TITLE
Facilitate 3.9 tests

### DIFF
--- a/client/verta/requirements.txt
+++ b/client/verta/requirements.txt
@@ -27,7 +27,7 @@ scipy>=1.4; python_version >= '3.8'
 spacy!=2.3.1,<2.3.3; python_version < '3.6'  # https://github.com/explosion/spaCy/issues/5729, https://github.com/explosion/spaCy/issues/6454
 spacy; python_version >= '3.6'
 tensorflow<2.0; python_version < '3.8'
-tensorflow>=2.2; python_version == '3.8'  # https://www.tensorflow.org/install/pip
+tensorflow>=2.2; python_version >= '3.8' and python_version < '3.9'  # https://www.tensorflow.org/install/pip
 torch
 xgboost
 

--- a/client/verta/requirements.txt
+++ b/client/verta/requirements.txt
@@ -14,7 +14,7 @@ pytest>=4.3
 # unit testing dependencies
 boto3
 google-cloud-bigquery
-h5py<3.0.0  # https://github.com/tensorflow/tensorflow/issues/44467
+h5py<3.0.0; python_version < '3.9'  # https://github.com/tensorflow/tensorflow/issues/44467
 matplotlib<3.0; python_version < '3.8'
 matplotlib>=3.2; python_version >= '3.8'
 numpy<1.17

--- a/client/verta/requirements.txt
+++ b/client/verta/requirements.txt
@@ -19,7 +19,7 @@ matplotlib<3.0; python_version < '3.8'
 matplotlib>=3.2; python_version >= '3.8'
 numpy<1.17
 pandas
-pillow<7.0
+pillow
 scikit-learn<0.21; python_version < '3.8'  # https://scikit-learn.org/stable/install.html
 scikit-learn>=0.22; python_version >= '3.8'
 scipy<1.3; python_version < '3.8'


### PR DESCRIPTION
- `pillow<7.0` means Py3.9 requires a source installation, which requires zlib, which test containers don't have. The constraint was only set because 7.0 dropped support for Py2, which means it's a bit redundant.
- skip `h5py` because Debian requires an `apt` installation, and we don't need it without Tensorflow anyway