### PR TITLE
Skip tests properly

### DIFF
--- a/client/verta/tests/test_deployment.py
+++ b/client/verta/tests/test_deployment.py
@@ -667,7 +667,7 @@ class TestHistogram:
         assert float_hist['count'] == retrieved_float_hist['count']
 
 
-@pytest.skip(reason="old deployment API is being phased out (VR-7935)")
+@pytest.mark.skip(reason="old deployment API is being phased out (VR-7935)")
 class TestDeploy:
     def test_auto_path_auto_token_deploy(self, experiment_run, model_for_deployment):
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
@@ -874,7 +874,7 @@ class TestDeploy:
         )
 
 
-@pytest.skip(reason="old deployment API is being phased out (VR-7935)")
+@pytest.mark.skip(reason="old deployment API is being phased out (VR-7935)")
 class TestUndeploy:
     def test_undeploy(self, experiment_run, model_for_deployment):
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
@@ -897,7 +897,7 @@ class TestUndeploy:
         experiment_run.undeploy()
 
 
-@pytest.skip(reason="old deployment API is being phased out (VR-7935)")
+@pytest.mark.skip(reason="old deployment API is being phased out (VR-7935)")
 class TestGetDeployedModel:
     def test_get(self, experiment_run, model_for_deployment):
         model = model_for_deployment['model'].fit(


### PR DESCRIPTION
Follow-up to https://github.com/VertaAI/modeldb/pull/2113 😞 

I should've run the tests locally first, but I think adding a quick pytest check to the linting job (filed VR-10728) could also help catch this in PRs.