### PR TITLE
Remove epub publication from ReadTheDocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,7 +1,6 @@
 version: 2
 
 formats:
-  - epub
   - pdf
 
 python:


### PR DESCRIPTION
Sphinx encounters a [warning](https://github.com/sphinx-doc/sphinx/issues/3214) (which intentionally blocks our docs build) when building the EPUB for our docs, that I'm choosing to sidestep by forgoing EPUB altogether as I strongly suspect it's not being used.