### PR TITLE
Mention addition of download_model() in 0.17.1 release notes

### DIFF
--- a/client/verta/docs/changelog.rst
+++ b/client/verta/docs/changelog.rst
@@ -44,6 +44,8 @@ New Features
 ^^^^^^^^^^^^
 - `add run.log_environment()
   <https://github.com/VertaAI/modeldb/pull/1972>`__
+- `add run.download_model()
+  <https://github.com/VertaAI/modeldb/pull/1973>`__
 
 Enhancements
 ^^^^^^^^^^^^

--- a/client/verta/verta/_tracking/experimentrun.py
+++ b/client/verta/verta/_tracking/experimentrun.py
@@ -1679,6 +1679,8 @@ class ExperimentRun(_DeployableEntity):
         """
         Downloads the model logged with :meth:`log_model` to path `download_to_path`.
 
+        .. versionadded:: 0.17.1
+
         Parameters
         ----------
         download_to_path : str


### PR DESCRIPTION
I missed this one because it was buried a bit in its PR