### PR TITLE
[VR-10434] Enable retrieving complex attribute instances

### DIFF
--- a/client/verta/tests/test_data_types.py
+++ b/client/verta/tests/test_data_types.py
@@ -9,13 +9,15 @@ class TestConfusionMatrix:
             value=[[1, 2, 3], [4, 5, 6], [7, 8, 9]],
             labels=["a", "b", "c"],
         )
-        assert attr._as_dict() == {
+        d = {
             "type": "verta.confusionMatrix.v1",
             "confusionMatrix": {
                 "labels": ["a", "b", "c"],
                 "value": [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
             },
         }
+        assert attr._as_dict() == d
+        assert attr == data_types.ConfusionMatrix._from_dict(d)
 
     def test_confusion_matrix_numpy(self):
         np = pytest.importorskip("numpy")
@@ -38,13 +40,15 @@ class TestDiscreteHistogram:
             buckets=["yes", "no"],
             data=[10, 20],
         )
-        assert attr._as_dict() == {
+        d = {
             "type": "verta.discreteHistogram.v1",
             "discreteHistogram": {
                 "buckets": ["yes", "no"],
                 "data": [10, 20],
             },
         }
+        assert attr._as_dict() == d
+        assert attr == data_types.DiscreteHistogram._from_dict(d)
 
     def test_discrete_histogram_numpy(self):
         np = pytest.importorskip("numpy")
@@ -67,13 +71,15 @@ class TestFloatHistogram:
             bucket_limits=[0, 3, 6],
             data=[10, 20],
         )
-        assert attr._as_dict() == {
+        d = {
             "type": "verta.floatHistogram.v1",
             "floatHistogram": {
                 "bucketLimits": [0, 3, 6],
                 "data": [10, 20],
             },
         }
+        assert attr._as_dict() == d
+        assert attr == data_types.FloatHistogram._from_dict(d)
 
     def test_float_histogram_numpy(self):
         np = pytest.importorskip("numpy")
@@ -96,13 +102,15 @@ class TestLine:
             x=[1, 2, 3],
             y=[1, 4, 9],
         )
-        assert attr._as_dict() == {
+        d = {
             "type": "verta.line.v1",
             "line": {
                 "x": [1, 2, 3],
                 "y": [1, 4, 9],
             },
         }
+        assert attr._as_dict() == d
+        assert attr == data_types.Line._from_dict(d)
 
     def test_line_numpy(self):
         np = pytest.importorskip("numpy")
@@ -134,12 +142,14 @@ class TestLine:
 class TestMatrix:
     def test_matrix(self):
         attr = data_types.Matrix([[1, 2, 3], [4, 5, 6]])
-        assert attr._as_dict() == {
+        d = {
             "type": "verta.matrix.v1",
             "matrix": {
                 "value": [[1, 2, 3], [4, 5, 6]],
             },
         }
+        assert attr._as_dict() == d
+        assert attr == data_types.Matrix._from_dict(d)
 
     def test_matrix_numpy(self):
         np = pytest.importorskip("numpy")
@@ -158,13 +168,15 @@ class TestTable:
             data=[[1, "two", 3], [4, "five", 6]],
             columns=["header1", "header2", "header3"],
         )
-        assert attr._as_dict() == {
+        d = {
             "type": "verta.table.v1",
             "table": {
                 "header": ["header1", "header2", "header3"],
                 "rows": [[1, "two", 3], [4, "five", 6]],
             },
         }
+        assert attr._as_dict() == d
+        assert attr == data_types.Table._from_dict(d)
 
     def test_table_numpy(self):
         np = pytest.importorskip("numpy")

--- a/client/verta/tests/test_data_types.py
+++ b/client/verta/tests/test_data_types.py
@@ -127,9 +127,7 @@ class TestLine:
         }
 
     def test_line_from_tuples(self):
-        attr = data_types.Line.from_tuples(
-            [(1, 1), (2, 4), (3, 9)]
-        )
+        attr = data_types.Line.from_tuples([(1, 1), (2, 4), (3, 9)])
         assert attr._as_dict() == {
             "type": "verta.line.v1",
             "line": {

--- a/client/verta/tests/test_experimentrun/test_attributes.py
+++ b/client/verta/tests/test_experimentrun/test_attributes.py
@@ -109,7 +109,7 @@ class TestComplexAttributes:
             value=[[1, 2, 3], [4, 5, 6], [7, 8, 9]],
             labels=["a", "b", "c"],
         )
-        attr3 = {'a': 1}
+        attr3 = {"a": 1}
 
         experiment_run.log_attribute(key1, attr1)
         assert experiment_run.get_attribute(key1) == attr1

--- a/client/verta/tests/test_experimentrun/test_attributes.py
+++ b/client/verta/tests/test_experimentrun/test_attributes.py
@@ -87,7 +87,7 @@ class TestComplexAttributes:
         experiment_run = client.create_experiment_run(
             attrs={key: attr},
         )
-        assert experiment_run.get_attribute(key) == attr._as_dict()
+        assert experiment_run.get_attribute(key) == attr
 
     def test_single(self, experiment_run, strs):
         key = strs[0]
@@ -97,10 +97,10 @@ class TestComplexAttributes:
         )
 
         experiment_run.log_attribute(key, attr)
-        assert experiment_run.get_attribute(key) == attr._as_dict()
+        assert experiment_run.get_attribute(key) == attr
 
     def test_batch(self, experiment_run, strs):
-        key1, key2 = strs[:2]
+        key1, key2, key3 = strs[:3]
         attr1 = data_types.Table(
             data=[[1, "two", 3], [4, "five", 6]],
             columns=["header1", "header2", "header3"],
@@ -109,8 +109,16 @@ class TestComplexAttributes:
             value=[[1, 2, 3], [4, 5, 6], [7, 8, 9]],
             labels=["a", "b", "c"],
         )
+        attr3 = {'a': 1}
 
         experiment_run.log_attribute(key1, attr1)
-        assert experiment_run.get_attribute(key1) == attr1._as_dict()
+        assert experiment_run.get_attribute(key1) == attr1
         experiment_run.log_attribute(key2, attr2)
-        assert experiment_run.get_attribute(key2) == attr2._as_dict()
+        assert experiment_run.get_attribute(key2) == attr2
+        experiment_run.log_attribute(key3, attr3)
+
+        assert experiment_run.get_attributes() == {
+            key1: attr1,
+            key2: attr2,
+            key3: attr3,
+        }

--- a/client/verta/verta/_tracking/experimentrun.py
+++ b/client/verta/verta/_tracking/experimentrun.py
@@ -747,7 +747,7 @@ class ExperimentRun(_DeployableEntity):
             attribute = attributes[key]
             try:
                 return data_types._VertaDataType._from_dict(attribute)
-            except:
+            except (KeyError, TypeError, ValueError):
                 return attribute
         except KeyError:
             six.raise_from(
@@ -778,7 +778,7 @@ class ExperimentRun(_DeployableEntity):
         for key, attribute in attributes.items():
             try:
                 attributes[key] = data_types._VertaDataType._from_dict(attribute)
-            except:
+            except (KeyError, TypeError, ValueError):
                 pass
         return attributes
 

--- a/client/verta/verta/_tracking/experimentrun.py
+++ b/client/verta/verta/_tracking/experimentrun.py
@@ -744,8 +744,11 @@ class ExperimentRun(_DeployableEntity):
             _utils.body_to_json(response), Message.Response)
         attributes = _utils.unravel_key_values(response_msg.attributes)
         try:
-            # TODO: VR-10434 try to read into a `_VertaDataType`
-            return attributes[key]
+            attribute = attributes[key]
+            try:
+                return data_types._VertaDataType._from_dict(attribute)
+            except:
+                return attribute
         except KeyError:
             six.raise_from(
                 KeyError("no attribute found with key {}".format(key)), None)
@@ -771,8 +774,13 @@ class ExperimentRun(_DeployableEntity):
 
         response_msg = _utils.json_to_proto(
             _utils.body_to_json(response), Message.Response)
-        # TODO: VR-10434 try to read into a `_VertaDataType`
-        return _utils.unravel_key_values(response_msg.attributes)
+        attributes = _utils.unravel_key_values(response_msg.attributes)
+        for key, attribute in attributes.items():
+            try:
+                attributes[key] = data_types._VertaDataType._from_dict(attribute)
+            except:
+                pass
+        return attributes
 
     def _delete_attributes(self, keys):
         response = _utils.make_request("DELETE",

--- a/client/verta/verta/data_types/_confusion_matrix.py
+++ b/client/verta/verta/data_types/_confusion_matrix.py
@@ -30,3 +30,11 @@ class ConfusionMatrix(_VertaDataType):
                 "labels": self._labels,
             }
         )
+
+    @classmethod
+    def _from_dict(cls, d):
+        data = d[cls._TYPE_NAME]
+        return cls(
+            value=data["value"],
+            labels=data["labels"],
+        )

--- a/client/verta/verta/data_types/_discrete_histogram.py
+++ b/client/verta/verta/data_types/_discrete_histogram.py
@@ -28,3 +28,11 @@ class DiscreteHistogram(_VertaDataType):
                 "data": self._data,
             }
         )
