### PR TITLE
Clarify behavior change with default permissions

### DIFF
--- a/client/verta/docs/changelog.rst
+++ b/client/verta/docs/changelog.rst
@@ -42,8 +42,9 @@ v0.17.0 (2021-02-16)
 
 Backwards Incompatibilities
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-- `an entity created in an organization will use that organization's
-  permissions settings by default, instead of defaulting to private
+- `in newer backends, an entity created in an organization will use that
+  organization's permissions settings by default, instead of defaulting to
+  private
   <https://github.com/VertaAI/modeldb/pull/1993>`__
 
 New Features

--- a/client/verta/docs/changelog.rst
+++ b/client/verta/docs/changelog.rst
@@ -44,7 +44,7 @@ Backwards Incompatibilities
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - `an entity created in an organization will use that organization's
   permissions settings by default, instead of defaulting to private
-  <https://github.com/VertaAI/modeldb/pull/1896>`__
+  <https://github.com/VertaAI/modeldb/pull/1993>`__
 
 New Features
 ^^^^^^^^^^^^

--- a/client/verta/docs/changelog.rst
+++ b/client/verta/docs/changelog.rst
@@ -40,6 +40,12 @@ Release Notes
 v0.17.0 (2021-02-16)
 --------------------
 
+Backwards Incompatibilities
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+- `an entity created in an organization will use that organization's
+  permissions settings by default, instead of defaulting to private
+  <https://github.com/VertaAI/modeldb/pull/1896>`__
+
 New Features
 ^^^^^^^^^^^^
 - `add client.set_workspace() and client.get_workspace()

--- a/client/verta/tests/test_permissions/test_sharing_old.py
+++ b/client/verta/tests/test_permissions/test_sharing_old.py
@@ -169,7 +169,7 @@ class TestEndpoint:
 
         # PRIVATE
         private_path = "private-{}".format(path)
-        endpoint = client.create_endpoint(private_path, workspace=organization.name)
+        endpoint = client.create_endpoint(private_path, workspace=organization.name, public_within_org=False)
         with pytest.raises(ValueError, match="Endpoint not found"):
             client_2.get_endpoint(private_path, workspace=organization.name)
         endpoint.delete()

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -402,12 +402,14 @@ class Client(object):
         workspace : str, optional
             Workspace under which the Project with name `name` exists. If not provided, the current
             user's personal workspace will be used.
-        public_within_org : bool, default False
-            If creating a Project in an organization's workspace, whether to make this Project
-            accessible to all members of that organization.
+        public_within_org : bool, optional
+            If creating a Project in an organization's workspace: ``True`` for
+            public, ``False`` for private. In older backends, default is
+            private; in newer backends, uses the org's settings by default.
         visibility : :ref:`visibility <visibility-api>`, optional
             Visibility to set when creating this project. If not provided, an
-            appropriate default will be used.
+            appropriate default will be used. This parameter should be
+            preferred over `public_within_org`.
         id : str, optional
             ID of the Project. This parameter cannot be provided alongside `name`, and other
             parameters will be ignored.
@@ -657,12 +659,14 @@ class Client(object):
             current user's personal workspace will be used.
         id : str, optional
             ID of the Repository, to be provided instead of `name`.
-        public_within_org : bool, default False
-            If creating a Repository in an organization's workspace, whether to make this Repository
-            accessible to all members of that organization.
+        public_within_org : bool, optional
+            If creating a Repository in an organization's workspace: ``True``
+            for public, ``False`` for private. In older backends, default is
+            private; in newer backends, uses the org's settings by default.
         visibility : :ref:`visibility <visibility-api>`, optional
             Visibility to set when creating this repository. If not provided,
-            an appropriate default will be used.
+            an appropriate default will be used. This parameter should be
+            preferred over `public_within_org`.
 
         Returns
         -------
@@ -754,12 +758,15 @@ class Client(object):
         workspace : str, optional
             Workspace under which the registered_model with name `name` exists. If not provided, the current
             user's personal workspace will be used.
-        public_within_org : bool, default False
-            If creating a registered_model in an organization's workspace, whether to make this registered_model
-            accessible to all members of that organization.
+        public_within_org : bool, optional
+            If creating a registered_model in an organization's workspace:
+            ``True`` for public, ``False`` for private. In older backends,
+            default is private; in newer backends, uses the org's settings by
+            default.
         visibility : :ref:`visibility <visibility-api>`, optional
             Visibility to set when creating this registered model. If not
-            provided, an appropriate default will be used.
+            provided, an appropriate default will be used. This parameter
+            should be preferred over `public_within_org`.
         id : str, optional
             ID of the registered_model. This parameter cannot be provided alongside `name`, and other
             parameters will be ignored.
@@ -884,12 +891,14 @@ class Client(object):
         workspace : str, optional
             Workspace under which the endpoint with name `name` exists. If not provided, the current
             user's personal workspace will be used.
-        public_within_org : bool, default False
-            If creating an endpoint in an organization's workspace, whether to make this endpoint
-            accessible to all members of that organization.
+        public_within_org : bool, optional
+            If creating an endpoint in an organization's workspace: ``True``
+            for public, ``False`` for private. In older backends, default is
+            private; in newer backends, uses the org's settings by default.
         visibility : :ref:`visibility <visibility-api>`, optional
             Visibility to set when creating this endpoint. If not provided, an
-            appropriate default will be used.
+            appropriate default will be used. This parameter should be
+            preferred over `public_within_org`.
         id : str, optional
             ID of the endpoint. This parameter cannot be provided alongside `name`, and other
             parameters will be ignored.
@@ -993,12 +1002,14 @@ class Client(object):
         workspace : str, optional
             Workspace under which the Project with name `name` exists. If not provided, the current
             user's personal workspace will be used.
-        public_within_org : bool, default False
-            If creating a Project in an organization's workspace, whether to make this Project
-            accessible to all members of that organization.
+        public_within_org : bool, optional
+            If creating a Project in an organization's workspace: ``True`` for
+            public, ``False`` for private. In older backends, default is
+            private; in newer backends, uses the org's settings by default.
         visibility : :ref:`visibility <visibility-api>`, optional
             Visibility to set when creating this project. If not provided, an
-            appropriate default will be used.
+            appropriate default will be used. This parameter should be
+            preferred over `public_within_org`.
 
         Returns
         -------
@@ -1119,12 +1130,15 @@ class Client(object):
         workspace : str, optional
             Workspace under which the registered_model with name `name` exists. If not provided, the current
             user's personal workspace will be used.
-        public_within_org : bool, default False
-            If creating a registered_model in an organization's workspace, whether to make this registered_model
-            accessible to all members of that organization.
+        public_within_org : bool, optional
+            If creating a registered_model in an organization's workspace:
+            ``True`` for public, ``False`` for private. In older backends,
+            default is private; in newer backends, uses the org's settings by
+            default.
         visibility : :ref:`visibility <visibility-api>`, optional
             Visibility to set when creating this registered model. If not
-            provided, an appropriate default will be used.
+            provided, an appropriate default will be used. This parameter
+            should be preferred over `public_within_org`.
 
         Returns
         -------
@@ -1168,12 +1182,14 @@ class Client(object):
         workspace : str, optional
             Workspace under which the endpoint with name `name` exists. If not provided, the current
             user's personal workspace will be used.
-        public_within_org : bool, default False
-            If creating an endpoint in an organization's workspace, whether to make this endpoint
-            accessible to all members of that organization.
+        public_within_org : bool, optional
+            If creating an endpoint in an organization's workspace: ``True``
+            for public, ``False`` for private. In older backends, default is
+            private; in newer backends, uses the org's settings by default.
         visibility : :ref:`visibility <visibility-api>`, optional
             Visibility to set when creating this endpoint. If not provided, an
-            appropriate default will be used.
+            appropriate default will be used. This parameter should be
+            preferred over `public_within_org`.
 
         Returns
         -------
@@ -1280,12 +1296,14 @@ class Client(object):
         workspace : str, optional
             Workspace under which the dataset with name `name` exists. If not provided, the current
             user's personal workspace will be used.
-        public_within_org : bool, default False
-            If creating a dataset in an organization's workspace, whether to make this dataset
-            accessible to all members of that organization.
+        public_within_org : bool, optional
+            If creating a dataset in an organization's workspace: ``True`` for
+            public, ``False`` for private. In older backends, default is
+            private; in newer backends, uses the org's settings by default.
         visibility : :ref:`visibility <visibility-api>`, optional
             Visibility to set when creating this dataset. If not provided, an
-            appropriate default will be used.
+            appropriate default will be used. This parameter should be
+            preferred over `public_within_org`.
         id : str, optional
             ID of the dataset. This parameter cannot be provided alongside `name`, and other
             parameters will be ignored.
@@ -1359,12 +1377,14 @@ class Client(object):
         workspace : str, optional
             Workspace under which the dataset with name `name` exists. If not provided, the current
             user's personal workspace will be used.
-        public_within_org : bool, default False
-            If creating a dataset in an organization's workspace, whether to make this dataset
-            accessible to all members of that organization.
+        public_within_org : bool, optional
+            If creating a dataset in an organization's workspace: ``True`` for
+            public, ``False`` for private. In older backends, default is
+            private; in newer backends, uses the org's settings by default.
         visibility : :ref:`visibility <visibility-api>`, optional
             Visibility to set when creating this dataset. If not provided, an
-            appropriate default will be used.
+            appropriate default will be used. This parameter should be
+            preferred over `public_within_org`.
 
         Returns
         -------


### PR DESCRIPTION
We're shifting our system to use an organization's default permissions settings by default, instead entities being private by default. This needs to be clarified in the documentation (and updated in a test).