### PR TITLE
VR-9939: Make log_model() output less confusing for a user when logging arbitrary model

### DIFF
--- a/client/verta/tests/test_artifacts.py
+++ b/client/verta/tests/test_artifacts.py
@@ -521,8 +521,8 @@ class TestArbitraryModels:
     @staticmethod
     def _assert_no_deployment_artifacts(experiment_run):
         artifact_keys = experiment_run.get_artifact_keys()
-        assert 'custom_modules' not in artifact_keys
-        assert 'model_api.json' not in artifact_keys
+        assert _artifact_utils.CUSTOM_MODULES_KEY not in artifact_keys
+        assert _artifact_utils.MODEL_API_KEY not in artifact_keys
 
     def test_arbitrary_file(self, experiment_run, random_data):
         with tempfile.TemporaryFile() as f:

--- a/client/verta/tests/test_artifacts.py
+++ b/client/verta/tests/test_artifacts.py
@@ -529,7 +529,7 @@ class TestArbitraryModels:
             f.write(random_data)
             f.seek(0)
 
-            experiment_run.log_model(f, custom_modules=[])
+            experiment_run.log_model(f)
 
         assert experiment_run.get_model().read() == random_data
 
@@ -538,7 +538,7 @@ class TestArbitraryModels:
     def test_arbitrary_directory(self, experiment_run, dir_and_files):
         dirpath, filepaths = dir_and_files
 
-        experiment_run.log_model(dirpath, custom_modules=[])
+        experiment_run.log_model(dirpath)
 
         with zipfile.ZipFile(experiment_run.get_model(), 'r') as zipf:
             assert set(zipf.namelist()) == filepaths
@@ -548,7 +548,7 @@ class TestArbitraryModels:
     def test_arbitrary_object(self, experiment_run):
         model = {'a': 1}
 
-        experiment_run.log_model(model, custom_modules=[])
+        experiment_run.log_model(model)
 
         assert experiment_run.get_model() == model
 

--- a/client/verta/tests/test_cli/test_registry.py
+++ b/client/verta/tests/test_cli/test_registry.py
@@ -254,7 +254,7 @@ class TestCreate:
                 "type": "torch",
                 "python_version": "2.7.17"
             }
-            model_version.log_artifact("model_api.json", model_api, True, "json")
+            model_version.log_artifact(_artifact_utils.MODEL_API_KEY, model_api, True, "json")
 
             path = _utils.generate_default_name()
             endpoint = client.set_endpoint(path)

--- a/client/verta/tests/test_cli/test_registry.py
+++ b/client/verta/tests/test_cli/test_registry.py
@@ -10,7 +10,10 @@ from verta import Client
 from verta._cli import cli
 from verta._cli.registry.update import add_attributes
 from verta._registry import RegisteredModel
-from verta._internal_utils import _utils
+from verta._internal_utils import (
+    _artifact_utils,
+    _utils,
+)
 from verta.environment import Python
 from verta.utils import ModelAPI
 from verta.endpoint.update._strategies import DirectUpdateStrategy
@@ -630,7 +633,8 @@ class TestUpdate:
 
         custom_module_filenames = {"__init__.py", "_verta_config.py"}
         model_version = registered_model.get_version(name=version_name)
-        with zipfile.ZipFile(model_version.get_artifact("custom_modules"), 'r') as zipf:
+        custom_modules = model_version.get_artifact(_artifact_utils.CUSTOM_MODULES_KEY)
+        with zipfile.ZipFile(custom_modules, 'r') as zipf:
             assert custom_module_filenames == set(map(os.path.basename, zipf.namelist()))
 
 

--- a/client/verta/tests/test_deployment.py
+++ b/client/verta/tests/test_deployment.py
@@ -49,7 +49,7 @@ class TestLogModelForDeployment:
     def test_model_api(self, experiment_run, model_for_deployment):
         experiment_run.log_model_for_deployment(**model_for_deployment)
         retrieved_model_api = verta.utils.ModelAPI.from_file(
-            experiment_run.get_artifact("model_api.json"))
+            experiment_run.get_artifact(_artifact_utils.MODEL_API_KEY))
 
         assert all(item in six.viewitems(retrieved_model_api.to_dict())
                    for item in six.viewitems(model_for_deployment['model_api'].to_dict()))
@@ -128,7 +128,8 @@ class TestLogModel:
         model_api.update({
             'model_packaging': model_packaging,
         })
