### PR TITLE
Parameterize runLiquibaseMigration to take the liquibase root as a parameter

### DIFF
--- a/backend/common/src/main/java/ai/verta/modeldb/common/CommonHibernateUtil.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/CommonHibernateUtil.java
@@ -271,7 +271,7 @@ public abstract class CommonHibernateUtil {
   }
 
   public void createTablesLiquibaseMigration(
-      DatabaseConfig config, String changeSetToRevertUntilTag)
+      DatabaseConfig config, String changeSetToRevertUntilTag, String liquibaseRootPath)
       throws LiquibaseException, SQLException, InterruptedException, ClassNotFoundException {
     RdbConfig rdb = config.RdbConfiguration;
 
@@ -287,7 +287,7 @@ public abstract class CommonHibernateUtil {
       // Initialize Liquibase and run the update
       Database database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(jdbcCon);
       String rootPath = System.getProperty(CommonConstants.userDir);
-      rootPath = rootPath + liquibaseRootFilePath;
+      rootPath = rootPath + liquibaseRootPath;
       Liquibase liquibase = new Liquibase(rootPath, new FileSystemResourceAccessor(), database);
 
       boolean liquibaseExecuted = false;
@@ -457,6 +457,11 @@ public abstract class CommonHibernateUtil {
 
   public void runLiquibaseMigration(DatabaseConfig config)
       throws InterruptedException, LiquibaseException, SQLException, ClassNotFoundException {
+    runLiquibaseMigration(config, liquibaseRootFilePath);
+  }
+
+  public void runLiquibaseMigration(DatabaseConfig config, String liquibaseRootPath)
+      throws InterruptedException, LiquibaseException, SQLException, ClassNotFoundException {
     // Change liquibase default table names
     System.getProperties().put("liquibase.databaseChangeLogTableName", "database_change_log");
     System.getProperties()
@@ -482,7 +487,7 @@ public abstract class CommonHibernateUtil {
     releaseLiquibaseLock(config);
 
     // Run tables liquibase migration
-    createTablesLiquibaseMigration(config, config.changeSetToRevertUntilTag);
+    createTablesLiquibaseMigration(config, config.changeSetToRevertUntilTag, liquibaseRootPath);
   }
 
   public void createDBIfNotExists(RdbConfig rdb) throws SQLException {

--- a/backend/common/src/main/java/ai/verta/modeldb/common/config/Config.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/config/Config.java
@@ -14,6 +14,7 @@ public abstract class Config {
   public GrpcServerConfig grpcServer;
   public SpringServerConfig springServer;
   public TestConfig test;
+  public ServiceUserConfig mdb_service_user;
 
   public void Validate() throws InvalidConfigException {
 

--- a/backend/common/src/main/java/ai/verta/modeldb/common/connections/UAC.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/connections/UAC.java
@@ -4,7 +4,7 @@ import ai.verta.modeldb.common.CommonConstants;
 import ai.verta.modeldb.common.CommonMessages;
 import ai.verta.modeldb.common.authservice.AuthInterceptor;
 import ai.verta.modeldb.common.exceptions.UnavailableException;
-import ai.verta.modeldb.config.Config;
+import ai.verta.modeldb.common.config.Config;
 import ai.verta.uac.CollaboratorServiceGrpc;
 import io.grpc.ClientInterceptor;
 import io.grpc.ManagedChannel;

--- a/backend/src/main/java/ai/verta/modeldb/config/Config.java
+++ b/backend/src/main/java/ai/verta/modeldb/config/Config.java
@@ -15,7 +15,6 @@ import org.yaml.snakeyaml.constructor.Constructor;
 public class Config extends ai.verta.modeldb.common.config.Config {
 
   private static Config config = null;
-  public ServiceUserConfig mdb_service_user;
   public String starterProject;
   public ArtifactStoreConfig artifactStoreConfig;
   public TelemetryConfig telemetry;


### PR DESCRIPTION
To allow projects to support multiple database schemas it is necesarry to allow callers to specify which liquibase root to use when running migration.

