### PR TITLE
VR-9959: Fix bug where arbitrary files can't be passed to log_model() in Python 2

### DIFF
--- a/client/verta/verta/_internal_utils/_artifact_utils.py
+++ b/client/verta/verta/_internal_utils/_artifact_utils.py
@@ -278,7 +278,6 @@ def serialize_model(model):
             return model, None, None  # return bytestream
         finally:
             reset_stream(model)  # reset cursor to beginning as a courtesy
-        # here, `model` is either still a stream, or an deserialized object
 
     # if `model` is a class
     if isinstance(model, six.class_types):

--- a/client/verta/verta/_internal_utils/_artifact_utils.py
+++ b/client/verta/verta/_internal_utils/_artifact_utils.py
@@ -260,14 +260,16 @@ def serialize_model(model):
         Framework with which the model was built.
 
     """
-    if isinstance(model, six.string_types):  # filesystem path
+    # if `model` is filesystem path
+    if isinstance(model, six.string_types):
         if os.path.isdir(model):
             return zip_dir(model), "zip", None
         else:  # filepath
             # open and continue
             model = open(model, 'rb')
 
-    if hasattr(model, 'read'):  # if `model` is file-like
+    # if `model` is file-like
+    if hasattr(model, 'read'):
         try:  # attempt to deserialize
             reset_stream(model)  # reset cursor to beginning in case user forgot
             model = deserialize_model(model.read())
@@ -278,13 +280,13 @@ def serialize_model(model):
             reset_stream(model)  # reset cursor to beginning as a courtesy
         # here, `model` is either still a stream, or an deserialized object
 
-    # `model` is a class
+    # if `model` is a class
     if isinstance(model, six.class_types):
         model_type = "class"
         bytestream, method = ensure_bytestream(model)
         return bytestream, method, model_type
 
-    # `model` is an instance
+    # if`model` is an instance
     pyspark_ml_base = maybe_dependency("pyspark.ml.base")
     if pyspark_ml_base:
         # https://spark.apache.org/docs/latest/api/python/_modules/pyspark/ml/base.html

--- a/client/verta/verta/_internal_utils/_artifact_utils.py
+++ b/client/verta/verta/_internal_utils/_artifact_utils.py
@@ -271,12 +271,12 @@ def serialize_model(model):
         try:  # attempt to deserialize
             reset_stream(model)  # reset cursor to beginning in case user forgot
             model = deserialize_model(model.read())
-        except (TypeError, pickle.UnpicklingError):  # unrecognized model
-            bytestream = model
-            method = None
-            model_type = "custom"
+        except (TypeError, pickle.UnpicklingError):
+            # unrecognized serialization method and model type
+            return model, None, None  # return bytestream
         finally:
             reset_stream(model)  # reset cursor to beginning as a courtesy
+        # here, `model` is either still a stream, or an deserialized object
 
     # `model` is a class
     if isinstance(model, six.class_types):

--- a/client/verta/verta/_internal_utils/_artifact_utils.py
+++ b/client/verta/verta/_internal_utils/_artifact_utils.py
@@ -354,7 +354,7 @@ def serialize_model(model):
     return bytestream, method, model_type
 
 
-def deserialize_model(bytestring):
+def deserialize_model(bytestring, error_ok=False):
     """
     Deserializes a model from a bytestring, attempting various methods.
 
@@ -364,11 +364,20 @@ def deserialize_model(bytestring):
     ----------
     bytestring : bytes
         Bytes representing the model.
+    error_ok : bool, default False
+        Whether to return the serialized bytes if the model cannot be
+        deserialized. If False, an ``UnpicklingError`` is raised instead.
 
     Returns
     -------
     model : obj or file-like
         Model or buffered bytestream representing the model.
+
+    Raises
+    ------
+    pickle.UnpicklingError
+        If `bytestring` cannot be deserialized into an object, and `error_ok`
+        is False.
 
     """
     keras = maybe_dependency("tensorflow.keras")
@@ -407,7 +416,10 @@ def deserialize_model(bytestring):
     except:  # not a pickled object
         bytestream.seek(0)
 
-    return bytestream
+    if error_ok:
+        return bytestream
+    else:
+        raise pickle.UnpicklingError("unable to deserialize model")
 
 
 def get_stream_length(stream, chunk_size=_5MB):

--- a/client/verta/verta/_registry/modelversion.py
+++ b/client/verta/verta/_registry/modelversion.py
@@ -293,7 +293,7 @@ class RegisteredModelVersion(_DeployableEntity):
 
         """
         model_artifact = self._get_artifact("model", _CommonCommonService.ArtifactTypeEnum.MODEL)
-        return _artifact_utils.deserialize_model(model_artifact)
+        return _artifact_utils.deserialize_model(model_artifact, error_ok=True)
 
     def del_model(self):
         """

--- a/client/verta/verta/_tracking/experimentrun.py
+++ b/client/verta/verta/_tracking/experimentrun.py
@@ -1378,7 +1378,7 @@ class ExperimentRun(_DeployableEntity):
 
         """
         model, _ = self._get_artifact(_artifact_utils.MODEL_KEY)
-        return _artifact_utils.deserialize_model(model)
+        return _artifact_utils.deserialize_model(model, error_ok=True)
 
     def log_image(self, key, image, overwrite=False):
         """


### PR DESCRIPTION
## Context
In `serialize_model()`, the client actually first attempts to **de**serialize the input if it's a file handle, to determine its type and serialization method for downstream deployment. `deserialize_model()` returns its input (as [`StringIO`](https://docs.python.org/2/library/stringio.html#StringIO.StringIO)) if it cannot be deserialized into a supported model.

## Problem
An arbitrary file handle is passed to `log_model()` is passed to `serialize_model()`, fails to be deserialized in the section for file-like objects, and falls through to the general object-handling section. In Python 2, the `StringIO` class lacks `__mro__` which is used in that section, and causes an `AttributeError`.

## Changes
- add `error_ok` param to `deserialize_model()`
- catch and immediately return a non-deserializable file handle in `serialize_model()`, instead of letting it fall through to irrelevant code

## Followups
`__mro__` probably shouldn't be relied on for handling objects. VR-9966 has been filed to track a rewrite.