-        assert model_api == json.loads(six.ensure_str(experiment_run.get_artifact('model_api.json').read()))
+        assert model_api == json.loads(six.ensure_str(
+            experiment_run.get_artifact(_artifact_utils.MODEL_API_KEY).read()))
 
     def test_no_model_api(self, experiment_run, model_for_deployment, model_packaging):
         experiment_run.log_model(model_for_deployment['model'])
@@ -137,14 +138,16 @@ class TestLogModel:
             'version': "v1",
             'model_packaging': model_packaging,
         }
-        assert model_api == json.loads(six.ensure_str(experiment_run.get_artifact('model_api.json').read()))
+        assert model_api == json.loads(six.ensure_str(
+            experiment_run.get_artifact(_artifact_utils.MODEL_API_KEY).read()))
 
     def test_model_class(self, experiment_run, model_for_deployment):
         experiment_run.log_model(model_for_deployment['model'].__class__)
 
         assert model_for_deployment['model'].__class__ == experiment_run.get_model()
 
-        retrieved_model_api = verta.utils.ModelAPI.from_file(experiment_run.get_artifact("model_api.json"))
+        retrieved_model_api = verta.utils.ModelAPI.from_file(
+            experiment_run.get_artifact(_artifact_utils.MODEL_API_KEY))
         assert retrieved_model_api.to_dict()['model_packaging']['type'] == "class"
 
     def test_artifacts(self, experiment_run, model_for_deployment, strs, flat_dicts):
@@ -826,13 +829,13 @@ class TestDeploy:
             "DELETE",
             "{}://{}/api/v1/modeldb/experiment-run/deleteArtifact".format(experiment_run._conn.scheme,
                                                               experiment_run._conn.socket),
-            experiment_run._conn, json={'id': experiment_run.id, 'key': "model_api.json"}
+            experiment_run._conn, json={'id': experiment_run.id, 'key': _artifact_utils.MODEL_API_KEY}
         )
         _utils.raise_for_http_error(response)
 
         with pytest.raises(RuntimeError) as excinfo:
             experiment_run.deploy()
