### PR TITLE
Make a correction to docstring

### DIFF
--- a/client/verta/verta/_internal_utils/arg_handler.py
+++ b/client/verta/verta/_internal_utils/arg_handler.py
@@ -9,7 +9,7 @@ from . import _utils
 
 def args_to_builtin(ignore_self):
     """
-    Function decorator that applies ``_utils.to_builtin()`` to all arguments.
+    Returns a decorator that applies ``_utils.to_builtin()`` to all arguments.
 
     Parameters
     ----------


### PR DESCRIPTION
`args_to_builtin()` is a decorator factory, not a decorator!