### PR TITLE
Ignore bad-continuation in pylint for black

### DIFF
--- a/client/verta/.pylintrc
+++ b/client/verta/.pylintrc
@@ -139,6 +139,7 @@ disable=print-statement,
         exception-escape,
         comprehension-escape,
     # everything below was added by @convoliution
+        bad-continuation,
         invalid-name,
         missing-docstring,
         line-too-long,


### PR DESCRIPTION
`black`'s pattern for formatting function definition parameters violates PEP 8 (somewhat sensibly, I'd argue), so this warning needs to be disabled in pylint