### PR TITLE
[VR-10494] Notification Channel CRUD

### DIFF
--- a/client/verta/tests/operations/monitoring/notification_channels/test_config_classes.py
+++ b/client/verta/tests/operations/monitoring/notification_channels/test_config_classes.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+
+import hypothesis
+import hypothesis.strategies as st
+
+from verta._protos.public.monitoring import Alert_pb2 as _AlertService
+from verta.operations.monitoring.notification_channel import (
+    SlackNotificationChannel,
+)
+
+
+class TestSlack:
+    @hypothesis.given(webhook_url=st.text())
+    def test_create(self, webhook_url):
+        slack_channel = SlackNotificationChannel(webhook_url)
+        assert slack_channel._url == webhook_url
+
+        msg = _AlertService.NotificationChannelSlackWebhook(
+            url=webhook_url,
+        )
+        assert slack_channel._as_proto() == msg
+
+    @hypothesis.given(webhook_url=st.text())
+    def test_repr(self, webhook_url):
+        """__repr__() does not raise exceptions"""
+        slack_channel = SlackNotificationChannel(webhook_url)
+        assert repr(slack_channel)

--- a/client/verta/tests/operations/monitoring/notification_channels/test_entities.py
+++ b/client/verta/tests/operations/monitoring/notification_channels/test_entities.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+
+from verta.operations.monitoring.notification_channel import (
+    SlackNotificationChannel,
+)
+from verta.operations.monitoring.notification_channel import _entities
+
+
+class TestSlack:
+    def test_crud(self, client, strs):
+        notification_channels = client.operations.notification_channels
+        name, webhook_url = strs[:2]
+        slack_channel = SlackNotificationChannel(webhook_url)
+
+        created_channel = notification_channels.create(name, slack_channel)
+        assert isinstance(created_channel, _entities.NotificationChannel)
+        assert created_channel._msg.type == slack_channel._TYPE
+
+        retrieved_channel = notification_channels.get(id=created_channel.id)
+        assert isinstance(retrieved_channel, _entities.NotificationChannel)
+        assert retrieved_channel._msg.type == slack_channel._TYPE
+
+        listed_channels = notification_channels.list()
+        assert created_channel.id in map(lambda c: c.id, listed_channels)
+
+        assert notification_channels.delete([created_channel])
+
+    def test_repr(self, client, strs):
+        """__repr__() does not raise exceptions"""
+        notification_channels = client.operations.notification_channels
+        name, webhook_url = strs[:2]
+        slack_channel = SlackNotificationChannel(webhook_url)
+
+        created_channel = notification_channels.create(name, slack_channel)
+        assert repr(created_channel)
+
+        retrieved_channel = notification_channels.get(id=created_channel.id)
+        assert repr(retrieved_channel)

--- a/client/verta/verta/operations/monitoring/client.py
+++ b/client/verta/verta/operations/monitoring/client.py
@@ -6,6 +6,7 @@ import itertools
 from verta._tracking import _Context
 
 from .monitored_entity import MonitoredEntity
+from .notification_channel._entities import NotificationChannels
 from .profilers import Profilers
 from .summaries import Summaries
 from .labels import Labels
@@ -29,6 +30,10 @@ class Client(object):
     @property
     def _ctx(self):
         return self._client._ctx
+
+    @property
+    def notification_channels(self):
+        return NotificationChannels(self._conn, self._conf)
 
     def get_or_create_monitored_entity(self, name=None, workspace=None, id=None):
         if name is not None and id is not None:

--- a/client/verta/verta/operations/monitoring/notification_channel/__init__.py
+++ b/client/verta/verta/operations/monitoring/notification_channel/__init__.py
@@ -1,0 +1,4 @@
+from ._notification_channel import (
+    _NotificationChannel,
+    SlackNotificationChannel,
+)

--- a/client/verta/verta/operations/monitoring/notification_channel/_entities/__init__.py
+++ b/client/verta/verta/operations/monitoring/notification_channel/_entities/__init__.py
@@ -1,0 +1,1 @@
+from .notification_channel import NotificationChannel, NotificationChannels

--- a/client/verta/verta/operations/monitoring/notification_channel/_entities/notification_channel.py
+++ b/client/verta/verta/operations/monitoring/notification_channel/_entities/notification_channel.py
@@ -3,8 +3,10 @@
 import warnings
 
 from ....._protos.public.monitoring import Alert_pb2 as _AlertService
+from ....._internal_utils import _utils
 from ....._tracking import entity, _Context
 from ... import utils
+from .. import _notification_channel
 
 
 class NotificationChannel(entity._ModelDBEntity):
@@ -16,6 +18,22 @@ class NotificationChannel(entity._ModelDBEntity):
             "alerts",
             msg,
         )
