### PR TITLE
Enable micrometer metrics for prometheus

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -182,9 +182,26 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/io.micrometer/micrometer-core -->
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+            <version>1.6.5</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/io.micrometer/micrometer-registry-prometheus -->
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+            <version>1.6.5</version>
+        </dependency>
+
         <!-- https://mvnrepository.com/artifact/io.prometheus/simpleclient_servlet -->
         <dependency>
             <groupId>io.prometheus</groupId>

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+management.endpoint.*.enabled=false
+management.endpoint.metrics.enabled=true
+management.endpoint.prometheus.enabled=true


### PR DESCRIPTION
Enable spring-boot actuator and micrometer for metrics collection and dispatch to prometheus.

This will enable us to gather metrics on a wide range of libraries and technologies, and is published to `/actuator/metrics` and `/actuator/prometheus` for collection by prometheus.