### PR TITLE
Set version pin in environment test case

### DIFF
--- a/client/verta/tests/test_experimentrun/test_environment.py
+++ b/client/verta/tests/test_experimentrun/test_environment.py
@@ -32,7 +32,7 @@ class TestLogEnvironment:
         assert experiment_run.has_environment
         reqs_before = _extract_requirements(experiment_run.get_environment())
 
-        python_env = Python(['pytest'])
+        python_env = Python(['tensorflow=1.2.3'])
         experiment_run.log_environment(python_env, overwrite=True)
         assert experiment_run.has_environment
         reqs_after = _extract_requirements(experiment_run.get_environment())

--- a/client/verta/tests/test_experimentrun/test_environment.py
+++ b/client/verta/tests/test_experimentrun/test_environment.py
@@ -32,7 +32,7 @@ class TestLogEnvironment:
         assert experiment_run.has_environment
         reqs_before = _extract_requirements(experiment_run.get_environment())
 
-        python_env = Python(['tensorflow'])
+        python_env = Python(['pytest'])
         experiment_run.log_environment(python_env, overwrite=True)
         assert experiment_run.has_environment
         reqs_after = _extract_requirements(experiment_run.get_environment())

--- a/client/verta/tests/test_experimentrun/test_environment.py
+++ b/client/verta/tests/test_experimentrun/test_environment.py
@@ -32,7 +32,7 @@ class TestLogEnvironment:
         assert experiment_run.has_environment
         reqs_before = _extract_requirements(experiment_run.get_environment())
 
-        python_env = Python(['tensorflow=1.2.3'])
+        python_env = Python(['tensorflow==1.2.3'])
         experiment_run.log_environment(python_env, overwrite=True)
         assert experiment_run.has_environment
         reqs_after = _extract_requirements(experiment_run.get_environment())


### PR DESCRIPTION
`Python()` raises an exception for the user if it's passed a library that isn't installed, and without a version pin. This is because a version number is needed for environment reproducibility.
```python
ValueError: unable to determine a version number for requirement 'tensorflow';
it might not be installed; please manually specify it as 'tensorflow==x.y.z'
```

The nightly client tests involve a runthrough where only the client is installed (to validate core functionality without external dependencies), so passing `"tensorflow"` raises this exception.