+
+    def __repr__(self):
+        self._refresh_cache()
+        msg = self._msg
+        return "\n\t".join((
+            "Notification Channel",
+            "name: {}".format(msg.name),
+            "id: {}".format(msg.id),
+            "created: {}".format(
+                _utils.timestamp_to_str(msg.created_at_millis)),
+            "updated: {}".format(
+                _utils.timestamp_to_str(msg.updated_at_millis)),
+            "channel: {}".format(
+                # TODO: use a `channel` property that returns the actual class
+                _AlertService.NotificationChannelTypeEnum.NotificationChannelType.Name(msg.type)),
+        ))
 
     @classmethod
     def _get_proto_by_id(cls, conn, id):

--- a/client/verta/verta/operations/monitoring/notification_channel/_entities/notification_channel.py
+++ b/client/verta/verta/operations/monitoring/notification_channel/_entities/notification_channel.py
@@ -22,18 +22,21 @@ class NotificationChannel(entity._ModelDBEntity):
     def __repr__(self):
         self._refresh_cache()
         msg = self._msg
-        return "\n\t".join((
-            "Notification Channel",
-            "name: {}".format(msg.name),
-            "id: {}".format(msg.id),
-            "created: {}".format(
-                _utils.timestamp_to_str(msg.created_at_millis)),
-            "updated: {}".format(
-                _utils.timestamp_to_str(msg.updated_at_millis)),
-            "channel: {}".format(
-                # TODO: use a `channel` property that returns the actual class
-                _AlertService.NotificationChannelTypeEnum.NotificationChannelType.Name(msg.type)),
-        ))
+        return "\n\t".join(
+            (
+                "Notification Channel",
+                "name: {}".format(msg.name),
+                "id: {}".format(msg.id),
+                "created: {}".format(_utils.timestamp_to_str(msg.created_at_millis)),
+                "updated: {}".format(_utils.timestamp_to_str(msg.updated_at_millis)),
+                "channel: {}".format(
+                    # TODO: use a `channel` property that returns the actual class
+                    _AlertService.NotificationChannelTypeEnum.NotificationChannelType.Name(
+                        msg.type
+                    )
+                ),
+            )
+        )
 
     @classmethod
     def _get_proto_by_id(cls, conn, id):

--- a/client/verta/verta/operations/monitoring/notification_channel/_entities/notification_channel.py
+++ b/client/verta/verta/operations/monitoring/notification_channel/_entities/notification_channel.py
@@ -153,7 +153,7 @@ class NotificationChannels(object):
     # TODO: use lazy list and pagination
     # TODO: a proper find
     def list(self):
-        msg = _AlertService.FindNotificationChannelsRequest()
+        msg = _AlertService.FindNotificationChannelRequest()
         endpoint = "/api/v1/alerts/findNotificationChannel"
         response = self._conn.make_proto_request("POST", endpoint, body=msg)
         channels = self._conn.must_proto_response(response, msg.Response).channels

