### PR TITLE
VR-10121: Add client tests for lock levels

### DIFF
--- a/client/verta/tests/test_model_registry/test_model_version.py
+++ b/client/verta/tests/test_model_registry/test_model_version.py
@@ -685,7 +685,7 @@ class TestLockLevels:
             assert model_ver.get_description() == description
             model_ver.add_label(label)
             assert model_ver.get_labels() == [label]
-            # model_ver.del_label(label)  # TODO: backend VR-10150
+            model_ver.del_label(label)
             with pytest.raises(requests.HTTPError, match="locked for changes"):
                 model_ver.add_attribute("a", {"a": 1})
             with pytest.raises(requests.HTTPError, match="locked for changes"):
@@ -712,7 +712,7 @@ class TestLockLevels:
             assert model_ver.get_description() == description
             model_ver.add_label(label)
             assert model_ver.get_labels() == [label]
-            # model_ver.del_label(label)  # TODO: backend VR-10150
+            model_ver.del_label(label)
 
         admin_model_ver.add_attribute("a", {"a": 1})
         with pytest.raises(requests.HTTPError, match="Access Denied"):

--- a/client/verta/verta/registry/_entities/modelversion.py
+++ b/client/verta/verta/registry/_entities/modelversion.py
@@ -911,3 +911,14 @@ class RegisteredModelVersion(_DeployableEntity):
         else :
             id_or_name = model_name
         return [self._msg.version, str(self.id), id_or_name, _utils.timestamp_to_str(self._msg.time_updated)]
+
+    def delete(self):
+        """
+        Deletes this model version.
+
+        .. versionadded:: 0.17.3
+
+        """
+        endpoint = "/api/v1/registry/model_versions/{}".format(self.id)
+        response = self._conn.make_proto_request("DELETE", endpoint)
+        self._conn.must_response(response)


### PR DESCRIPTION
These were deliberately not written to be comprehensive, but should cover enough functionality to find regressions.

```
9 passed, 13 warnings in 104.53s (0:01:44)
```