+
+    @classmethod
+    def _from_dict(cls, d):
+        data = d[cls._TYPE_NAME]
+        return cls(
+            buckets=data["buckets"],
+            data=data["data"],
+        )

--- a/client/verta/verta/data_types/_float_histogram.py
+++ b/client/verta/verta/data_types/_float_histogram.py
@@ -36,7 +36,4 @@ class FloatHistogram(_VertaDataType):
     @classmethod
     def _from_dict(cls, d):
         data = d[cls._TYPE_NAME]
-        return cls(
-            bucket_limits=data["bucketLimits"],
-            data=data["data"]
-        )
+        return cls(bucket_limits=data["bucketLimits"], data=data["data"])

--- a/client/verta/verta/data_types/_float_histogram.py
+++ b/client/verta/verta/data_types/_float_histogram.py
@@ -32,3 +32,11 @@ class FloatHistogram(_VertaDataType):
                 "data": self._data,
             }
         )
+
+    @classmethod
+    def _from_dict(cls, d):
+        data = d[cls._TYPE_NAME]
+        return cls(
+            bucket_limits=data["bucketLimits"],
+            data=data["data"]
+        )

--- a/client/verta/verta/data_types/_line.py
+++ b/client/verta/verta/data_types/_line.py
@@ -33,3 +33,11 @@ class Line(_VertaDataType):
                 "y": self._y,
             }
         )
