### PR TITLE
Add compare() to comparisons

### DIFF
--- a/client/verta/tests/common/comparison/test_comparison.py
+++ b/client/verta/tests/common/comparison/test_comparison.py
@@ -1,10 +1,14 @@
 # -*- coding: utf-8 -*-
 
+# for composite strategy
+# pylint: disable=no-value-for-parameter
+
 import hypothesis
 import hypothesis.strategies as st
 
 from verta._protos.public.common import CommonService_pb2 as _CommonService
 from verta.common.comparison import (
+    _VertaComparison,
     EqualTo,
     NotEqualTo,
     GreaterThan,
@@ -14,6 +18,17 @@ from verta.common.comparison import (
 )
 
 
+@st.composite
+def lower_and_higher(draw):
+    lower = draw(st.floats(allow_nan=False, allow_infinity=False))
+
+    higher = lower
+    while _VertaComparison.isclose(lower, higher):
+        higher = draw(st.floats(min_value=lower, exclude_min=True, allow_nan=False))
+
+    return lower, higher
+
+
 class TestEqualTo:
     @hypothesis.given(value=st.floats(allow_nan=False))
     def test_creation(self, value):
@@ -21,6 +36,13 @@ class TestEqualTo:
 
         assert comparison.value == value
         assert comparison._operator_as_proto() == _CommonService.OperatorEnum.EQ
+
+    @hypothesis.given(lower_and_higher=lower_and_higher())
+    def test_compare(self, lower_and_higher):
+        lower, higher = lower_and_higher
+
+        assert EqualTo(lower).compare(lower)
+        assert not EqualTo(lower).compare(higher)
 
     @hypothesis.given(value=st.floats())
     def test_repr(self, value):
@@ -38,6 +60,13 @@ class TestNotEqualTo:
         assert comparison.value == value
         assert comparison._operator_as_proto() == _CommonService.OperatorEnum.NE
 
+    @hypothesis.given(lower_and_higher=lower_and_higher())
+    def test_compare(self, lower_and_higher):
+        lower, higher = lower_and_higher
+
+        assert NotEqualTo(lower).compare(higher)
+        assert not NotEqualTo(lower).compare(lower)
+
     @hypothesis.given(value=st.floats())
     def test_repr(self, value):
         comparison = NotEqualTo(value)
@@ -53,6 +82,14 @@ class TestGreaterThan:
 
         assert comparison.value == value
         assert comparison._operator_as_proto() == _CommonService.OperatorEnum.GT
+
+    @hypothesis.given(lower_and_higher=lower_and_higher())
+    def test_compare(self, lower_and_higher):
+        lower, higher = lower_and_higher
+
+        assert GreaterThan(lower).compare(higher)
+        assert not GreaterThan(lower).compare(lower)
+        assert not GreaterThan(higher).compare(lower)
 
     @hypothesis.given(value=st.floats())
     def test_repr(self, value):
@@ -70,6 +107,14 @@ class TestGreaterThanOrEqualTo:
         assert comparison.value == value
         assert comparison._operator_as_proto() == _CommonService.OperatorEnum.GTE
 
+    @hypothesis.given(lower_and_higher=lower_and_higher())
+    def test_compare(self, lower_and_higher):
+        lower, higher = lower_and_higher
+
+        assert GreaterThanOrEqualTo(lower).compare(lower)
+        assert GreaterThanOrEqualTo(lower).compare(higher)
+        assert not GreaterThanOrEqualTo(higher).compare(lower)
+
     @hypothesis.given(value=st.floats())
     def test_repr(self, value):
         comparison = GreaterThanOrEqualTo(value)
@@ -86,6 +131,14 @@ class TestLessThan:
         assert comparison.value == value
         assert comparison._operator_as_proto() == _CommonService.OperatorEnum.LT
 
+    @hypothesis.given(lower_and_higher=lower_and_higher())
+    def test_compare(self, lower_and_higher):
+        lower, higher = lower_and_higher
+
+        assert LessThan(higher).compare(lower)
+        assert not LessThan(higher).compare(higher)
+        assert not LessThan(lower).compare(higher)
+
     @hypothesis.given(value=st.floats())
     def test_repr(self, value):
         comparison = LessThan(value)
@@ -101,6 +154,14 @@ class TestLessThanOrEqualTo:
 
         assert comparison.value == value
         assert comparison._operator_as_proto() == _CommonService.OperatorEnum.LTE
+
+    @hypothesis.given(lower_and_higher=lower_and_higher())
+    def test_compare(self, lower_and_higher):
+        lower, higher = lower_and_higher
+
+        assert LessThanOrEqualTo(higher).compare(higher)
+        assert LessThanOrEqualTo(higher).compare(lower)
+        assert not LessThanOrEqualTo(lower).compare(higher)
 
     @hypothesis.given(value=st.floats())
     def test_repr(self, value):

--- a/client/verta/verta/common/comparison/_equal_to.py
+++ b/client/verta/verta/common/comparison/_equal_to.py
@@ -19,9 +19,15 @@ class EqualTo(_VertaComparison):
     .. code-block:: python
 
         from verta.common.comparison import EqualTo
-        EqualTo(.5)
+        assert EqualTo(.5).compare(.5)
 
     """
 
     _OPERATOR = _CommonService.OperatorEnum.EQ
     _SYMBOL = "=="
+
+    def compare(self, other_value):
+        if isinstance(self.value, float) or isinstance(other_value, float):
+            return self.isclose(other_value, self.value)
+        else:
+            return other_value == self.value

--- a/client/verta/verta/common/comparison/_greater_than.py
+++ b/client/verta/verta/common/comparison/_greater_than.py
@@ -19,9 +19,12 @@ class GreaterThan(_VertaComparison):
     .. code-block:: python
 
         from verta.common.comparison import GreaterThan
-        GreaterThan(.7)
+        assert GreaterThan(.7).compare(.9)
 
     """
 
     _OPERATOR = _CommonService.OperatorEnum.GT
     _SYMBOL = ">"
+
+    def compare(self, other_value):
+        return other_value > self.value

--- a/client/verta/verta/common/comparison/_greater_than_or_equal_to.py
+++ b/client/verta/verta/common/comparison/_greater_than_or_equal_to.py
@@ -19,9 +19,12 @@ class GreaterThanOrEqualTo(_VertaComparison):
     .. code-block:: python
 
         from verta.common.comparison import GreaterThanOrEqualTo
-        GreaterThanOrEqualTo(.7)
+        assert GreaterThanOrEqualTo(.7).compare(.9)
 
     """
 
     _OPERATOR = _CommonService.OperatorEnum.GTE
     _SYMBOL = ">="
+
+    def compare(self, other_value):
+        return other_value >= self.value

--- a/client/verta/verta/common/comparison/_less_than.py
+++ b/client/verta/verta/common/comparison/_less_than.py
@@ -19,9 +19,12 @@ class LessThan(_VertaComparison):
     .. code-block:: python
 
         from verta.common.comparison import LessThan
-        LessThan(.3)
+        assert LessThan(.3).compare(.1)
 
     """
 
     _OPERATOR = _CommonService.OperatorEnum.LT
     _SYMBOL = "<"
+
+    def compare(self, other_value):
+        return other_value < self.value

--- a/client/verta/verta/common/comparison/_less_than_or_equal_to.py
+++ b/client/verta/verta/common/comparison/_less_than_or_equal_to.py
@@ -19,9 +19,12 @@ class LessThanOrEqualTo(_VertaComparison):
     .. code-block:: python
 
         from verta.common.comparison import LessThanOrEqualTo
-        LessThanOrEqualTo(.3)
+        assert LessThanOrEqualTo(.3).compare(.1)
 
     """
 
     _OPERATOR = _CommonService.OperatorEnum.LTE
     _SYMBOL = "<="
+
+    def compare(self, other_value):
+        return other_value <= self.value

--- a/client/verta/verta/common/comparison/_not_equal_to.py
+++ b/client/verta/verta/common/comparison/_not_equal_to.py
@@ -19,9 +19,15 @@ class NotEqualTo(_VertaComparison):
     .. code-block:: python
 
         from verta.common.comparison import NotEqualTo
-        NotEqualTo(.5)
+        assert NotEqualTo(.5).compare(.7)
 
     """
 
     _OPERATOR = _CommonService.OperatorEnum.NE
     _SYMBOL = "!="
+
+    def compare(self, other_value):
+        if isinstance(self.value, float) or isinstance(other_value, float):
+            return not self.isclose(other_value, self.value)
+        else:
+            return other_value != self.value

--- a/client/verta/verta/common/comparison/_verta_comparison.py
+++ b/client/verta/verta/common/comparison/_verta_comparison.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import abc
+import math
 
 from verta.external import six
 
@@ -24,9 +25,60 @@ class _VertaComparison(object):
             self.value,
         )
 
