### PR TITLE
[VR-10699] Capture summary samples in alert status objects

### DIFF
--- a/client/verta/tests/operations/monitoring/alerts/test_entities.py
+++ b/client/verta/tests/operations/monitoring/alerts/test_entities.py
@@ -55,8 +55,8 @@ class TestIntegration:
         alert = alerts.create(name, alerter, sample_query)
         assert alert.status == Ok()
 
-        alert.set_status(Alerting(), summary_sample)
-        assert alert.status == Alerting()
+        alert.set_status(Alerting([summary_sample]))
+        assert alert.status == Alerting([summary_sample])
 
         alert.set_status(Ok())
         assert alert.status == Ok()

--- a/client/verta/tests/operations/monitoring/alerts/test_status.py
+++ b/client/verta/tests/operations/monitoring/alerts/test_status.py
@@ -1,5 +1,10 @@
 # -*- coding: utf-8 -*-
 
+import pytest
+import hypothesis
+import hypothesis.strategies as st
+
+from verta._protos.public.monitoring import Alert_pb2 as _AlertService
 from verta.operations.monitoring.alert.status import (
     Alerting,
     Ok,
@@ -7,13 +12,35 @@ from verta.operations.monitoring.alert.status import (
 
 
 class TestAlerting:
-    def test_repr(self):
+    @hypothesis.given(sample_ids=st.lists(st.integers(), min_size=1))
+    def test_creation(self, sample_ids):
+        status = Alerting(sample_ids)
+
+        assert status._ALERT_STATUS == _AlertService.AlertStatusEnum.ALERTING
+        assert status._sample_ids == sample_ids
+
+    def test_samples_required(self):
+        with pytest.raises(TypeError):
+            Alerting()  # pylint: disable=no-value-for-parameter
+
+    @hypothesis.given(sample_ids=st.lists(st.integers(), min_size=1))
+    def test_repr(self, sample_ids):
         """__repr__() does not raise exceptions"""
-        status = Alerting()
+        status = Alerting([sample_ids])
         assert repr(status)
 
 
 class TestOk:
+    @hypothesis.given(sample_ids=st.lists(st.integers(), min_size=1))
+    def test_creation(self, sample_ids):
+        status = Ok(sample_ids)
+
+        assert status._ALERT_STATUS == _AlertService.AlertStatusEnum.OK
+        assert status._sample_ids == sample_ids
+
+    def test_samples_optional(self):
+        assert Ok()
+
     def test_repr(self):
         """__repr__() does not raise exceptions"""
         status = Ok()

--- a/client/verta/verta/operations/monitoring/alert/_entities/alert.py
+++ b/client/verta/verta/operations/monitoring/alert/_entities/alert.py
@@ -192,10 +192,10 @@ class Alert(entity._ModelDBEntity):
 
         self._update(alert_msg)
 
-    def set_status(self, status, event_time_millis=None):
+    def set_status(self, status, event_time=None):
         msg = _AlertService.UpdateAlertStatusRequest(
             alert_id=self.id,
-            event_time_millis=event_time_millis,
+            event_time_millis=time_utils.epoch_millis(event_time) if event_time else None,
             status=status._ALERT_STATUS,
             violating_summary_sample_ids=status._sample_ids,
         )

--- a/client/verta/verta/operations/monitoring/alert/_entities/alert.py
+++ b/client/verta/verta/operations/monitoring/alert/_entities/alert.py
@@ -69,7 +69,17 @@ class Alert(entity._ModelDBEntity):
     def status(self):
         self._refresh_cache()
 
-        return status_module._AlertStatus._from_proto(self._msg.status)
+        if self._msg.status == status_module.Ok._ALERT_STATUS:
+            # violating samples aren't relevant to a retrieved Ok status
+            sample_ids = None
+        else:
+            sample_ids = self._msg.violating_summary_sample_ids
+
+
+        return status_module._AlertStatus._from_proto(
+            self._msg.status,
+            sample_ids,
+        )
 
     @property
     def summary_sample_query(self):
@@ -182,13 +192,12 @@ class Alert(entity._ModelDBEntity):
 
         self._update(alert_msg)
 
-    # TODO: alternatively, fire() & resolve()?
-    def set_status(self, status, summary_sample=None, event_time_millis=None):
+    def set_status(self, status, event_time_millis=None):
         msg = _AlertService.UpdateAlertStatusRequest(
             alert_id=self.id,
             event_time_millis=event_time_millis,
             status=status._ALERT_STATUS,
-            violating_summary_sample_id=summary_sample.id if summary_sample else None,
+            violating_summary_sample_ids=status._sample_ids,
         )
         endpoint = "/api/v1/alerts/updateAlertStatus"
         response = self._conn.make_proto_request("POST", endpoint, body=msg)
@@ -286,8 +295,10 @@ class Alerts(object):
 class AlertHistoryItem(object):
     def __init__(self, msg):
         self._event_time = time_utils.datetime_from_millis(msg.event_time_millis)
-        self._status = status_module._AlertStatus._from_proto(msg.status)
-        self._violating_summary_sample_ids = msg.violating_summary_sample_ids
+        self._status = status_module._AlertStatus._from_proto(
+            msg.status,
+            msg.violating_summary_sample_ids,
+        )
 
     def __repr__(self):
         return "\n\t".join(
@@ -295,8 +306,5 @@ class AlertHistoryItem(object):
                 "AlertHistoryItem",
                 "occurred at: {}".format(self._event_time),
                 "status: {}".format(self._status),
-                "associated summary sample IDs: {}".format(
-                    self._violating_summary_sample_ids
-                ),
             )
         )

--- a/client/verta/verta/operations/monitoring/alert/status/_status.py
+++ b/client/verta/verta/operations/monitoring/alert/status/_status.py
@@ -2,52 +2,85 @@
 
 import abc
 
-from .....external import six
+from verta.external import six
 
-from ....._protos.public.monitoring import Alert_pb2 as _AlertService
+from verta._protos.public.monitoring import Alert_pb2 as _AlertService
+
+from ... import utils
 
 
 # TODO: move into separate files
 @six.add_metaclass(abc.ABCMeta)
 class _AlertStatus(object):
+    """
+    Base class for alert status. Not for external use.
+
+    """
+
     _ALERT_STATUS = _AlertService.AlertStatusEnum.UNKNOWN
+
+    def __init__(self, summary_samples):
+        self._sample_ids = utils.extract_ids(summary_samples) if summary_samples else []
 
     def __eq__(self, other):
         if not isinstance(other, _AlertStatus):
             return NotImplemented
 
-        return self._ALERT_STATUS == other._ALERT_STATUS
+        if self._ALERT_STATUS != other._ALERT_STATUS:
+            return False
+        if set(self._sample_ids) != set(other._sample_ids):
+            return False
+
+        return True
 
     def __repr__(self):
         return "<{} alert status>".format(
             _AlertService.AlertStatusEnum.AlertStatus.Name(self._ALERT_STATUS).lower()
         )
 
-    @classmethod
-    def _from_proto(cls, msg):
-        """
-        Returns an alert status object.
-
-        Parameters
-        ----------
-        msg : int
-            Variant of ``AlertStatusEnum``.
-
-        Returns
-        -------
-        :class:`_AlertStatus` subclass
-
-        """
-        for subcls in cls.__subclasses__():
-            if msg == subcls._ALERT_STATUS:
-                return subcls()
-
-        raise ValueError("alert status {} not recognized".format(msg))
-
 
 class Alerting(_AlertStatus):
+    """
+    Alerting status for an alert.
+
+    Parameters
+    ----------
+    summary_samples : list of :class:`~verta.operations.monitoring.summary.SummarySample`
+        Summary samples that triggered the alert.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        from verta.operations.monitoring.alert.status import Alerting
+        alert.set_status(Alerting([monitored_entity]))
+
+    """
+
     _ALERT_STATUS = _AlertService.AlertStatusEnum.ALERTING
 
 
 class Ok(_AlertStatus):
+    """
+    Ok status for an alert.
+
+    Parameters
+    ----------
+    summary_samples : list of :class:`~verta.operations.monitoring.summary.SummarySample`, optional
+        Summary samples to be removed from the alert's list of violating
+        summary samples. If not provided, all summary samples will be cleared
+        from the list.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        from verta.operations.monitoring.alert.status import Ok
+        alert.set_status(Ok())
+
+    """
+
     _ALERT_STATUS = _AlertService.AlertStatusEnum.OK
+
+    def __init__(self, summary_samples=None):
+        super(Ok, self).__init__(summary_samples=summary_samples)

--- a/client/verta/verta/operations/monitoring/alert/status/_status.py
+++ b/client/verta/verta/operations/monitoring/alert/status/_status.py
@@ -34,9 +34,33 @@ class _AlertStatus(object):
         return True
 
     def __repr__(self):
-        return "<{} alert status>".format(
-            _AlertService.AlertStatusEnum.AlertStatus.Name(self._ALERT_STATUS).lower()
+        return "<alert status \"{}\" (sample IDs {})>".format(
+            _AlertService.AlertStatusEnum.AlertStatus.Name(self._ALERT_STATUS).lower(),
+            self._sample_ids,
         )
+
+    @classmethod
+    def _from_proto(cls, msg, sample_ids=None):
+        """
+        Returns an alert status object.
+
+        Parameters
+        ----------
+        msg : int
+            Variant of ``AlertStatusEnum``.
+        sample_ids : list of int
+            Summary Sample IDs that triggered the status.
+
+        Returns
+        -------
+        :class:`_AlertStatus` subclass
+
+        """
+        for subcls in cls.__subclasses__():
+            if msg == subcls._ALERT_STATUS:
+                return subcls(sample_ids)
+
+        raise ValueError("alert status {} not recognized".format(msg))
 
 
 class Alerting(_AlertStatus):


### PR DESCRIPTION
**before**
```python
from verta.operations.monitoring.alert.status import Alerting, Ok
alert.set_status(Alerting(), monitored_entity1)
alert.set_status(Alerting(), monitored_entity2)
alert.set_status(Ok())
```
**after**
```python
from verta.operations.monitoring.alert.status import Alerting, Ok
alert.set_status(Alerting([monitored_entity1, monitored_entity2]))
alert.set_status(Ok())
```

## Changes

- move "triggering summary samples" parameter from `alert.set_status()` to alert status objects (e.g. `Alerting()`)
- add docstrings for alert status objects, while I'm at it
- improve implementation of `alert.status` property (ignore violating summary samples if status is `Ok()`)