### PR TITLE
Make endpoint_update_config.html accessible in docs

### DIFF
--- a/client/verta/docs/api/deployment.rst
+++ b/client/verta/docs/api/deployment.rst
@@ -1,3 +1,5 @@
+.. _deployment-api:
+
 Deployment
 ==========
 

--- a/client/verta/docs/tutorials/deployment/deployment.rst
+++ b/client/verta/docs/tutorials/deployment/deployment.rst
@@ -24,6 +24,7 @@ Endpoint configuration
 * `Configuring endpoint autoscaling <endpoint_autoscaling.html>`__
 * `Configuring endpoint compute resources <endpoint_resources.html>`__
 * `Configuring endpoint environment variables <endpoint_env_vars.html>`__
+* `Configuring endpoint using config file <endpoint_update_config.html>`__
 
 Endpoint querying
 -----------------
@@ -34,10 +35,11 @@ Endpoint querying
     :hidden:
     :titlesonly:
 
-    Creating and retrieving an endpoint <endpoint_creation>
-    Model deployment <endpoint_update>
-    Updating endpoints with canary <endpoint_canary_update>
-    Endpoint autoscaling <endpoint_autoscaling>
-    Endpoint resources <endpoint_resources>
-    Endpoint environment variables <endpoint_env_vars>
-    Querying an endpoint <endpoint_query>
+    endpoint_creation
+    endpoint_update
+    endpoint_canary_update
+    endpoint_autoscaling
+    endpoint_resources
+    endpoint_env_vars
+    endpoint_update_config
+    endpoint_query

--- a/client/verta/docs/tutorials/deployment/endpoint_update_config.rst
+++ b/client/verta/docs/tutorials/deployment/endpoint_update_config.rst
@@ -34,7 +34,7 @@ For example:
             "resources": {"cpu": 0.25, "memory": "100M"}
         }
 
-.. TODO: Link to configuration file fields.
+The JSON representations for endpoint configuration values can be found in their respective :ref:`Python API documentation <deployment-api>` entries.
 
 This allows for easier inspection and modification later on. Users can find out more about the fields of the configuration file here.
 

--- a/client/verta/docs/tutorials/tutorials.rst
+++ b/client/verta/docs/tutorials/tutorials.rst
@@ -26,6 +26,7 @@ Deployment and release
 * `Configuring endpoint autoscaling <deployment/endpoint_autoscaling.html>`__
 * `Configuring endpoint compute resources <deployment/endpoint_resources.html>`__
 * `Configuring endpoint environment variables <deployment/endpoint_env_vars.html>`__
+* `Configuring endpoint using config file <deployment/endpoint_update_config.html>`__
 * `Querying an endpoint <deployment/endpoint_query.html>`__
 
 Real-time model monitoring


### PR DESCRIPTION
This holdover from our deployment documentation effort causes a Sphinx build warning every time.