### PR TITLE
[VR-10753] Add return-all pagination

### DIFF
--- a/client/verta/verta/operations/monitoring/alert/_entities/alert.py
+++ b/client/verta/verta/operations/monitoring/alert/_entities/alert.py
@@ -91,7 +91,7 @@ class Alert(entity._ModelDBEntity):
     @classmethod
     def _get_proto_by_id(cls, conn, id):
         msg = _AlertService.FindAlertRequest(
-            ids=[int(id)],
+            ids=[int(id)], page_number=1, page_limit=-1,
         )
         endpoint = "/api/v1/alerts/findAlert"
         response = conn.make_proto_request("POST", endpoint, body=msg)
@@ -108,6 +108,7 @@ class Alert(entity._ModelDBEntity):
         msg = _AlertService.FindAlertRequest(
             names=[name],
             monitored_entity_ids=[int(monitored_entity_id)],
+            page_number=1, page_limit=-1,
         )
         endpoint = "/api/v1/alerts/findAlert"
         response = conn.make_proto_request("POST", endpoint, body=msg)
@@ -266,7 +267,9 @@ class Alerts(object):
     # TODO: use lazy list and pagination
     # TODO: a proper find
     def list(self):
-        msg = _AlertService.FindAlertRequest()
+        msg = _AlertService.FindAlertRequest(
+            page_number=1, page_limit=-1,
+        )
         if self._monitored_entity_id is not None:
             msg.monitored_entity_ids.append(self._monitored_entity_id)
         endpoint = "/api/v1/alerts/findAlert"

--- a/client/verta/verta/operations/monitoring/labels.py
+++ b/client/verta/verta/operations/monitoring/labels.py
@@ -31,7 +31,9 @@ class Labels:
             :rtype: list
         """
         summary_filter = self._build_summary_filter(**kwargs)
-        msg = FindSampleLabelsRequest(filter=summary_filter)
+        msg = FindSampleLabelsRequest(
+            filter=summary_filter, page_number=1, page_limit=-1,
+        )
         endpoint = "/api/v1/labels/findLabels"
         response = self._conn.make_proto_request("POST", endpoint, body=msg)
         proto = self._conn.must_proto_response(
@@ -57,7 +59,10 @@ class Labels:
             keys = kwargs['keys']
         else:
             keys = []
-        msg = FindSampleLabelValuesRequest(filter=summary_filter, labels=keys)
+        msg = FindSampleLabelValuesRequest(
+            filter=summary_filter, labels=keys,
+            page_number=1, page_limit=-1,
+        )
         endpoint = "/api/v1/labels/findLabelValues"
         response = self._conn.make_proto_request("POST", endpoint, body=msg)
         proto = self._conn.must_proto_response(

--- a/client/verta/verta/operations/monitoring/notification_channel/_entities/notification_channel.py
+++ b/client/verta/verta/operations/monitoring/notification_channel/_entities/notification_channel.py
@@ -41,7 +41,7 @@ class NotificationChannel(entity._ModelDBEntity):
     @classmethod
     def _get_proto_by_id(cls, conn, id):
         msg = _AlertService.FindNotificationChannelRequest(
-            ids=[int(id)],
+            ids=[int(id)], page_number=1, page_limit=-1,
         )
         endpoint = "/api/v1/alerts/findNotificationChannel"
         response = conn.make_proto_request("POST", endpoint, body=msg)
@@ -57,7 +57,7 @@ class NotificationChannel(entity._ModelDBEntity):
     def _get_proto_by_name(cls, conn, name, workspace):
         # NOTE: workspace is currently unsupported until https://vertaai.atlassian.net/browse/VR-9792
         msg = _AlertService.FindNotificationChannelRequest(
-            names=[name],
+            names=[name], page_number=1, page_limit=-1,
         )
         endpoint = "/api/v1/alerts/findNotificationChannel"
         response = conn.make_proto_request("POST", endpoint, body=msg)
@@ -156,7 +156,9 @@ class NotificationChannels(object):
     # TODO: use lazy list and pagination
     # TODO: a proper find
     def list(self):
-        msg = _AlertService.FindNotificationChannelRequest()
+        msg = _AlertService.FindNotificationChannelRequest(
+            page_number=1, page_limit=-1,
+        )
         endpoint = "/api/v1/alerts/findNotificationChannel"
         response = self._conn.make_proto_request("POST", endpoint, body=msg)
         channels = self._conn.must_proto_response(response, msg.Response).channels


### PR DESCRIPTION
The backend has implemented pagination, which means that the client gets **nothing** unless we at least send _some_ value for pagination. This sets default values for the `/find*` requests, until we can fully implement pagination next week with VR-10744.