### PR TITLE
[VR-10839] Fix workspace get_or_create bug for monitored entities

### DIFF
--- a/client/verta/tests/operations/monitoring/test_client.py
+++ b/client/verta/tests/operations/monitoring/test_client.py
@@ -13,3 +13,20 @@ class TestClient(object):
         name = monitored_entity.name
         retrieved_entity = client.operations.get_or_create_monitored_entity(name=name)
         assert monitored_entity.id == retrieved_entity.id
+
+    def test_create_ME_in_workspace(self, client):
+        ops = client.operations
+        team_workspace = "Demos"
+        default_workspace = client._conn.get_default_workspace()
+        assert team_workspace != default_workspace
+
+        monitored_in_default = ops.get_or_create_monitored_entity()
+        assert monitored_in_default.id
+        assert monitored_in_default.workspace == default_workspace
+
+        monitored_in_team = ops.get_or_create_monitored_entity(workspace=team_workspace)
+        assert monitored_in_team.id
+        assert monitored_in_team.workspace == team_workspace
+
+        still_default = client.get_workspace()
+        assert still_default == default_workspace

--- a/client/verta/tests/operations/monitoring/test_client.py
+++ b/client/verta/tests/operations/monitoring/test_client.py
@@ -17,7 +17,7 @@ class TestClient(object):
     def test_create_ME_in_workspace(self, client):
         ops = client.operations
         team_workspace = "Demos"
-        default_workspace = client._conn.get_default_workspace()
+        default_workspace = client.get_workspace()
         assert team_workspace != default_workspace
 
         monitored_in_default = ops.get_or_create_monitored_entity()

--- a/client/verta/tests/operations/monitoring/test_client.py
+++ b/client/verta/tests/operations/monitoring/test_client.py
@@ -14,9 +14,9 @@ class TestClient(object):
         retrieved_entity = client.operations.get_or_create_monitored_entity(name=name)
         assert monitored_entity.id == retrieved_entity.id
 
-    def test_create_ME_in_workspace(self, client):
+    def test_create_ME_in_workspace(self, client, organization):
         ops = client.operations
-        team_workspace = "Demos"
+        team_workspace = organization.name
         default_workspace = client.get_workspace()
         assert team_workspace != default_workspace
 

--- a/client/verta/verta/operations/monitoring/client.py
+++ b/client/verta/verta/operations/monitoring/client.py
@@ -109,10 +109,6 @@ class Client(object):
         if workspace is None:
             workspace = self._client.get_workspace()
 
-        ctx = self._ctx
-        ctx.workspace_name = workspace
-
-        resource_name = "MonitoredEntity"
         if id is not None:
             entity = MonitoredEntity._get_by_id(self._conn, self._conf, id)
         else:
@@ -123,7 +119,7 @@ class Client(object):
                     self._conn, self._conf, name=name, parent=workspace
                 ),
                 lambda name: MonitoredEntity._create(
-                    self._conn, self._conf, ctx, name=name
+                    self._conn, self._conf, self._ctx, name=name, workspace_name=workspace
                 ),
                 lambda: self.__noop_checker(),
             )

--- a/client/verta/verta/operations/monitoring/monitored_entity.py
+++ b/client/verta/verta/operations/monitoring/monitored_entity.py
@@ -77,7 +77,7 @@ class MonitoredEntity(entity._ModelDBEntity):
         self._refresh_cache()
 
         if self._msg.workspace_id:
-            return self._conn._get_workspace_name_by_id(self._msg.workspace_id)
+            return self._conn.get_workspace_name_by_id(self._msg.workspace_id)
         else:
             return self._conn._OSS_DEFAULT_WORKSPACE
 
@@ -134,16 +134,15 @@ class MonitoredEntity(entity._ModelDBEntity):
             return None
 
     @classmethod
-    def _create_proto_internal(cls, conn, ctx, name):
+    def _create_proto_internal(cls, conn, ctx, name, workspace_name):
         Message = _DataMonitoringService.CreateMonitoredEntityRequest
-        msg = Message(name=name)
-
+        msg = Message(name=name, workspace_name=workspace_name)
         endpoint = "/api/v1/monitored_entity/createMonitoredEntity"
         response = conn.make_proto_request("POST", endpoint, body=msg)
         obj = conn.must_proto_response(response, Message.Response).monitored_entity
 
-        if ctx.workspace_name is not None:
-            WORKSPACE_PRINT_MSG = "workspace: {}".format(ctx.workspace_name)
+        if workspace_name is not None:
+            WORKSPACE_PRINT_MSG = "workspace: {}".format(workspace_name)
         else:
             WORKSPACE_PRINT_MSG = "personal workspace"
 

--- a/client/verta/verta/operations/monitoring/monitored_entity.py
+++ b/client/verta/verta/operations/monitoring/monitored_entity.py
@@ -77,7 +77,7 @@ class MonitoredEntity(entity._ModelDBEntity):
         self._fetch_with_no_cache()
 
         if self._msg.workspace_id:
-            return self._conn.get_workspace_name_by_id(self._msg.workspace_id)
+            return self._conn.get_workspace_name_from_id(self._msg.workspace_id)
         else:
             return self._conn._OSS_DEFAULT_WORKSPACE
 

--- a/client/verta/verta/operations/monitoring/monitored_entity.py
+++ b/client/verta/verta/operations/monitoring/monitored_entity.py
@@ -74,7 +74,7 @@ class MonitoredEntity(entity._ModelDBEntity):
         -------
         string
         """
-        self._refresh_cache()
+        self._fetch_with_no_cache()
 
         if self._msg.workspace_id:
             return self._conn.get_workspace_name_by_id(self._msg.workspace_id)


### PR DESCRIPTION
## Testing

```
(verta-py3) daniel@Daniels-MacBook-Pro verta % pytest tests/operations/monitoring/test_client.py::TestClient::test_create_ME_in_workspace
============================================================================== test session starts ===============================================================================
platform darwin -- Python 3.7.9, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /Users/daniel/workspace/modeldb/client/verta/tests, configfile: pytest.ini
plugins: hypothesis-6.3.4
collected 1 item

tests/operations/monitoring/test_client.py .                                                                                                                               [100%]

================================================================================ warnings summary ================================================================================
operations/monitoring/test_client.py::TestClient::test_create_ME_in_workspace
  /Users/daniel/.pyenv/versions/verta-py3/lib/python3.7/site-packages/urllib3/util/retry.py:255: DeprecationWarning: Using 'method_whitelist' with Retry is deprecated and will be removed in v2.0. Use 'allowed_methods' instead
    DeprecationWarning,

-- Docs: https://docs.pytest.org/en/stable/warnings.html
========================================================================== 1 passed, 1 warning in 6.92s ==========================================================================
```