### PR TITLE
Ignore pre-commit-config while we experiment with this tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ data
 # ignore Python dev tool files and dirs
 **/.python-version
 **/.ropeproject
+.pre-commit-config.yaml
+


### PR DESCRIPTION
I'm trying out some things with [pre-commit](https://pre-commit.com/index.html) and I'd like to ignore my iteration on this configuration until I work out some patterns worth pushing into master.