### PR TITLE
Consolidate data dirs for docker-compose and add to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,10 @@ __pycache__/
 .DS_Store
 .ipynb
 .vscode
+
+# ignore dirs created and used by docker-compose modeldb-backend
+data
+
+# ignore Python dev tool files and dirs
+**/.python-version
+**/.ropeproject

--- a/docker-compose-all.yaml
+++ b/docker-compose-all.yaml
@@ -15,7 +15,7 @@ services:
             - VERTA_MODELDB_CONFIG:/config/config.yaml
         volumes:
             - ./backend/config:/config/
-            - ./artifact-store:/artifact-store/
+            - ./data/artifact-store:/artifact-store/
 
     modeldb-proxy:
         image: vertaaiofficial/modeldb-proxy:2.0.8.1
@@ -78,7 +78,7 @@ services:
         networks:
             - modeldb_network
         volumes:
-            - ./data:/var/lib/postgresql/data/pgdata
+            - ./data/pgdata:/var/lib/postgresql/data/pgdata
 
 networks:
   modeldb_network:


### PR DESCRIPTION
- Updates `docker-compose-all.yaml` to put both the `artifact-store` and `pgdata` directories in `data`
- Adds `data` folder to `.gitignore`
- Adds some Python dev tool files to the `.gitignore` 

### Testing

- Ran `docker-compose` and confirmed that a usable environment stands up, with the data dirs created as intended