### PR TITLE
[VR-10496] Enable creation of reference-based alert

### DIFF
--- a/client/verta/tests/operations/monitoring/alerts/test_alerter.py
+++ b/client/verta/tests/operations/monitoring/alerts/test_alerter.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=unidiomatic-typecheck
 
 import hypothesis
 import hypothesis.strategies as st
 
 from verta._protos.public.monitoring import Alert_pb2 as _AlertService
 from verta.operations.monitoring.alert import (
+    _Alerter,
     FixedAlerter,
     ReferenceAlerter,
 )
@@ -23,6 +25,20 @@ class TestFixed:
             threshold=threshold,
             operator=comparison._OPERATOR,
         )
+        assert alerter._as_proto() == msg
+
+    @hypothesis.given(
+        comparison=st.sampled_from(_VertaComparison.__subclasses__()),
+        threshold=st.floats(allow_nan=False),
+    )
+    def test_from_proto(self, comparison, threshold):
+        msg = _AlertService.AlertFixed(
+            threshold=threshold,
+            operator=comparison._OPERATOR,
+        )
+
+        alerter = _Alerter._from_proto(msg)
+        assert type(alerter) is FixedAlerter
         assert alerter._as_proto() == msg
 
     @hypothesis.given(
@@ -50,6 +66,22 @@ class TestReference:
             reference_sample_id=reference_sample_id,
             operator=comparison._OPERATOR,
         )