-        assert "model_api.json" in str(excinfo.value)
+        assert _artifact_utils.MODEL_API_KEY in str(excinfo.value)
 
         conn = experiment_run._conn
         requests.delete(

--- a/client/verta/tests/test_deployment.py
+++ b/client/verta/tests/test_deployment.py
@@ -90,7 +90,8 @@ class TestLogModel:
 
             custom_module_filenames.update(map(os.path.basename, filenames))
 
-        with zipfile.ZipFile(experiment_run.get_artifact("custom_modules"), 'r') as zipf:
+        custom_modules = experiment_run.get_artifact(_artifact_utils.CUSTOM_MODULES_KEY)
+        with zipfile.ZipFile(custom_modules, 'r') as zipf:
             assert custom_module_filenames == set(map(os.path.basename, zipf.namelist()))
 
     def test_no_custom_modules(self, experiment_run, model_for_deployment):
@@ -113,7 +114,8 @@ class TestLogModel:
                     continue
                 custom_module_filenames.update(map(os.path.basename, filenames))
 
-        with zipfile.ZipFile(experiment_run.get_artifact("custom_modules"), 'r') as zipf:
+        custom_modules = experiment_run.get_artifact(_artifact_utils.CUSTOM_MODULES_KEY)
+        with zipfile.ZipFile(custom_modules, 'r') as zipf:
             assert custom_module_filenames == set(map(os.path.basename, zipf.namelist()))
 
     def test_model_api(self, experiment_run, model_for_deployment, model_packaging):

--- a/client/verta/tests/test_model_registry/test_model_version.py
+++ b/client/verta/tests/test_model_registry/test_model_version.py
@@ -578,7 +578,7 @@ class TestArbitraryModels:
             f.write(random_data)
             f.seek(0)
 
-            model_version.log_model(f, custom_modules=[])
+            model_version.log_model(f)
 
         assert model_version.get_model().read() == random_data
 
@@ -587,7 +587,7 @@ class TestArbitraryModels:
     def test_arbitrary_directory(self, model_version, dir_and_files):
         dirpath, filepaths = dir_and_files
 
-        model_version.log_model(dirpath, custom_modules=[])
+        model_version.log_model(dirpath)
 
         with zipfile.ZipFile(model_version.get_model(), 'r') as zipf:
             assert set(zipf.namelist()) == filepaths
@@ -597,7 +597,7 @@ class TestArbitraryModels:
     def test_arbitrary_object(self, model_version):
         model = {'a': 1}
 
-        model_version.log_model(model, custom_modules=[])
+        model_version.log_model(model)
 
         assert model_version.get_model() == model
 

--- a/client/verta/tests/test_model_registry/test_model_version.py
+++ b/client/verta/tests/test_model_registry/test_model_version.py
@@ -22,7 +22,10 @@ import verta.dataset
 from verta.environment import Python
 from verta._tracking.deployable_entity import _CACHE_DIR
 from verta.endpoint.update import DirectUpdateStrategy
-from verta._internal_utils import _utils
+from verta._internal_utils import (
+    _artifact_utils,
+    _utils,
+)
 
 pytestmark = pytest.mark.not_oss  # skip if run in oss setup. Applied to entire module
 
@@ -473,7 +476,8 @@ class TestDeployability:
                     continue
                 custom_module_filenames.update(map(os.path.basename, filenames))
 
-        with zipfile.ZipFile(model_version.get_artifact("custom_modules"), 'r') as zipf:
+        custom_modules = model_version.get_artifact(_artifact_utils.CUSTOM_MODULES_KEY)
+        with zipfile.ZipFile(custom_modules, 'r') as zipf:
             assert custom_module_filenames == set(map(os.path.basename, zipf.namelist()))
 
     def test_log_model_with_custom_modules(self, model_version, model_for_deployment):
@@ -493,7 +497,8 @@ class TestDeployability:
 
             custom_module_filenames.update(map(os.path.basename, filenames))
 
-        with zipfile.ZipFile(model_version.get_artifact("custom_modules"), 'r') as zipf:
+        custom_modules = model_version.get_artifact(_artifact_utils.CUSTOM_MODULES_KEY)
+        with zipfile.ZipFile(custom_modules, 'r') as zipf:
             assert custom_module_filenames == set(map(os.path.basename, zipf.namelist()))
 
     def test_download_docker_context(self, experiment_run, model_for_deployment, in_tempdir,
@@ -570,8 +575,8 @@ class TestArbitraryModels:
     @staticmethod
     def _assert_no_deployment_artifacts(model_version):
         artifact_keys = model_version.get_artifact_keys()
-        assert 'custom_modules' not in artifact_keys
-        assert 'model_api.json' not in artifact_keys
+        assert _artifact_utils.CUSTOM_MODULES_KEY not in artifact_keys
+        assert _artifact_utils.MODEL_API_KEY not in artifact_keys
 
     def test_arbitrary_file(self, model_version, random_data):
         with tempfile.TemporaryFile() as f:

--- a/client/verta/tests/test_model_registry/test_model_version.py
+++ b/client/verta/tests/test_model_registry/test_model_version.py
@@ -567,6 +567,12 @@ class TestDeployability:
 
 class TestArbitraryModels:
     """Analogous to test_artifacts.TestArbitraryModels."""
+    @staticmethod
+    def _assert_no_deployment_artifacts(model_version):
+        artifact_keys = model_version.get_artifact_keys()
+        assert 'custom_modules' not in artifact_keys
+        assert 'model_api.json' not in artifact_keys
+
     def test_arbitrary_file(self, model_version, random_data):
         with tempfile.TemporaryFile() as f:
             f.write(random_data)
@@ -576,6 +582,8 @@ class TestArbitraryModels:
 
         assert model_version.get_model().read() == random_data
 
+        self._assert_no_deployment_artifacts(model_version)
+
     def test_arbitrary_directory(self, model_version, dir_and_files):
         dirpath, filepaths = dir_and_files
 
@@ -584,9 +592,13 @@ class TestArbitraryModels:
         with zipfile.ZipFile(model_version.get_model(), 'r') as zipf:
             assert set(zipf.namelist()) == filepaths
 
+        self._assert_no_deployment_artifacts(model_version)
+
     def test_arbitrary_object(self, model_version):
         model = {'a': 1}
 
         model_version.log_model(model, custom_modules=[])
 
         assert model_version.get_model() == model
+
+        self._assert_no_deployment_artifacts(model_version)

--- a/client/verta/tests/test_model_registry/test_model_version.py
+++ b/client/verta/tests/test_model_registry/test_model_version.py
@@ -440,9 +440,9 @@ class TestDeployability:
         assert np.array_equal(retrieved_classfier.coef_, original_coef)
 
         # check model api:
-        assert "model_api.json" in model_version.get_artifact_keys()
+        assert _artifact_utils.MODEL_API_KEY in model_version.get_artifact_keys()
         for artifact in model_version._msg.artifacts:
-            if artifact.key == "model_api.json":
+            if artifact.key == _artifact_utils.MODEL_API_KEY:
                 assert artifact.filename_extension == "json"
 
         # overwrite should work:

--- a/client/verta/verta/_internal_utils/_artifact_utils.py
+++ b/client/verta/verta/_internal_utils/_artifact_utils.py
@@ -267,7 +267,9 @@ def serialize_model(model):
             reset_stream(model)  # reset cursor to beginning in case user forgot
             model = deserialize_model(model.read())
         except (TypeError, pickle.UnpicklingError):  # unrecognized model
-            return model, None, None
+            bytestream = model
+            method = None
+            model_type = "custom"
         finally:
             reset_stream(model)  # reset cursor to beginning as a courtesy
 

--- a/client/verta/verta/_internal_utils/_artifact_utils.py
+++ b/client/verta/verta/_internal_utils/_artifact_utils.py
@@ -260,9 +260,7 @@ def serialize_model(model):
             reset_stream(model)  # reset cursor to beginning in case user forgot
             model = deserialize_model(model.read())
         except (TypeError, pickle.UnpicklingError):  # unrecognized model
-            bytestream = model
-            method = None
-            model_type = "custom"
+            return model, None, None
         finally:
             reset_stream(model)  # reset cursor to beginning as a courtesy
 

--- a/client/verta/verta/_internal_utils/_artifact_utils.py
+++ b/client/verta/verta/_internal_utils/_artifact_utils.py
@@ -26,15 +26,17 @@ ZIP_EXTENSION = "dir.zip"
 
 
 # NOTE: keep up-to-date with Deployment API
+CUSTOM_MODULES_KEY = "custom_modules"
 MODEL_KEY = "model.pkl"
+MODEL_API_KEY = "model_api.json"
 # TODO: maybe bind constants for other keys used throughout client
 BLOCKLISTED_KEYS = {
+    CUSTOM_MODULES_KEY,
     MODEL_KEY,
-    'model_api.json',
+    MODEL_API_KEY,
     'requirements.txt',
     'train_data',
     'tf_saved_model',
-    'custom_modules',
     'setup_script',
 }
 

--- a/client/verta/verta/_registry/modelversion.py
+++ b/client/verta/verta/_registry/modelversion.py
@@ -253,7 +253,6 @@ class RegisteredModelVersion(_DeployableEntity):
         self._update(model_version_update)
 
         # Upload the artifact to ModelDB:
-        print("uploading model")
         self._upload_artifact(
             "model", serialized_model,
             _CommonCommonService.ArtifactTypeEnum.MODEL,
@@ -356,7 +355,6 @@ class RegisteredModelVersion(_DeployableEntity):
             self._msg.artifacts[same_key_ind].CopyFrom(artifact_msg)
 
         self._update(self._msg, method="PUT")
-        print("uploading {}".format(key))
         self._upload_artifact(key, artifact_stream, artifact_type=artifact_type)
 
     def get_artifact(self, key):
@@ -513,6 +511,7 @@ class RegisteredModelVersion(_DeployableEntity):
         # check if multipart upload ok
         url_for_artifact = self._get_url_for_artifact(key, "PUT", artifact_type, part_num=1)
 
+        print("uploading {} to Registry".format(key))
         if url_for_artifact.multipart_upload_ok:
             # TODO: parallelize this
             file_parts = iter(lambda: file_handle.read(part_size), b'')

--- a/client/verta/verta/_registry/modelversion.py
+++ b/client/verta/verta/_registry/modelversion.py
@@ -216,6 +216,9 @@ class RegisteredModelVersion(_DeployableEntity):
         if self.has_model and not overwrite:
             raise ValueError("model already exists; consider setting overwrite=True")
 
+        if model_api and not isinstance(model_api, utils.ModelAPI):
+            raise ValueError(
+                "`model_api` must be `verta.utils.ModelAPI`, not {}".format(type(model_api)))
         if (artifacts is not None
                 and not (isinstance(artifacts, list)
                          and all(isinstance(artifact_key, six.string_types) for artifact_key in artifacts))):
@@ -242,8 +245,10 @@ class RegisteredModelVersion(_DeployableEntity):
             extension = _artifact_utils.ext_from_method(method)
 
         # Create artifact message and update ModelVersion's message:
-        model_msg = self._create_artifact_msg("model", serialized_model,
-                                        artifact_type=_CommonCommonService.ArtifactTypeEnum.MODEL, extension=extension)
+        model_msg = self._create_artifact_msg(
+            "model", serialized_model,
+            artifact_type=_CommonCommonService.ArtifactTypeEnum.MODEL, extension=extension,
+        )
         model_version_update = self.ModelVersionMessage(model=model_msg)
         self._update(model_version_update)
 
@@ -253,23 +258,24 @@ class RegisteredModelVersion(_DeployableEntity):
             _CommonCommonService.ArtifactTypeEnum.MODEL,
         )
 
-        # Log modules:
-        custom_modules_artifact = self._custom_modules_as_artifact(custom_modules)
-        self.log_artifact("custom_modules", custom_modules_artifact, overwrite, 'zip')
+        # create and upload model API
+        if model_type or model_api:  # only if provided or model is deployable
+            if model_api is None:
+                model_api = utils.ModelAPI()
+            if 'model_packaging' not in model_api:
+                # add model serialization info to model_api
+                model_api['model_packaging'] = {
+                    'python_version': _utils.get_python_version(),
+                    'type': model_type,
+                    'deserialization': method,
+                }
+            self.log_artifact("model_api.json", model_api, overwrite, "json")
 
-        # build model API
-        if model_api is None:
-            model_api = utils.ModelAPI()
-        elif not isinstance(model_api, utils.ModelAPI):
-            raise ValueError("`model_api` must be `verta.utils.ModelAPI`, not {}".format(type(model_api)))
-        if 'model_packaging' not in model_api:
-            # add model serialization info to model_api
-            model_api['model_packaging'] = {
-                'python_version': _utils.get_python_version(),
-                'type': model_type,
-                'deserialization': method,
-            }
-        self.log_artifact("model_api.json", model_api, overwrite, "json")
+        # create and upload custom modules
+        if model_type or custom_modules:  # only if provided or model is deployable
+            # Log modules:
+            custom_modules_artifact = self._custom_modules_as_artifact(custom_modules)
+            self.log_artifact("custom_modules", custom_modules_artifact, overwrite, 'zip')
 
     def get_model(self):
         """

--- a/client/verta/verta/_registry/modelversion.py
+++ b/client/verta/verta/_registry/modelversion.py
@@ -253,6 +253,7 @@ class RegisteredModelVersion(_DeployableEntity):
         self._update(model_version_update)
 
         # Upload the artifact to ModelDB:
+        print("uploading model")
         self._upload_artifact(
             "model", serialized_model,
             _CommonCommonService.ArtifactTypeEnum.MODEL,
@@ -355,6 +356,7 @@ class RegisteredModelVersion(_DeployableEntity):
             self._msg.artifacts[same_key_ind].CopyFrom(artifact_msg)
 
         self._update(self._msg, method="PUT")
+        print("uploading {}".format(key))
         self._upload_artifact(key, artifact_stream, artifact_type=artifact_type)
 
     def get_artifact(self, key):
@@ -511,7 +513,6 @@ class RegisteredModelVersion(_DeployableEntity):
         # check if multipart upload ok
         url_for_artifact = self._get_url_for_artifact(key, "PUT", artifact_type, part_num=1)
 
-        print("uploading {} to Registry".format(key))
         if url_for_artifact.multipart_upload_ok:
             # TODO: parallelize this
             file_parts = iter(lambda: file_handle.read(part_size), b'')

--- a/client/verta/verta/_registry/modelversion.py
+++ b/client/verta/verta/_registry/modelversion.py
@@ -275,7 +275,8 @@ class RegisteredModelVersion(_DeployableEntity):
         if model_type or custom_modules:  # only if provided or model is deployable
             # Log modules:
             custom_modules_artifact = self._custom_modules_as_artifact(custom_modules)
-            self.log_artifact("custom_modules", custom_modules_artifact, overwrite, 'zip')
+            self.log_artifact(_artifact_utils.CUSTOM_MODULES_KEY, custom_modules_artifact,
+                              overwrite, 'zip')
 
     def get_model(self):
         """

--- a/client/verta/verta/_registry/modelversion.py
+++ b/client/verta/verta/_registry/modelversion.py
@@ -269,7 +269,7 @@ class RegisteredModelVersion(_DeployableEntity):
                     'type': model_type,
                     'deserialization': method,
                 }
-            self.log_artifact("model_api.json", model_api, overwrite, "json")
+            self.log_artifact(_artifact_utils.MODEL_API_KEY, model_api, overwrite, "json")
 
         # create and upload custom modules
         if model_type or custom_modules:  # only if provided or model is deployable

--- a/client/verta/verta/_tracking/experimentrun.py
+++ b/client/verta/verta/_tracking/experimentrun.py
@@ -365,7 +365,10 @@ class ExperimentRun(_DeployableEntity):
                     "PUT", url_for_artifact.url, self._conn, data=artifact_stream)
             _utils.raise_for_http_error(response)
 
