### PR TITLE
Make client debug cURLs more readable

### DIFF
--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -148,14 +148,14 @@ class Connection:
                 raise
 
         """
-        curl = "curl -X"
-        curl += ' ' + request.method
-        curl += ' ' + '"{}"'.format(request.url)
+        lines = []
+        lines.append("curl -X {} \"{}\"".format(request.method, request.url))
         if request.headers:
-            curl += ' ' + ' '.join('-H "{}: {}"'.format(key, val) for key, val in request.headers.items())
+            lines.extend('-H "{}: {}"'.format(key, val) for key, val in request.headers.items())
         if request.body:
-            curl += ' ' + "-d '{}'".format(request.body.decode())
+            lines.append("-d '{}'".format(request.body.decode()))
 
+        curl = " \\\n    ".join(lines)
         print(curl)
 
     @staticmethod


### PR DESCRIPTION
From
```bash
curl -X GET "https://app.verta.ai/api/v1/modeldb/project/verifyConnection" -H "Grpc-Metadata-
source: PythonClient" -H "Grpc-Metadata-email: user@domain.com" -H "Grpc-Metadata-developer_k
ey: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" -H "Grpc-Metadata-developer-key: xxxxxxxx-xxxx-xxxx
-xxxx-xxxxxxxxxxxx" -H "Grpc-Metadata-scheme: https"
```
to
```bash
curl -X GET "https://app.verta.ai/api/v1/modeldb/project/verifyConnection" \
    -H "Grpc-Metadata-source: PythonClient" \
    -H "Grpc-Metadata-email: user@domain.com" \
    -H "Grpc-Metadata-developer_key: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" \
    -H "Grpc-Metadata-developer-key: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" \
    -H "Grpc-Metadata-scheme: https"
```