### PR TITLE
[VR-10760] Take datetime as a parameter

### DIFF
--- a/client/verta/tests/operations/monitoring/alerts/test_entities.py
+++ b/client/verta/tests/operations/monitoring/alerts/test_entities.py
@@ -83,6 +83,7 @@ class TestIntegration:
 
 class TestAlert:
     """Tests that aren't specific to an alerter type."""
+
     def test_update_last_evaluated_at(self, monitored_entity):
         alerts = monitored_entity.alerts
         name = _utils.generate_default_name()
@@ -104,6 +105,47 @@ class TestAlert:
         alert._update_last_evaluated_at(yesterday)
         alert._fetch_with_no_cache()
         assert alert._msg.last_evaluated_at_millis == yesterday_millis
+
+    def test_creation_datetime(self, monitored_entity, strs, created_entities):
+        strs = iter(strs)
+        alerts = monitored_entity.alerts
+        alerter = FixedAlerter(comparison.GreaterThan(0.7))
+        sample_query = SummarySampleQuery()
+
+        created_at = time_utils.now() - datetime.timedelta(weeks=1)
+        updated_at = time_utils.now() - datetime.timedelta(days=1)
+        last_evaluated_at = time_utils.now() - datetime.timedelta(hours=1)
+        created_at_millis = time_utils.epoch_millis(created_at)
+        updated_at_millis = time_utils.epoch_millis(updated_at)
+        last_evaluated_at_millis = time_utils.epoch_millis(last_evaluated_at)
+
+        # as datetime
+        alert = alerts.create(
+            next(strs),
+            alerter,
+            sample_query,
+            created_at=created_at,
+            updated_at=updated_at,
+            last_evaluated_at=last_evaluated_at,
+        )
+        created_entities.append(alert)
+        assert alert._msg.created_at_millis == created_at_millis
+        assert alert._msg.updated_at_millis == updated_at_millis
+        assert alert._msg.last_evaluated_at_millis == last_evaluated_at_millis
+
+        # as millis
+        alert = alerts.create(
+            next(strs),
+            alerter,
+            sample_query,
+            created_at=created_at_millis,
+            updated_at=updated_at_millis,
+            last_evaluated_at=last_evaluated_at_millis,
+        )
+        created_entities.append(alert)
+        assert alert._msg.created_at_millis == created_at_millis
+        assert alert._msg.updated_at_millis == updated_at_millis
+        assert alert._msg.last_evaluated_at_millis == last_evaluated_at_millis
 
 
 class TestFixed:

--- a/client/verta/tests/operations/monitoring/notification_channels/test_entities.py
+++ b/client/verta/tests/operations/monitoring/notification_channels/test_entities.py
@@ -1,9 +1,47 @@
 # -*- coding: utf-8 -*-
 
+import datetime
+
+from verta._internal_utils import time_utils
 from verta.operations.monitoring.notification_channel import (
     SlackNotificationChannel,
 )
 from verta.operations.monitoring.notification_channel import _entities
+
+
+class TestNotificationChannel:
+    """Tests that aren't specific to a channel type."""
+
+    def test_creation_datetime(self, client, strs, created_entities):
+        strs = iter(strs)
+        notification_channels = client.operations.notification_channels
+
+        created_at = time_utils.now() - datetime.timedelta(weeks=1)
+        updated_at = time_utils.now() - datetime.timedelta(days=1)
+        created_at_millis = time_utils.epoch_millis(created_at)
+        updated_at_millis = time_utils.epoch_millis(updated_at)
+
+        # as datetime
+        channel = notification_channels.create(
+            next(strs),
+            SlackNotificationChannel(next(strs)),
+            created_at,
+            updated_at,
+        )
+        created_entities.append(channel)
+        assert channel._msg.created_at_millis == created_at_millis
+        assert channel._msg.updated_at_millis == updated_at_millis
+
+        # as millis
+        channel = notification_channels.create(
+            next(strs),
+            SlackNotificationChannel(next(strs)),
+            created_at_millis,
+            updated_at_millis,
+        )
+        created_entities.append(channel)
+        assert channel._msg.created_at_millis == created_at_millis
+        assert channel._msg.updated_at_millis == updated_at_millis
 
 
 class TestSlack:

--- a/client/verta/tests/operations/monitoring/test_summaries.py
+++ b/client/verta/tests/operations/monitoring/test_summaries.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import datetime
+
 from verta._internal_utils._utils import generate_default_name
 from verta.operations.monitoring.summaries import (
     Summary,
@@ -71,3 +73,35 @@ class TestSummaries(object):
             SummarySampleQuery(labels={"color": ["blue"]}),
         )
         assert len(blue_samples) == 1
+
+
+class TestSummarySampleQuery:
+    def test_creation_datetime(self):
+        time_window_start = time_utils.now() - datetime.timedelta(weeks=1)
+        time_window_end = time_utils.now() - datetime.timedelta(days=1)
+        created_after =  time_utils.now() - datetime.timedelta(hours=1)
+        time_window_start_millis = time_utils.epoch_millis(time_window_start)
+        time_window_end_millis = time_utils.epoch_millis(time_window_end)
+        created_after_millis = time_utils.epoch_millis(created_after)
+
+        # as datetime
+        sample_query = SummarySampleQuery(
+            time_window_start=time_window_start,
+            time_window_end=time_window_end,
+            created_after=created_after,
+        )
+        proto_request = sample_query._to_proto_request()
+        assert proto_request.filter.time_window_start_at_millis == time_window_start_millis
+        assert proto_request.filter.time_window_end_at_millis == time_window_end_millis
+        assert proto_request.filter.created_at_after_millis == created_after_millis
+
+        # as millis
+        sample_query = SummarySampleQuery(
+            time_window_start=time_window_start_millis,
+            time_window_end=time_window_end_millis,
+            created_after=created_after_millis,
+        )
+        proto_request = sample_query._to_proto_request()
+        assert proto_request.filter.time_window_start_at_millis == time_window_start_millis
+        assert proto_request.filter.time_window_end_at_millis == time_window_end_millis
+        assert proto_request.filter.created_at_after_millis == created_after_millis

--- a/client/verta/verta/_internal_utils/time_utils/_time_utils_py2.py
+++ b/client/verta/verta/_internal_utils/time_utils/_time_utils_py2.py
@@ -35,6 +35,8 @@ def epoch_millis(dt):
         return int(round((dt - UNIX_EPOCH).total_seconds() * 1000))
     elif type(dt) == int:
         return dt
+    elif dt is None:
+        return dt
     else:
         raise ValueError("Cannot convert argument to epoch milliseconds")
 

--- a/client/verta/verta/_internal_utils/time_utils/_time_utils_py3.py
+++ b/client/verta/verta/_internal_utils/time_utils/_time_utils_py3.py
@@ -20,6 +20,8 @@ def epoch_millis(dt):
         return int(round((dt - UNIX_EPOCH).total_seconds() * 1000))
     elif type(dt) == int:
         return dt
+    elif dt is None:
+        return dt
     else:
         raise ValueError("Cannot convert argument to epoch milliseconds")
 

--- a/client/verta/verta/operations/monitoring/alert/_entities/alert.py
+++ b/client/verta/verta/operations/monitoring/alert/_entities/alert.py
@@ -240,9 +240,9 @@ class Alerts(object):
         alerter,
         summary_sample_query,
         notification_channels=None,
-        created_at_millis=None,
-        updated_at_millis=None,
-        last_evaluated_at_millis=None,
+        created_at=None,
+        updated_at=None,
+        last_evaluated_at=None,
     ):
         if self._monitored_entity_id is None:
             raise RuntimeError(
@@ -265,9 +265,9 @@ class Alerts(object):
             alerter=alerter,
             summary_sample_query=summary_sample_query,
             notification_channels=notification_channels,
-            created_at_millis=created_at_millis,
-            updated_at_millis=updated_at_millis,
-            last_evaluated_at_millis=last_evaluated_at_millis,
+            created_at_millis=time_utils.epoch_millis(created_at),
+            updated_at_millis=time_utils.epoch_millis(updated_at),
+            last_evaluated_at_millis=time_utils.epoch_millis(last_evaluated_at),
         )
 
     def get(self, name=None, id=None):