-        print("upload complete ({})".format(key))
+        if key is _artifact_utils.MODEL_KEY:
+            print("model upload complete")
+        else:
+            print("upload complete ({})".format(key))
 
     def _log_artifact_path(self, key, artifact_path, artifact_type, overwrite=False):
         """

--- a/client/verta/verta/_tracking/experimentrun.py
+++ b/client/verta/verta/_tracking/experimentrun.py
@@ -365,7 +365,7 @@ class ExperimentRun(_DeployableEntity):
                     "PUT", url_for_artifact.url, self._conn, data=artifact_stream)
             _utils.raise_for_http_error(response)
 
-        print("upload complete")
+        print("upload complete ({})".format(key))
 
     def _log_artifact_path(self, key, artifact_path, artifact_type, overwrite=False):
         """
@@ -1253,14 +1253,11 @@ class ExperimentRun(_DeployableEntity):
         else:
             train_data = None
 
-        print("uploading model")
         self._log_artifact(
             "model.pkl", model, _CommonCommonService.ArtifactTypeEnum.MODEL, model_extension, method)
-        print("uploading model API")
         self._log_artifact("model_api.json", model_api,
                             _CommonCommonService.ArtifactTypeEnum.BLOB, 'json')
         if train_data is not None:
-            print("uploading training data")
             self._log_artifact("train_data", train_data,
                                _CommonCommonService.ArtifactTypeEnum.DATA, 'csv')
 