--- a/client/verta/verta/operations/monitoring/notification_channel/_entities/notification_channel.py
+++ b/client/verta/verta/operations/monitoring/notification_channel/_entities/notification_channel.py
@@ -1,0 +1,152 @@
+# -*- coding: utf-8 -*-
+
+import warnings
+
+from ....._protos.public.monitoring import Alert_pb2 as _AlertService
+from ....._tracking import entity, _Context
+from ... import utils
+
+
+class NotificationChannel(entity._ModelDBEntity):
+    def __init__(self, conn, conf, msg):
+        super(NotificationChannel, self).__init__(
+            conn,
+            conf,
+            _AlertService,
+            "alerts",
+            msg,
+        )
+
+    @classmethod
+    def _get_proto_by_id(cls, conn, id):
+        msg = _AlertService.FindNotificationChannelRequest(
+            ids=[int(id)],
+        )
+        endpoint = "/api/v1/alerts/findNotificationChannel"
+        response = conn.make_proto_request("POST", endpoint, body=msg)
+        channels = conn.must_proto_response(response, msg.Response).channels
+        if len(channels) > 1:
+            warnings.warn(
+                "unexpectedly found multiple alerts with the same name and"
+                " monitored entity ID"
+            )
+        return channels[0]
+
+    @classmethod
+    def _get_proto_by_name(cls, conn, name, workspace):
+        # NOTE: workspace is currently unsupported until https://vertaai.atlassian.net/browse/VR-9792
+        msg = _AlertService.FindNotificationChannelRequest(
+            names=[name],
+        )
+        endpoint = "/api/v1/alerts/findNotificationChannel"
+        response = conn.make_proto_request("POST", endpoint, body=msg)
+        channels = conn.must_proto_response(response, msg.Response).channels
+        if len(channels) > 1:
+            warnings.warn(
+                "unexpectedly found multiple alerts with the same name and"
+                " monitored entity ID"
+            )
+        return channels[0]
+
+    @classmethod
+    def _create_proto_internal(
+        cls,
+        conn,
+        ctx,
+        name,
+        channel,
+        created_at_millis,
+        updated_at_millis,
+    ):
+        msg = _AlertService.CreateNotificationChannelRequest(
+            channel=_AlertService.NotificationChannel(
+                name=name,
+                created_at_millis=created_at_millis,
+                updated_at_millis=updated_at_millis,
+                type=channel._TYPE,
+            )
+        )
+        if msg.channel.type == _AlertService.NotificationChannelTypeEnum.SLACK:
+            msg.channel.slack_webhook.CopyFrom(channel._as_proto())
+        else:
+            raise ValueError(
+                "unrecognized notification channel type enum value {}".format(
+                    msg.alert.alerter_type
+                )
+            )
+
+        endpoint = "/api/v1/alerts/createNotificationChannel"
+        response = conn.make_proto_request("POST", endpoint, body=msg)
+        notification_channel_msg = conn.must_proto_response(
+            response,
+            _AlertService.NotificationChannel,
+        )
+        return notification_channel_msg
+
+    def _update(self):
+        raise NotImplementedError
+
+    def delete(self):
+        msg = _AlertService.DeleteNotificationChannelRequest(ids=[self.id])
+        endpoint = "/api/v1/alerts/deleteNotificationChannel"
+        response = self._conn.make_proto_request("DELETE", endpoint, body=msg)
+        self._conn.must_response(response)
+        return True
+
+
+class NotificationChannels(object):
+    def __init__(self, conn, conf):
+        self._conn = conn
+        self._conf = conf
+
+    def create(
+        self,
+        name,
+        channel,
+        created_at_millis=None,
+        updated_at_millis=None,
+    ):
+        ctx = _Context(self._conn, self._conf)
+        return NotificationChannel._create(
+            self._conn,
+            self._conf,
+            ctx,
+            name=name,
+            channel=channel,
+            created_at_millis=created_at_millis,
+            updated_at_millis=updated_at_millis,
+        )
+
+    def get(self, name=None, id=None):
+        if name and id:
+            raise ValueError("cannot specify both `name` and `id`")
+        elif name:
+            return NotificationChannel._get_by_name(
+                self._conn,
+                self._conf,
+                name,
+                None,  # TODO: pass workspace instead of None
+            )
+        elif id:
+            return NotificationChannel._get_by_id(self._conn, self._conf, id)
+        else:
+            raise ValueError("must specify either `name` or `id`")
+
+    # TODO: use lazy list and pagination
+    # TODO: a proper find
+    def list(self):
+        msg = _AlertService.FindNotificationChannelsRequest()
+        endpoint = "/api/v1/alerts/findNotificationChannel"
+        response = self._conn.make_proto_request("POST", endpoint, body=msg)
+        channels = self._conn.must_proto_response(response, msg.Response).channels
+        return [
+            NotificationChannel(self._conn, self._conf, channel) for channel in channels
+        ]
+
+    def delete(self, channels):
+        channel_ids = utils.extract_ids(channels)
+        msg = _AlertService.DeleteNotificationChannelRequest(ids=channel_ids)
+        endpoint = "/api/v1/alerts/deleteNotificationChannel"
+        response = self._conn.make_proto_request("DELETE", endpoint, body=msg)
+        self._conn.must_response(response)
+        return True

--- a/client/verta/verta/operations/monitoring/notification_channel/_notification_channel.py
+++ b/client/verta/verta/operations/monitoring/notification_channel/_notification_channel.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+
+import abc
+
+from ....external import six
+
+from ...._protos.public.monitoring import Alert_pb2 as _AlertService
+
+
+# TODO: move into separate files
+@six.add_metaclass(abc.ABCMeta)
+class _NotificationChannel(object):
+    _TYPE = _AlertService.NotificationChannelTypeEnum.UNKNOWN
+
+    def __repr__(self):
+        return "<{} notification channel>".format(
+            _AlertService.NotificationChannelTypeEnum.NotificationChannelType.Name(
+                self._TYPE
+            ).lower()
+        )
+
+    @abc.abstractmethod
+    def _as_proto(self):
+        raise NotImplementedError
+
+
+class SlackNotificationChannel(_NotificationChannel):
+    _TYPE = _AlertService.NotificationChannelTypeEnum.SLACK
+
+    def __init__(self, url):
+        self._url = url
+
+    def _as_proto(self):
+        return _AlertService.NotificationChannelSlackWebhook(
+            url=self._url,
+        )


### PR DESCRIPTION
```python
from verta import Client
from verta.operations.monitoring.notification_channel import SlackNotificationChannel

client = Client().operations
channel = client.notification_channels.create(
    "slack-webhook",
    SlackNotificationChannel("https://hooks.slack.com/..."),
)
```

## Changes

### Config classes

- Add `_NotificationChannel` config classes (e.g. `SlackNotificationChannel(webhook_url)`) to `verta.operations.monitoring.notification_channel`

### Entities

- Add `NotificationChannel` create & get via `client.notification_channels.create()`, etc.