### PR TITLE
Disable mysql connector SSL

### DIFF
--- a/backend/common/src/main/java/ai/verta/modeldb/common/CommonHibernateUtil.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/CommonHibernateUtil.java
@@ -75,7 +75,7 @@ public abstract class CommonHibernateUtil {
             rdb.RdbUrl
                 + "/"
                 + rdb.RdbDatabaseName
-                + "?createDatabaseIfNotExist=true&useUnicode=yes&characterEncoding=UTF-8";
+                + "?createDatabaseIfNotExist=true&useUnicode=yes&characterEncoding=UTF-8&sslMode=DISABLED";
         settings.put(Environment.DRIVER, rdb.RdbDriver);
         settings.put(Environment.URL, connectionString);
         settings.put(Environment.USER, rdb.RdbUsername);
@@ -315,7 +315,7 @@ public abstract class CommonHibernateUtil {
         rdb.RdbUrl
             + "/"
             + rdb.RdbDatabaseName
-            + "?createDatabaseIfNotExist=true&useUnicode=yes&characterEncoding=UTF-8";
+            + "?createDatabaseIfNotExist=true&useUnicode=yes&characterEncoding=UTF-8&sslMode=DISABLED";
     try {
       Class.forName(rdb.RdbDriver);
     } catch (ClassNotFoundException e) {
@@ -489,9 +489,13 @@ public abstract class CommonHibernateUtil {
   }
 
   public void createDBIfNotExists(RdbConfig rdb) throws SQLException {
-
+    LOGGER.info("Checking DB " + rdb.RdbUrl);
+    Properties properties = new Properties();
+    properties.put("user", rdb.RdbUsername);
+    properties.put("password", rdb.RdbPassword);
+    properties.put("sslMode","DISABLED");
     Connection connection =
-        DriverManager.getConnection(rdb.RdbUrl, rdb.RdbUsername, rdb.RdbPassword);
+        DriverManager.getConnection(rdb.RdbUrl, properties);
     ResultSet resultSet = connection.getMetaData().getCatalogs();
 
     while (resultSet.next()) {

--- a/backend/common/src/main/java/ai/verta/modeldb/common/CommonHibernateUtil.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/CommonHibernateUtil.java
@@ -75,7 +75,9 @@ public abstract class CommonHibernateUtil {
             rdb.RdbUrl
                 + "/"
                 + rdb.RdbDatabaseName
-                + "?createDatabaseIfNotExist=true&useUnicode=yes&characterEncoding=UTF-8&sslMode=DISABLED";
+                + "?createDatabaseIfNotExist=true&useUnicode=yes&characterEncoding=UTF-8"
+                + "&sslMode="
+                + rdb.sslMode;
         settings.put(Environment.DRIVER, rdb.RdbDriver);
         settings.put(Environment.URL, connectionString);
         settings.put(Environment.USER, rdb.RdbUsername);
@@ -315,7 +317,9 @@ public abstract class CommonHibernateUtil {
         rdb.RdbUrl
             + "/"
             + rdb.RdbDatabaseName
-            + "?createDatabaseIfNotExist=true&useUnicode=yes&characterEncoding=UTF-8&sslMode=DISABLED";
+            + "?createDatabaseIfNotExist=true&useUnicode=yes&characterEncoding=UTF-8"
+            + "&sslMode="
+            + rdb.sslMode;
     try {
       Class.forName(rdb.RdbDriver);
     } catch (ClassNotFoundException e) {
@@ -493,7 +497,7 @@ public abstract class CommonHibernateUtil {
     Properties properties = new Properties();
     properties.put("user", rdb.RdbUsername);
     properties.put("password", rdb.RdbPassword);
-    properties.put("sslMode","DISABLED");
+    properties.put("sslMode", rdb.sslMode);
     Connection connection =
         DriverManager.getConnection(rdb.RdbUrl, properties);
     ResultSet resultSet = connection.getMetaData().getCatalogs();

--- a/backend/common/src/main/java/ai/verta/modeldb/common/config/RdbConfig.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/config/RdbConfig.java
@@ -8,6 +8,7 @@ public class RdbConfig {
   public String RdbUrl;
   public String RdbUsername;
   public String RdbPassword;
+  public String sslMode = "DISABLED";
 
   public void Validate(String base) throws InvalidConfigException {
     if (RdbDatabaseName == null || RdbDatabaseName.isEmpty())
@@ -20,6 +21,8 @@ public class RdbConfig {
       throw new InvalidConfigException(base + ".RdbUrl", Config.MISSING_REQUIRED);
     if (RdbUsername == null || RdbUsername.isEmpty())
       throw new InvalidConfigException(base + ".RdbUsername", Config.MISSING_REQUIRED);
+    if (sslMode == null || sslMode.isEmpty())
+      throw new InvalidConfigException(base + ".sslMode", Config.MISSING_REQUIRED);
   }
 
   public boolean isPostgres() {

--- a/backend/config.example.yaml
+++ b/backend/config.example.yaml
@@ -52,6 +52,7 @@ database:
     RdbUrl: "jdbc:postgresql://localhost:5432"
     RdbUsername:
     RdbPassword:
+    sslMode: DISABLED
 
 # Test Database settings (type mongodb, couchbasedb, relational etc..)
 test:
@@ -70,6 +71,7 @@ test:
       RdbUrl: "jdbc:postgresql://localhost:5432"
       RdbUsername:
       RdbPassword:
+      sslMode: DISABLED
   testUsers:
     primaryUser:
       email:


### PR DESCRIPTION
Adds a configuration parameter that is used to set the SSL mode for database connections.  This is required to migrate to newer versions of the JDK to prevent database connection failure.