@@ -1268,7 +1265,6 @@ class ExperimentRun(_DeployableEntity):
         tempf = _artifact_utils.zip_dir(export_dir)
 
         # TODO: change _log_artifact() to not read file into memory
-        print("uploading {}".format(export_dir))
         self._log_artifact("tf_saved_model", tempf,
                            _CommonCommonService.ArtifactTypeEnum.BLOB, 'zip')
 
@@ -1358,19 +1354,16 @@ class ExperimentRun(_DeployableEntity):
                 print("[DEBUG] model API is:")
                 pprint.pprint(model_api.to_dict())
 
-            print("uploading model API")
             self._log_artifact("model_api.json", model_api,
                                _CommonCommonService.ArtifactTypeEnum.BLOB, 'json', overwrite=overwrite)
 
         # create and upload custom modules
         if model_type or custom_modules:  # only if provided or model is deployable
             custom_modules_artifact = self._custom_modules_as_artifact(custom_modules)
-            print("uploading custom modules")
             self._log_artifact("custom_modules", custom_modules_artifact,
                                _CommonCommonService.ArtifactTypeEnum.BLOB, 'zip', overwrite=overwrite)
 
         # upload model
-        print("uploading model")
         self._log_artifact("model.pkl", serialized_model,
                            _CommonCommonService.ArtifactTypeEnum.MODEL, extension, method, overwrite=overwrite)
 