+    @staticmethod
+    def isclose(a, b, rel_tol=1e-9, abs_tol=0):
+        if six.PY3:
+            # pylint: disable=no-member
+            return math.isclose(a, b, rel_tol=rel_tol, abs_tol=abs_tol)
+        else:
+            # equivalent implementation
+            # https://docs.python.org/3/library/math.html#math.isclose
+            return abs(a - b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)
+
     @property
     def value(self):
         return self._value
 
     def _operator_as_proto(self):
         return self._OPERATOR
+
+    @classmethod
+    def _from_proto(cls, msg, value):
+        """
+        Returns an comparison object.
+
+        Parameters
+        ----------
+        msg : int
+            Variant of ``OperatorEnum``.
+        value : obj
+            Value to be compared against.
+
+        Returns
+        -------
+        :class:`_VertaComparison` subclass
+
+        """
+        for subcls in cls.__subclasses__():
+            if msg == subcls._OPERATOR:
+                return subcls(value)
+
+        raise ValueError("operator {} not recognized".format(msg))
+
+    @abc.abstractmethod
+    def compare(self, other_value):
+        """
+        Compares `other_value` with this comparison's value.
+
+        Parameters
+        ----------
+        other_value : obj
+            Value to be compared with this comparison's value.
+
+        Returns
+        -------
+        bool
+            Result of the comparison.
+
+        """
+        raise NotImplementedError


### PR DESCRIPTION
Basically re-invented Polish notation.

I found it very useful for the alerter for the actual comparison logic to be a part of the `_VertaComparison` interface.