### PR TITLE
VR-10149: Do not mask 403s/404s when updating registry entities

### DIFF
--- a/client/verta/verta/registry/_entities/model.py
+++ b/client/verta/verta/registry/_entities/model.py
@@ -339,9 +339,7 @@ class RegisteredModel(_ModelDBEntity):
     def _update(self, msg, method="PATCH"):
         response = self._conn.make_proto_request(method, "/api/v1/registry/registered_models/{}".format(self.id),
                                            body=msg, include_default=False)
-        Message = _RegistryService.SetRegisteredModel
-        if isinstance(self._conn.maybe_proto_response(response, Message.Response), NoneProtoResponse):
-            raise ValueError("Model not found")
+        self._conn.must_proto_response(response, _RegistryService.SetRegisteredModel.Response)
         self._clear_cache()
 
     def _get_info_list(self):

--- a/client/verta/verta/registry/_entities/modelversion.py
+++ b/client/verta/verta/registry/_entities/modelversion.py
@@ -886,7 +886,6 @@ class RegisteredModelVersion(_DeployableEntity):
         return lock._LockLevel._from_proto(self._msg.lock_level)
 
     def _update(self, msg, method="PATCH", update_mask=None):
-        Message = _RegistryService.SetModelVersion
         self._refresh_cache()  # to have `self._msg.registered_model_id` for URL
         if update_mask:
             url = "{}://{}/api/v1/registry/registered_models/{}/model_versions/{}/full_body".format(
@@ -900,8 +899,7 @@ class RegisteredModelVersion(_DeployableEntity):
             response = self._conn.make_proto_request(method, "/api/v1/registry/registered_models/{}/model_versions/{}"
                                                      .format(self._msg.registered_model_id, self.id),
                                                      body=msg, include_default=False)
-        if isinstance(self._conn.maybe_proto_response(response, Message.Response), NoneProtoResponse):
-            raise ValueError("Model not found")
+        self._conn.must_proto_response(response, _RegistryService.SetModelVersion.Response)
         self._clear_cache()
 
     def _get_info_list(self, model_name):


### PR DESCRIPTION
Due to an copy & paste error from `_get_*()`, the `_update()` method in registry entities displays `ValueError: Model not found` instead of propagating the `403` if the update operation is not allowed.

This was not caught by our tests because, in an effort to keep them simple, I used `.delete()` to check read-only permissions for all entities. Unfortunately, that is the one operation that doesn't go through `_update()` in registry entities.