### PR TITLE
[VR-10767] Fail ReadTheDocs builds on warnings

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,3 +14,4 @@ python:
 sphinx:
   builder: html
   configuration: client/verta/docs/conf.py
+  fail_on_warning: true


### PR DESCRIPTION
Two weeks ago, ReadTheDocs ended up skipping most of our API because it couldn't import `scipy`, but the dashboard said the build **Passed** in spite of 113 warnings.

This change will have ReadTheDocs outright fail the build, instead.