### PR TITLE
Revert "Mock third-party imports (#2141)"

### DIFF
--- a/client/verta/docs/conf.py
+++ b/client/verta/docs/conf.py
@@ -61,9 +61,6 @@ autodoc_mock_imports = [
     'verta._protos',
     'xgboost',
     'yaml',
-    'numpy',
-    'scipy',
-    'pandas',
 ]
 
 napoleon_use_rtype = False


### PR DESCRIPTION
Reverts VertaAI/modeldb#2141

This is unfortunately not sufficient to resolve an import-time conflict.