--- a/client/verta/verta/operations/monitoring/notification_channel/_entities/notification_channel.py
+++ b/client/verta/verta/operations/monitoring/notification_channel/_entities/notification_channel.py
@@ -3,10 +3,9 @@
 import warnings
 
 from ....._protos.public.monitoring import Alert_pb2 as _AlertService
-from ....._internal_utils import _utils
+from ....._internal_utils import _utils, time_utils
 from ....._tracking import entity, _Context
 from ... import utils
-from .. import _notification_channel
 
 
 class NotificationChannel(entity._ModelDBEntity):
@@ -124,8 +123,8 @@ class NotificationChannels(object):
         self,
         name,
         channel,
-        created_at_millis=None,
-        updated_at_millis=None,
+        created_at=None,
+        updated_at=None,
     ):
         ctx = _Context(self._conn, self._conf)
         return NotificationChannel._create(
@@ -134,8 +133,8 @@ class NotificationChannels(object):
             ctx,
             name=name,
             channel=channel,
-            created_at_millis=created_at_millis,
-            updated_at_millis=updated_at_millis,
+            created_at_millis=time_utils.epoch_millis(created_at),
+            updated_at_millis=time_utils.epoch_millis(updated_at),
         )
 
     def get(self, name=None, id=None):

--- a/client/verta/verta/operations/monitoring/summaries.py
+++ b/client/verta/verta/operations/monitoring/summaries.py
@@ -81,9 +81,9 @@ class SummarySampleQuery(object):
         summary_query=None,
         ids=None,
         labels=None,
-        time_window_start_at_millis=None,
-        time_window_end_at_millis=None,
-        created_at_after_millis=None,
+        time_window_start=None,
+        time_window_end=None,
+        created_after=None,
         page_number=1,
         page_limit=None,
     ):
@@ -93,9 +93,9 @@ class SummarySampleQuery(object):
         self._find_summaries = summary_query._to_proto_request()
         self._sample_ids = extract_ids(ids) if ids else None
         self._labels = maybe(Summary._labels_proto, labels)
-        self._time_window_start_at_millis = time_window_start_at_millis
-        self._time_window_end_at_millis = time_window_end_at_millis
-        self._created_at_after_millis = created_at_after_millis
+        self._time_window_start = time_window_start
+        self._time_window_end = time_window_end
+        self._created_after = created_after
         self._page_number = page_number
         self._page_limit = page_limit
 
@@ -106,9 +106,9 @@ class SummarySampleQuery(object):
         obj._find_summaries = msg.filter.find_summaries
         obj._sample_ids = msg.filter.sample_ids
         obj._labels = msg.filter.labels
-        obj._time_window_start_at_millis = msg.filter.time_window_start_at_millis
-        obj._time_window_end_at_millis = msg.filter.time_window_end_at_millis
-        obj._created_at_after_millis = msg.filter.created_at_after_millis
+        obj._time_window_start = time_utils.datetime_from_millis(msg.filter.time_window_start_at_millis)
+        obj._time_window_end = time_utils.datetime_from_millis(msg.filter.time_window_end_at_millis)
+        obj._created_after = time_utils.datetime_from_millis(msg.filter.created_at_after_millis)
         obj._page_number = msg.page_number
         obj._page_limit = pagination_utils.page_limit_from_proto(msg.page_limit)
 
@@ -120,9 +120,9 @@ class SummarySampleQuery(object):
                 find_summaries=self._find_summaries,
                 sample_ids=self._sample_ids,
                 labels=self._labels,
-                time_window_start_at_millis=self._time_window_start_at_millis,
-                time_window_end_at_millis=self._time_window_end_at_millis,
-                created_at_after_millis=self._created_at_after_millis,
+                time_window_start_at_millis=time_utils.epoch_millis(self._time_window_start),
+                time_window_end_at_millis=time_utils.epoch_millis(self._time_window_end),
+                created_at_after_millis=time_utils.epoch_millis(self._created_after),
             ),
             page_number=self._page_number,
             page_limit=pagination_utils.page_limit_to_proto(self._page_limit),


### PR DESCRIPTION
## Changes
Accept `datetime` objects as parameters in:
- alerts.create()
- notification_channels.create()
- SummarySampleQuery()
- allow time_utils.epoch_millis() to take and return `None`