+
+    @classmethod
+    def _from_dict(cls, d):
+        data = d[cls._TYPE_NAME]
+        return cls(
+            x=data["x"],
+            y=data["y"],
+        )

--- a/client/verta/verta/data_types/_matrix.py
+++ b/client/verta/verta/data_types/_matrix.py
@@ -24,3 +24,10 @@ class Matrix(_VertaDataType):
                 "value": self._value,
             }
         )
+
+    @classmethod
+    def _from_dict(cls, d):
+        data = d[cls._TYPE_NAME]
+        return cls(
+            value=data["value"]
+        )

--- a/client/verta/verta/data_types/_matrix.py
+++ b/client/verta/verta/data_types/_matrix.py
@@ -28,6 +28,4 @@ class Matrix(_VertaDataType):
     @classmethod
     def _from_dict(cls, d):
         data = d[cls._TYPE_NAME]
-        return cls(
-            value=data["value"]
-        )
+        return cls(value=data["value"])

--- a/client/verta/verta/data_types/_table.py
+++ b/client/verta/verta/data_types/_table.py
@@ -30,3 +30,11 @@ class Table(_VertaDataType):
                 "header": self._columns,
             }
         )
+
+    @classmethod
+    def _from_dict(cls, d):
+        data = d[cls._TYPE_NAME]
+        return cls(
+            data=data["rows"],
+            columns=data["header"],
+        )

--- a/client/verta/verta/data_types/_verta_data_type.py
+++ b/client/verta/verta/data_types/_verta_data_type.py
@@ -42,6 +42,7 @@ class _VertaDataType(object):
             Matrix,
             Table,
         )
+
         SUBCLASSES = [
             ConfusionMatrix,
             DiscreteHistogram,

--- a/client/verta/verta/data_types/_verta_data_type.py
+++ b/client/verta/verta/data_types/_verta_data_type.py
@@ -10,6 +10,11 @@ class _VertaDataType(object):
     _TYPE_NAME = None
     _VERSION = None
 
+    def __eq__(self, other):
+        if type(self) is not type(other):
+            return NotImplemented
+        return self.__dict__ == other.__dict__
+
     def _as_dict_inner(self, data):
         return {
             "type": "verta.{}.{}".format(
@@ -23,5 +28,36 @@ class _VertaDataType(object):
     def _as_dict(self):
         raise NotImplementedError
 
-    def _from_dict(self, d):
-        pass
+    @staticmethod
+    def _from_dict(d):
+        # TODO: when we have v2 onwards, make sure old v are still supported
+
+        # imports here to avoid circular import in Python 2
+        # TODO: figure out if cls.__subclasses__() is robust to use
+        from . import (
+            ConfusionMatrix,
+            DiscreteHistogram,
+            FloatHistogram,
+            Line,
+            Matrix,
+            Table,
+        )
+        SUBCLASSES = [
+            ConfusionMatrix,
+            DiscreteHistogram,
+            FloatHistogram,
+            Line,
+            Matrix,
+            Table,
+        ]
+
+        d_type = d["type"]
+        for Subclass in SUBCLASSES:
+            subclass_type = "verta.{}.{}".format(
+                Subclass._TYPE_NAME,
+                Subclass._VERSION,
+            )
+            if d_type == subclass_type:
+                return Subclass._from_dict(d)
+
+        raise ValueError("data type {} not recognized".format(d_type))


### PR DESCRIPTION
## Changes

- implement `_from_dict()` for data type classes
- enable instantiating data type classes at the end of `run.get_attribute()` and `run.get_attributes()`
- add coverage in unit and integration tests

## References

- https://github.com/VertaAI/modeldb/pull/2057 implemented data type creation and logging