+        assert alerter._as_proto() == msg
+
+    @hypothesis.given(
+        comparison=st.sampled_from(_VertaComparison.__subclasses__()),
+        threshold=st.floats(allow_nan=False),
+        reference_sample_id=st.integers(min_value=1, max_value=2 ** 64 - 1),
+    )
+    def test_from_proto(self, comparison, threshold, reference_sample_id):
+        msg = _AlertService.AlertReference(
+            threshold=threshold,
+            reference_sample_id=reference_sample_id,
+            operator=comparison._OPERATOR,
+        )
+
+        alerter = _Alerter._from_proto(msg)
+        assert type(alerter) is ReferenceAlerter
         assert alerter._as_proto() == msg
 
     @hypothesis.given(

--- a/client/verta/tests/operations/monitoring/alerts/test_alerter.py
+++ b/client/verta/tests/operations/monitoring/alerts/test_alerter.py
@@ -38,26 +38,27 @@ class TestFixed:
 
 class TestReference:
     @hypothesis.given(
+        comparison=st.sampled_from(_VertaComparison.__subclasses__()),
         threshold=st.floats(allow_nan=False),
         reference_sample_id=st.integers(min_value=1, max_value=2 ** 64 - 1),
     )
-    def test_create(self, threshold, reference_sample_id):
-        alerter = ReferenceAlerter(threshold, reference_sample_id)
-        assert alerter._threshold == threshold
-        assert alerter._reference_sample_id == reference_sample_id
+    def test_create(self, comparison, threshold, reference_sample_id):
+        alerter = ReferenceAlerter(comparison(threshold), reference_sample_id)
 
         msg = _AlertService.AlertReference(
             threshold=threshold,
             reference_sample_id=reference_sample_id,
+            operator=comparison._OPERATOR,
         )
         assert alerter._as_proto() == msg
 
     @hypothesis.given(
+        comparison=st.sampled_from(_VertaComparison.__subclasses__()),
         threshold=st.floats(allow_nan=False),
         reference_sample_id=st.integers(min_value=1, max_value=2 ** 64 - 1),
     )
-    def test_repr(self, threshold, reference_sample_id):
+    def test_repr(self, comparison, threshold, reference_sample_id):
         """__repr__() does not raise exceptions"""
-        alerter = ReferenceAlerter(threshold, reference_sample_id)
+        alerter = ReferenceAlerter(comparison(threshold), reference_sample_id)
 
         assert repr(alerter)

--- a/client/verta/tests/operations/monitoring/alerts/test_entities.py
+++ b/client/verta/tests/operations/monitoring/alerts/test_entities.py
@@ -68,9 +68,11 @@ class TestIntegration:
         alert = alerts.create(name, alerter, sample_query)
         created_entities.append(alert)
         assert alert.status == Ok()
+        assert alert._last_evaluated_or_created_millis == alert._msg.created_at_millis
 
         alert.set_status(Alerting([summary_sample]))
         assert alert.status == Alerting([summary_sample])
+        assert alert._last_evaluated_or_created_millis == alert._msg.last_evaluated_at_millis
 
         alert.set_status(Ok())
         assert alert.status == Ok()
@@ -166,6 +168,7 @@ class TestFixed:
         created_alert = alerts.create(name, alerter, sample_query)
         assert isinstance(created_alert, _entities.Alert)
         assert created_alert._msg.alerter_type == alerter._TYPE
+        assert created_alert.monitored_entity_id == monitored_entity.id
 
         retrieved_alert = alerts.get(id=created_alert.id)
         client_retrieved_alert = client.operations.alerts.get(id=created_alert.id)
@@ -206,6 +209,7 @@ class TestReference:
         created_alert = alerts.create(name, alerter, sample_query)
         assert isinstance(created_alert, _entities.Alert)
         assert created_alert._msg.alerter_type == alerter._TYPE
+        assert created_alert.monitored_entity_id == monitored_entity.id
 
         retrieved_alert = alerts.get(id=created_alert.id)
         client_retrieved_alert = client.operations.alerts.get(id=created_alert.id)

--- a/client/verta/tests/operations/monitoring/alerts/test_entities.py
+++ b/client/verta/tests/operations/monitoring/alerts/test_entities.py
@@ -26,7 +26,10 @@ class TestIntegration:
     """Alerts + related entities/objects."""
 
     def test_add_notification_channels(
-        self, client, monitored_entity, created_entities,
+        self,
+        client,
+        monitored_entity,
+        created_entities,
     ):
         alerts = monitored_entity.alerts
         name = _utils.generate_default_name()
@@ -175,7 +178,7 @@ class TestFixed:
         assert retrieved_alert.id == client_retrieved_alert.id
         assert isinstance(retrieved_alert, _entities.Alert)
         assert retrieved_alert._msg.alerter_type == alerter._TYPE
-        assert retrieved_alert._msg.alerter_fixed == alerter._as_proto()
+        assert retrieved_alert.alerter._as_proto() == alerter._as_proto()
 
         listed_alerts = alerts.list()
         assert created_alert.id in map(lambda a: a.id, listed_alerts)
@@ -216,9 +219,8 @@ class TestReference:
         assert retrieved_alert.id == client_retrieved_alert.id
         assert isinstance(retrieved_alert, _entities.Alert)
         assert retrieved_alert._msg.alerter_type == alerter._TYPE
-        alerter_proto = retrieved_alert._msg.alerter_reference
-        assert alerter_proto == alerter._as_proto()
-        assert alerter_proto.reference_sample_id == summary_sample.id
+        assert retrieved_alert.alerter._as_proto() == alerter._as_proto()
+        assert retrieved_alert.alerter._reference_sample_id == summary_sample.id
 
         listed_alerts = alerts.list()
         assert created_alert.id in map(lambda a: a.id, listed_alerts)

--- a/client/verta/verta/operations/monitoring/alert/_alerter.py
+++ b/client/verta/verta/operations/monitoring/alert/_alerter.py
@@ -64,12 +64,19 @@ class FixedAlerter(_Alerter):
 class ReferenceAlerter(_Alerter):
     _TYPE = _AlertService.AlerterTypeEnum.REFERENCE
 
-    def __init__(self, threshold, reference_sample):
-        self._threshold = threshold
+    def __init__(self, comparison, reference_sample):
+        if not isinstance(comparison, comparison_module._VertaComparison):
+            raise TypeError(
+                "`comparison` must be an object from verta.common.comparison,"
+                " not {}".format(type(comparison))
+            )
+
+        self._comparison = comparison
         self._reference_sample_id = utils.extract_id(reference_sample)
 
     def _as_proto(self):
         return _AlertService.AlertReference(
-            threshold=self._threshold,
+            threshold=self._comparison.value,
             reference_sample_id=self._reference_sample_id,
+            operator=self._comparison._operator_as_proto(),
         )

--- a/client/verta/verta/operations/monitoring/alert/_alerter.py
+++ b/client/verta/verta/operations/monitoring/alert/_alerter.py
@@ -62,8 +62,7 @@ class FixedAlerter(_Alerter):
 
 
 class ReferenceAlerter(_Alerter):
-    """
-    Compare distances between samples and a reference against a threshold.
+    """Compare distances between samples and a reference against a threshold.
 
     Parameters
     ----------

--- a/client/verta/verta/operations/monitoring/alert/_alerter.py
+++ b/client/verta/verta/operations/monitoring/alert/_alerter.py
@@ -14,15 +14,41 @@ from .. import utils
 class _Alerter(object):
     _TYPE = _AlertService.AlerterTypeEnum.UNKNOWN
 
+    def __init__(self, comparison):
+        if not isinstance(comparison, comparison_module._VertaComparison):
+            raise TypeError(
+                "`comparison` must be an object from verta.common.comparison,"
+                " not {}".format(type(comparison))
+            )
+
+        self._comparison = comparison
+
     def __repr__(self):
         return "<{} alert>".format(
             _AlertService.AlerterTypeEnum.AlerterType.Name(self._TYPE).lower()
         )
 
+    @property
+    def comparison(self):
+        return self._comparison
+
     @abc.abstractmethod
     def _as_proto(self):
         raise NotImplementedError
 
+    @staticmethod
+    def _from_proto(msg):
+        comparison = comparison_module._VertaComparison._from_proto(
+            msg.operator,
+            msg.threshold,
+        )
+
+        if isinstance(msg, _AlertService.AlertFixed):
+            return FixedAlerter(comparison)
+        elif isinstance(msg, _AlertService.AlertReference):
+            return ReferenceAlerter(comparison, msg.reference_sample_id)
+
+        raise ValueError("unrecognized alerter type {}".format(type(msg)))
 
 class FixedAlerter(_Alerter):
     """
@@ -41,15 +67,6 @@ class FixedAlerter(_Alerter):
     """
 
     _TYPE = _AlertService.AlerterTypeEnum.FIXED
-
-    def __init__(self, comparison):
-        if not isinstance(comparison, comparison_module._VertaComparison):
-            raise TypeError(
-                "`comparison` must be an object from verta.common.comparison,"
-                " not {}".format(type(comparison))
-            )
-
-        self._comparison = comparison
 
     def __repr__(self):
         return "<fixed alerter ({})>".format(self._comparison)
@@ -99,13 +116,7 @@ class ReferenceAlerter(_Alerter):
     _TYPE = _AlertService.AlerterTypeEnum.REFERENCE
 
     def __init__(self, comparison, reference_sample):
-        if not isinstance(comparison, comparison_module._VertaComparison):
-            raise TypeError(
-                "`comparison` must be an object from verta.common.comparison,"
-                " not {}".format(type(comparison))
-            )
-
-        self._comparison = comparison
+        super(ReferenceAlerter, self).__init__(comparison)
         self._reference_sample_id = utils.extract_id(reference_sample)
 
     def _as_proto(self):

--- a/client/verta/verta/operations/monitoring/alert/_alerter.py
+++ b/client/verta/verta/operations/monitoring/alert/_alerter.py
@@ -62,6 +62,41 @@ class FixedAlerter(_Alerter):
 
 
 class ReferenceAlerter(_Alerter):
+    """
+    Compare distances between samples and a reference against a threshold.
+
+    Parameters
+    ----------
+    comparison : :class:`~verta.common.comparison._VertaComparison`
+        Alert condition. An alert is active if the distance between a queried
+        sample and `reference_sample` meets this condition.
+    reference_sample : :class:`~verta.operations.monitoring.summarySummarySample`
+        An existing summary sample to compare queried samples with.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        from verta import Client
+        from verta.common.comparison import GreaterThan
+        from verta.operations.monitoring.alert import ReferenceAlerter
+        from verta.operations.monitoring.summaries import SummarySampleQuery
+
+        ref_sample = summary.find_samples(SummarySampleQuery(ids=[123]))[0]
+        alerter = ReferenceAlerter(
+            GreaterThan(.7),
+            ref_sample,
+        )
+
+        alert = monitored_entity.alerts.create(
+            name="MSE",
+            alerter=alerter,
+            summary_sample_query=sample_query,
+            notification_channels=[channel],
+        )
+
+    """
+
     _TYPE = _AlertService.AlerterTypeEnum.REFERENCE
 
     def __init__(self, comparison, reference_sample):

--- a/client/verta/verta/operations/monitoring/alert/_entities/alert.py
+++ b/client/verta/verta/operations/monitoring/alert/_entities/alert.py
@@ -60,6 +60,19 @@ class Alert(entity._ModelDBEntity):
         return list(map(AlertHistoryItem, history))
 
     @property
+    def _last_evaluated_or_created_millis(self):
+        """For the alerter to filter for new summary samples."""
+        self._refresh_cache()
+
+        return self._msg.last_evaluated_at_millis or self._msg.created_at_millis
+
+    @property
+    def monitored_entity_id(self):
+        self._refresh_cache()
+
+        return self._msg.monitored_entity_id
+
+    @property
     def name(self):
         self._refresh_cache()
 

--- a/client/verta/verta/operations/monitoring/alert/_entities/alert.py
+++ b/client/verta/verta/operations/monitoring/alert/_entities/alert.py
@@ -8,6 +8,7 @@ from ....._tracking import entity, _Context
 from ... import notification_channel
 from ... import summaries
 from ... import utils
+from .. import _alerter
 from .. import status as status_module
 
 
@@ -49,6 +50,14 @@ class Alert(entity._ModelDBEntity):
                 ),
             )
         )
+
+    @property
+    def alerter(self):
+        self._refresh_cache()
+        alerter_field = self._msg.WhichOneof("alerter")
+        alerter_msg = getattr(self._msg, alerter_field)
+
+        return _alerter._Alerter._from_proto(alerter_msg)
 
     @property
     def history(self):


### PR DESCRIPTION
## Changes

- enable `ReferenceAlerter` to take a `_VertaComparison` rather than simply a `float` threshold
- add tests