@@ -1433,7 +1426,6 @@ class ExperimentRun(_DeployableEntity):
             bytestream.seek(0)
             image = bytestream
 
-        print("uploading {}".format(key))
         self._log_artifact(
             key, image, _CommonCommonService.ArtifactTypeEnum.IMAGE, extension, overwrite=overwrite)
 
@@ -1522,7 +1514,6 @@ class ExperimentRun(_DeployableEntity):
         except (TypeError, ValueError):
             extension = None
 
-        print("uploading {}".format(key))
         self._log_artifact(
             key, artifact, _CommonCommonService.ArtifactTypeEnum.BLOB, extension, overwrite=overwrite)
 
@@ -1879,7 +1870,6 @@ class ExperimentRun(_DeployableEntity):
         python_env = Python(copy.copy(requirements))
         requirements = six.BytesIO(six.ensure_binary(
             '\n'.join(requirements)))  # as file-like
-        print("uploading requirements")
         self._log_artifact("requirements.txt", requirements,
                            _CommonCommonService.ArtifactTypeEnum.BLOB, 'txt', overwrite=overwrite)
         try:
@@ -1967,7 +1957,6 @@ class ExperimentRun(_DeployableEntity):
                           category=FutureWarning)
 
         custom_modules_artifact = self._custom_modules_as_artifact(paths)
