### PR TITLE
[VR-10471] Add __repr__ to data types

### DIFF
--- a/client/verta/verta/data_types/_confusion_matrix.py
+++ b/client/verta/verta/data_types/_confusion_matrix.py
@@ -58,7 +58,7 @@ class ConfusionMatrix(_VertaDataType):
         )
 
     @classmethod
-    def _from_dict(cls, d):
+    def _from_dict_inner(cls, d):
         data = d[cls._TYPE_NAME]
         return cls(
             value=data["value"],

--- a/client/verta/verta/data_types/_discrete_histogram.py
+++ b/client/verta/verta/data_types/_discrete_histogram.py
@@ -53,7 +53,7 @@ class DiscreteHistogram(_VertaDataType):
         )
 
     @classmethod
-    def _from_dict(cls, d):
+    def _from_dict_inner(cls, d):
         data = d[cls._TYPE_NAME]
         return cls(
             buckets=data["buckets"],

--- a/client/verta/verta/data_types/_float_histogram.py
+++ b/client/verta/verta/data_types/_float_histogram.py
@@ -57,6 +57,6 @@ class FloatHistogram(_VertaDataType):
         )
 
     @classmethod
-    def _from_dict(cls, d):
+    def _from_dict_inner(cls, d):
         data = d[cls._TYPE_NAME]
         return cls(bucket_limits=data["bucketLimits"], data=data["data"])

--- a/client/verta/verta/data_types/_line.py
+++ b/client/verta/verta/data_types/_line.py
@@ -81,7 +81,7 @@ class Line(_VertaDataType):
         )
 
     @classmethod
-    def _from_dict(cls, d):
+    def _from_dict_inner(cls, d):
         data = d[cls._TYPE_NAME]
         return cls(
             x=data["x"],

--- a/client/verta/verta/data_types/_matrix.py
+++ b/client/verta/verta/data_types/_matrix.py
@@ -48,6 +48,6 @@ class Matrix(_VertaDataType):
         )
 
     @classmethod
-    def _from_dict(cls, d):
+    def _from_dict_inner(cls, d):
         data = d[cls._TYPE_NAME]
         return cls(value=data["value"])

--- a/client/verta/verta/data_types/_numeric_value.py
+++ b/client/verta/verta/data_types/_numeric_value.py
@@ -48,7 +48,7 @@ class NumericValue(_VertaDataType):
         return self._as_dict_inner(data)
 
     @classmethod
-    def _from_dict(cls, d):
+    def _from_dict_inner(cls, d):
         data = d[cls._TYPE_NAME]
         return cls(
             value=data["value"],

--- a/client/verta/verta/data_types/_numeric_value.py
+++ b/client/verta/verta/data_types/_numeric_value.py
@@ -8,6 +8,26 @@ from . import _VertaDataType
 
 
 class NumericValue(_VertaDataType):
+    """
+    Representation of a number.
+
+    Parameters
+    ----------
+    value : float
+        Number.
+    unit : str
+        Unit of measurement.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        from verta.data_types import NumericValue
+        data = NumericValue(4, unit="lbs")
+        run.log_attribute("weight", data)
+
+    """
+
     _TYPE_NAME = "numericValue"
     _VERSION = "v1"
 

--- a/client/verta/verta/data_types/_numeric_value.py
+++ b/client/verta/verta/data_types/_numeric_value.py
@@ -46,3 +46,11 @@ class NumericValue(_VertaDataType):
         if self._unit:
             data["unit"] = self._unit
         return self._as_dict_inner(data)
+
+    @classmethod
+    def _from_dict(cls, d):
+        data = d[cls._TYPE_NAME]
+        return cls(
+            value=data["value"],
+            unit=data["unit"],
+        )

--- a/client/verta/verta/data_types/_string_value.py
+++ b/client/verta/verta/data_types/_string_value.py
@@ -38,3 +38,8 @@ class StringValue(_VertaDataType):
         return self._as_dict_inner({
             "value": self._value,
         })
+
+    @classmethod
+    def _from_dict(cls, d):
+        data = d[cls._TYPE_NAME]
+        return cls(value=data["value"])

--- a/client/verta/verta/data_types/_string_value.py
+++ b/client/verta/verta/data_types/_string_value.py
@@ -40,6 +40,6 @@ class StringValue(_VertaDataType):
         })
 
     @classmethod
