### PR TITLE
[VR-10773] Ensure that epoch_millis() returns int

### DIFF
--- a/client/verta/verta/_internal_utils/time_utils/_time_utils_py2.py
+++ b/client/verta/verta/_internal_utils/time_utils/_time_utils_py2.py
@@ -32,7 +32,7 @@ def now_in_millis():
 
 def epoch_millis(dt):
     if isinstance(dt, datetime):
-        return round((dt - UNIX_EPOCH).total_seconds() * 1000)
+        return int(round((dt - UNIX_EPOCH).total_seconds() * 1000))
     elif type(dt) == int:
         return dt
     else:

--- a/client/verta/verta/_internal_utils/time_utils/_time_utils_py3.py
+++ b/client/verta/verta/_internal_utils/time_utils/_time_utils_py3.py
@@ -17,7 +17,7 @@ def now_in_millis():
 
 def epoch_millis(dt):
     if isinstance(dt, datetime):
-        return round((dt - UNIX_EPOCH).total_seconds() * 1000)
+        return int(round((dt - UNIX_EPOCH).total_seconds() * 1000))
     elif type(dt) == int:
         return dt
     else:


### PR DESCRIPTION
In Python 2, the built-in `round()` returns a float, even if rounding to the ones place unlike its Python 3 counterpart.

This causes issues when the proto message constructor consuming its return expects an int.