-        print("uploading custom modules")
         self._log_artifact("custom_modules", custom_modules_artifact,
                            _CommonCommonService.ArtifactTypeEnum.BLOB, 'zip')
 
@@ -2009,7 +1998,6 @@ class ExperimentRun(_DeployableEntity):
         # convert to file-like for `_log_artifact()`
         script = six.BytesIO(script)
 
-        print("uploading setup script")
         self._log_artifact(
             "setup_script", script, _CommonCommonService.ArtifactTypeEnum.BLOB, 'py', overwrite=overwrite)
 

--- a/client/verta/verta/_tracking/experimentrun.py
+++ b/client/verta/verta/_tracking/experimentrun.py
@@ -1255,7 +1255,7 @@ class ExperimentRun(_DeployableEntity):
 
         self._log_artifact(
             _artifact_utils.MODEL_KEY, model, _CommonCommonService.ArtifactTypeEnum.MODEL, model_extension, method)
-        self._log_artifact("model_api.json", model_api,
+        self._log_artifact(_artifact_utils.MODEL_API_KEY, model_api,
                            _CommonCommonService.ArtifactTypeEnum.BLOB, 'json')
         if train_data is not None:
             self._log_artifact("train_data", train_data,
@@ -1354,7 +1354,7 @@ class ExperimentRun(_DeployableEntity):
                 print("[DEBUG] model API is:")
                 pprint.pprint(model_api.to_dict())
 
-            self._log_artifact("model_api.json", model_api,
+            self._log_artifact(_artifact_utils.MODEL_API_KEY, model_api,
                                _CommonCommonService.ArtifactTypeEnum.BLOB, 'json', overwrite=overwrite)
 
         # create and upload custom modules

--- a/client/verta/verta/_tracking/experimentrun.py
+++ b/client/verta/verta/_tracking/experimentrun.py
@@ -365,7 +365,7 @@ class ExperimentRun(_DeployableEntity):
                     "PUT", url_for_artifact.url, self._conn, data=artifact_stream)
             _utils.raise_for_http_error(response)
 
-        print("upload complete ({})".format(key))
+        print("upload complete")
 
     def _log_artifact_path(self, key, artifact_path, artifact_type, overwrite=False):
         """
@@ -1253,11 +1253,14 @@ class ExperimentRun(_DeployableEntity):
         else:
             train_data = None
 
+        print("uploading model")
         self._log_artifact(
             "model.pkl", model, _CommonCommonService.ArtifactTypeEnum.MODEL, model_extension, method)
+        print("uploading model API")
         self._log_artifact("model_api.json", model_api,
                             _CommonCommonService.ArtifactTypeEnum.BLOB, 'json')
         if train_data is not None:
+            print("uploading training data")
             self._log_artifact("train_data", train_data,
                                _CommonCommonService.ArtifactTypeEnum.DATA, 'csv')
 
@@ -1265,6 +1268,7 @@ class ExperimentRun(_DeployableEntity):
         tempf = _artifact_utils.zip_dir(export_dir)
 
         # TODO: change _log_artifact() to not read file into memory
+        print("uploading {}".format(export_dir))
         self._log_artifact("tf_saved_model", tempf,
                            _CommonCommonService.ArtifactTypeEnum.BLOB, 'zip')
 
@@ -1354,16 +1358,19 @@ class ExperimentRun(_DeployableEntity):
                 print("[DEBUG] model API is:")
                 pprint.pprint(model_api.to_dict())
 
+            print("uploading model API")
             self._log_artifact("model_api.json", model_api,
                                _CommonCommonService.ArtifactTypeEnum.BLOB, 'json', overwrite=overwrite)
 
         # create and upload custom modules
         if model_type or custom_modules:  # only if provided or model is deployable
             custom_modules_artifact = self._custom_modules_as_artifact(custom_modules)
+            print("uploading custom modules")
             self._log_artifact("custom_modules", custom_modules_artifact,
                                _CommonCommonService.ArtifactTypeEnum.BLOB, 'zip', overwrite=overwrite)
 
         # upload model
+        print("uploading model")
         self._log_artifact("model.pkl", serialized_model,
                            _CommonCommonService.ArtifactTypeEnum.MODEL, extension, method, overwrite=overwrite)
 
@@ -1426,6 +1433,7 @@ class ExperimentRun(_DeployableEntity):
             bytestream.seek(0)
             image = bytestream
 
+        print("uploading {}".format(key))
         self._log_artifact(
             key, image, _CommonCommonService.ArtifactTypeEnum.IMAGE, extension, overwrite=overwrite)
 
@@ -1514,6 +1522,7 @@ class ExperimentRun(_DeployableEntity):
         except (TypeError, ValueError):
             extension = None
 
+        print("uploading {}".format(key))
         self._log_artifact(
             key, artifact, _CommonCommonService.ArtifactTypeEnum.BLOB, extension, overwrite=overwrite)
 
@@ -1870,6 +1879,7 @@ class ExperimentRun(_DeployableEntity):
         python_env = Python(copy.copy(requirements))
         requirements = six.BytesIO(six.ensure_binary(
             '\n'.join(requirements)))  # as file-like
+        print("uploading requirements")
         self._log_artifact("requirements.txt", requirements,
                            _CommonCommonService.ArtifactTypeEnum.BLOB, 'txt', overwrite=overwrite)
         try:
@@ -1957,6 +1967,7 @@ class ExperimentRun(_DeployableEntity):
                           category=FutureWarning)
 
         custom_modules_artifact = self._custom_modules_as_artifact(paths)
+        print("uploading custom modules")
         self._log_artifact("custom_modules", custom_modules_artifact,
                            _CommonCommonService.ArtifactTypeEnum.BLOB, 'zip')
 
@@ -1998,6 +2009,7 @@ class ExperimentRun(_DeployableEntity):
         # convert to file-like for `_log_artifact()`
         script = six.BytesIO(script)
 
+        print("uploading setup script")
         self._log_artifact(
             "setup_script", script, _CommonCommonService.ArtifactTypeEnum.BLOB, 'py', overwrite=overwrite)
 

--- a/client/verta/verta/_tracking/experimentrun.py
+++ b/client/verta/verta/_tracking/experimentrun.py
@@ -1360,7 +1360,7 @@ class ExperimentRun(_DeployableEntity):
         # create and upload custom modules
         if model_type or custom_modules:  # only if provided or model is deployable
             custom_modules_artifact = self._custom_modules_as_artifact(custom_modules)
-            self._log_artifact("custom_modules", custom_modules_artifact,
+            self._log_artifact(_artifact_utils.CUSTOM_MODULES_KEY, custom_modules_artifact,
                                _CommonCommonService.ArtifactTypeEnum.BLOB, 'zip', overwrite=overwrite)
 
         # upload model
@@ -1972,7 +1972,7 @@ class ExperimentRun(_DeployableEntity):
                           category=FutureWarning)
 
         custom_modules_artifact = self._custom_modules_as_artifact(paths)
-        self._log_artifact("custom_modules", custom_modules_artifact,
+        self._log_artifact(_artifact_utils.CUSTOM_MODULES_KEY, custom_modules_artifact,
                            _CommonCommonService.ArtifactTypeEnum.BLOB, 'zip')
 
     def log_setup_script(self, script, overwrite=False):

--- a/client/verta/verta/_tracking/experimentrun.py
+++ b/client/verta/verta/_tracking/experimentrun.py
@@ -1259,7 +1259,7 @@ class ExperimentRun(_DeployableEntity):
         self._log_artifact(
             "model.pkl", model, _CommonCommonService.ArtifactTypeEnum.MODEL, model_extension, method)
         self._log_artifact("model_api.json", model_api,
-                            _CommonCommonService.ArtifactTypeEnum.BLOB, 'json')
+                           _CommonCommonService.ArtifactTypeEnum.BLOB, 'json')
         if train_data is not None:
             self._log_artifact("train_data", train_data,
                                _CommonCommonService.ArtifactTypeEnum.DATA, 'csv')

--- a/client/verta/verta/_tracking/experimentrun.py
+++ b/client/verta/verta/_tracking/experimentrun.py
@@ -365,10 +365,7 @@ class ExperimentRun(_DeployableEntity):
                     "PUT", url_for_artifact.url, self._conn, data=artifact_stream)
             _utils.raise_for_http_error(response)
 
-        if key is _artifact_utils.MODEL_KEY:
-            print("model upload complete")
-        else:
-            print("upload complete ({})".format(key))
+        print("upload complete ({})".format(key))
 
     def _log_artifact_path(self, key, artifact_path, artifact_type, overwrite=False):
         """


### PR DESCRIPTION
Might help to review with "Hide whitespace changes" on.

## Changes
- rearrange internals of `log_model()` methods to only upload `custom_modules` and `model_api.json` if the model is Verta-deployable, or if provided by the user.

## Testing
- verifies these artifacts are not uploaded if the model is not Verta-deployable.