### PR TITLE
Revert test change

### DIFF
--- a/client/verta/tests/operations/monitoring/alerts/test_entities.py
+++ b/client/verta/tests/operations/monitoring/alerts/test_entities.py
@@ -91,9 +91,7 @@ class TestIntegration:
         sample_query = SummarySampleQuery()
 
         alert = alerts.create(name, alerter, sample_query)
-        created_query_proto = alerts._combine_query_with_default_summary(
-            sample_query
-        )._to_proto_request()
+        created_query_proto = sample_query._to_proto_request()
         retrieved_query_proto = alert.summary_sample_query._to_proto_request()
         assert created_query_proto == retrieved_query_proto
 


### PR DESCRIPTION
On top of https://github.com/VertaAI/modeldb/pull/2252

We had removed `Alerts._combine_query_with_defualt_summary()` during a rewrite, but we forgot to remove it from the tests!