### PR TITLE
Bring back NumericValue and StringValue

### DIFF
--- a/client/verta/tests/test_data_types.py
+++ b/client/verta/tests/test_data_types.py
@@ -160,6 +160,53 @@ class TestMatrix:
         }
 
 
+class TestNumericValue:
+    def test_numeric_value(self):
+        attr = data_types.NumericValue(42)
+        assert attr._as_dict() == {
+            "type": "verta.numericValue.v1",
+            "numericValue": {
+                "value": 42,
+            },
+        }
+
+    def test_numeric_value_with_unit(self):
+        attr = data_types.NumericValue(14, unit="lbs")
+        assert attr._as_dict() == {
+            "type": "verta.numericValue.v1",
+            "numericValue": {
+                "value": 14,
+                "unit": "lbs",
+            },
+        }
+
+    def test_numeric_value_numpy(self):
+        np = pytest.importorskip("numpy")
+        d = {
+            "type": "verta.numericValue.v1",
+            "numericValue": {
+                "value": 42,
+            },
+        }
+
+        attr = data_types.NumericValue(np.float32(42))
+        assert attr._as_dict() == d
+
+        attr = data_types.NumericValue(np.array(42))
+        assert attr._as_dict() == d
+
+
+class TestStringValue:
+    def test_string_value(self):
+        attr = data_types.StringValue("umbrella")
+        assert attr._as_dict() == {
+            "type": "verta.stringValue.v1",
+            "stringValue": {
+                "value": "umbrella",
+            },
+        }
+
+
 class TestTable:
     def test_table(self):
         attr = data_types.Table(

--- a/client/verta/verta/data_types/__init__.py
+++ b/client/verta/verta/data_types/__init__.py
@@ -5,4 +5,6 @@ from ._discrete_histogram import DiscreteHistogram
 from ._float_histogram import FloatHistogram
 from ._line import Line
 from ._matrix import Matrix
+from ._numeric_value import NumericValue
+from ._string_value import StringValue
 from ._table import Table

--- a/client/verta/verta/data_types/_numeric_value.py
+++ b/client/verta/verta/data_types/_numeric_value.py
@@ -1,0 +1,27 @@
+import numbers
+
+from ..external import six
+
+from .._internal_utils import _utils
+
+from . import _VertaDataType
+
+
+class NumericValue(_VertaDataType):
+    _TYPE_NAME = "numericValue"
+    _VERSION = "v1"
+
+    def __init__(self, value, unit=None):
+        if not isinstance(value, numbers.Real):
+            raise TypeError("`value` must be a number, not {}".format(type(value)))
+        if unit and not isinstance(unit, six.string_types):
+            raise TypeError("`unit` must be a string, not {}".format(type(unit)))
+
+        self._value = _utils.to_builtin(value)
+        self._unit = _utils.to_builtin(unit)
+
+    def _as_dict(self):
+        data = {"value": self._value}
+        if self._unit:
+            data["unit"] = self._unit
+        return self._as_dict_inner(data)

--- a/client/verta/verta/data_types/_numeric_value.py
+++ b/client/verta/verta/data_types/_numeric_value.py
@@ -2,7 +2,7 @@ import numbers
 
 from ..external import six
 
-from .._internal_utils import _utils
+from .._internal_utils import arg_handler
 
 from . import _VertaDataType
 
@@ -11,14 +11,15 @@ class NumericValue(_VertaDataType):
     _TYPE_NAME = "numericValue"
     _VERSION = "v1"
 
+    @arg_handler.args_to_builtin(ignore_self=True)
     def __init__(self, value, unit=None):
         if not isinstance(value, numbers.Real):
             raise TypeError("`value` must be a number, not {}".format(type(value)))
         if unit and not isinstance(unit, six.string_types):
             raise TypeError("`unit` must be a string, not {}".format(type(unit)))
 
-        self._value = _utils.to_builtin(value)
-        self._unit = _utils.to_builtin(unit)
+        self._value = value
+        self._unit = unit
 
     def _as_dict(self):
         data = {"value": self._value}

--- a/client/verta/verta/data_types/_string_value.py
+++ b/client/verta/verta/data_types/_string_value.py
@@ -1,0 +1,21 @@
+from ..external import six
+
+from .._internal_utils import _utils
+
+from . import _VertaDataType
+
+
+class StringValue(_VertaDataType):
+    _TYPE_NAME = "stringValue"
+    _VERSION = "v1"
+
+    def __init__(self, value):
+        if not isinstance(value, six.string_types):
+            raise TypeError("`value` must be a string, not {}".format(type(value)))
+
+        self._value = _utils.to_builtin(value)
+
+    def _as_dict(self):
+        return self._as_dict_inner({
+            "value": self._value,
+        })

--- a/client/verta/verta/data_types/_string_value.py
+++ b/client/verta/verta/data_types/_string_value.py
@@ -1,6 +1,6 @@
 from ..external import six
 
-from .._internal_utils import _utils
+from .._internal_utils import arg_handler
 
 from . import _VertaDataType
 
@@ -9,11 +9,12 @@ class StringValue(_VertaDataType):
     _TYPE_NAME = "stringValue"
     _VERSION = "v1"
 
+    @arg_handler.args_to_builtin(ignore_self=True)
     def __init__(self, value):
         if not isinstance(value, six.string_types):
             raise TypeError("`value` must be a string, not {}".format(type(value)))
 
-        self._value = _utils.to_builtin(value)
+        self._value = value
 
     def _as_dict(self):
         return self._as_dict_inner({


### PR DESCRIPTION
Effectively reverts 08835bd284ee35a9757d345eb89512f0be96addf

They were removed because they were redundant for complex attributes, but `NumericValue` is necessary for monitoring functionality.