-    def _from_dict(cls, d):
+    def _from_dict_inner(cls, d):
         data = d[cls._TYPE_NAME]
         return cls(value=data["value"])

--- a/client/verta/verta/data_types/_string_value.py
+++ b/client/verta/verta/data_types/_string_value.py
@@ -6,6 +6,24 @@ from . import _VertaDataType
 
 
 class StringValue(_VertaDataType):
+    """
+    Representation of a string.
+
+    Parameters
+    ----------
+    value : str
+        String.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        from verta.data_types import StringValue
+        data = StringValue("RNN")
+        run.log_attribute("architecture", data)
+
+    """
+
     _TYPE_NAME = "stringValue"
     _VERSION = "v1"
 

--- a/client/verta/verta/data_types/_table.py
+++ b/client/verta/verta/data_types/_table.py
@@ -68,7 +68,7 @@ class Table(_VertaDataType):
         )
 
     @classmethod
-    def _from_dict(cls, d):
+    def _from_dict_inner(cls, d):
         data = d[cls._TYPE_NAME]
         return cls(
             data=data["rows"],

--- a/client/verta/verta/data_types/_verta_data_type.py
+++ b/client/verta/verta/data_types/_verta_data_type.py
@@ -4,6 +4,8 @@ import abc
 
 from ..external import six
 
+from .._internal_utils import _file_utils
+
 
 @six.add_metaclass(abc.ABCMeta)
 class _VertaDataType(object):
@@ -19,6 +21,18 @@ class _VertaDataType(object):
         if type(self) is not type(other):
             return NotImplemented
         return self.__dict__ == other.__dict__
+
+    def __repr__(self):
+        attrs = {
+            _file_utils.remove_prefix(key, "_"): value
+            for key, value in self.__dict__.items()
+        }
+        lines = [
+            "{}: {}".format(key, value)
+            for key, value
+            in sorted(attrs.items())
+        ]
+        return "\n\t".join([type(self).__name__] + lines)
 
     def _as_dict_inner(self, data):
         return {

--- a/client/verta/verta/data_types/_verta_data_type.py
+++ b/client/verta/verta/data_types/_verta_data_type.py
@@ -45,6 +45,8 @@ class _VertaDataType(object):
             FloatHistogram,
             Line,
             Matrix,
+            NumericValue,
+            StringValue,
             Table,
         )
 
@@ -54,6 +56,8 @@ class _VertaDataType(object):
             FloatHistogram,
             Line,
             Matrix,
+            NumericValue,
+            StringValue,
             Table,
         ]
 

--- a/client/verta/verta/data_types/_verta_data_type.py
+++ b/client/verta/verta/data_types/_verta_data_type.py
@@ -33,6 +33,9 @@ class _VertaDataType(object):
     def _as_dict(self):
         raise NotImplementedError
 
+    # TODO: _from_dict_inner() should be an abstract class method, but need to
+    #       figure out how to do that in Python 2
+
     @staticmethod
     def _from_dict(d):
         # TODO: when we have v2 onwards, make sure old v are still supported
@@ -68,6 +71,6 @@ class _VertaDataType(object):
                 Subclass._VERSION,
             )
             if d_type == subclass_type:
-                return Subclass._from_dict(d)
+                return Subclass._from_dict_inner(d)
 
         raise ValueError("data type {} not recognized".format(d_type))


### PR DESCRIPTION
```
ConfusionMatrix
	labels: ['spam', 'not spam']
	value: [[6, 1], [2, 3]]
DiscreteHistogram
	buckets: ['yes', 'no']
	data: [10, 20]
FloatHistogram
	bucket_limits: [1, 13, 25, 37, 49, 61]
	data: [15, 53, 91, 34, 7]
Line
	x: [1, 2, 3]
	y: [1, 4, 9]
Matrix
	value: [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
NumericValue
	unit: lbs
	value: 4
StringValue
	value: RNN
Table
	columns: ['id', 'height', 'color']
	data: [[1, 24, 'blue'], [2, 36, 'red']]
```

## Changes

- change `_from_dict()` to `_from_dict_inner()` on subclasses to avoid an unhelpful recursion error
- add missing docstring and method to `NumericValue` and `StringValue`
- add `__repr__()` to data type base class