### PR TITLE
[VR-10987] Simplify defining sample query during alert creation

### DIFF
--- a/client/verta/tests/operations/monitoring/alerts/test_entities.py
+++ b/client/verta/tests/operations/monitoring/alerts/test_entities.py
@@ -105,7 +105,24 @@ class TestAlert:
 
     def test_creation_query_params(self, summary):
         """`labels` and `starting_from`"""
-        raise NotImplementedError
+        name = _utils.generate_default_name()
+        alerter = FixedAlerter(comparison.GreaterThan(0.7))
+        labels = {"datasource": ["census2010", "census2020"]}
+        starting_from = datetime.datetime(year=2021, month=5, day=10, tzinfo=time_utils.utc)
+
+        alert = summary.alerts.create(
+            name,
+            alerter,
+            labels=labels,
+            starting_from=starting_from,
+        )
+        expected_sample_query = SummarySampleQuery(
+            summary_query=summary.alerts._build_summary_query(),
+            labels=labels,
+            time_window_end=starting_from,
+        )
+
+        assert alert.summary_sample_query == expected_sample_query
 
     def test_creation_override_datetimes(self, summary, strs):
         strs = iter(strs)

--- a/client/verta/tests/operations/monitoring/conftest.py
+++ b/client/verta/tests/operations/monitoring/conftest.py
@@ -19,13 +19,23 @@ def monitored_entity(client, created_entities):
 
     return monitored_entity
 
+
 @pytest.fixture
-def summary_sample(client, monitored_entity, created_entities):
+def summary(client, monitored_entity, created_entities):
     summary = client.operations.summaries.create(
         _utils.generate_default_name(),
         data_types.NumericValue,
         monitored_entity,
     )
+
+    yield summary
+
+    # TODO: use `created_entities` if/when Summary reimplements delete()
+    client.operations.summaries.delete([summary])
+
+
+@pytest.fixture
+def summary_sample(client, summary):
     end_time = time_utils.now()
     start_time = end_time - datetime.timedelta(hours=1)
     sample = summary.log_sample(
@@ -33,7 +43,4 @@ def summary_sample(client, monitored_entity, created_entities):
         start_time, end_time,
     )
 
-    yield sample
-
-    # TODO: use `created_entities` if/when Summary reimplements delete()
-    client.operations.summaries.delete([summary])
+    return sample

--- a/client/verta/verta/operations/monitoring/alert/_alerter.py
+++ b/client/verta/verta/operations/monitoring/alert/_alerter.py
@@ -76,10 +76,9 @@ class FixedAlerter(_Alerter):
 
         alerter = FixedAlerter(GreaterThan(.7))
 
-        alert = monitored_entity.alerts.create(
+        alert = summary.alerts.create(
             name="MSE",
             alerter=alerter,
-            summary_sample_query=sample_query,
             notification_channels=[channel],
         )
 
@@ -123,10 +122,9 @@ class ReferenceAlerter(_Alerter):
             ref_sample,
         )
 
-        alert = monitored_entity.alerts.create(
+        alert = summary.alerts.create(
             name="MSE",
             alerter=alerter,
-            summary_sample_query=sample_query,
             notification_channels=[channel],
         )
 

--- a/client/verta/verta/operations/monitoring/alert/_entities/alert.py
+++ b/client/verta/verta/operations/monitoring/alert/_entities/alert.py
@@ -43,10 +43,9 @@ class Alert(entity._ModelDBEntity):
     --------
     .. code-block:: python
 
-        alert = monitored_entity.alerts.create(
+        alert = summary.alerts.create(
             name="MSE",
             alerter=alerter,
-            summary_sample_query=sample_query,
             notification_channels=[channel],
         )
 
@@ -360,16 +359,16 @@ class Alerts(object):
         A connection object to the backend service.
     conf
         A configuration object used by conn methods.
-    monitored_entity_id : int
+    monitored_entity_id : int, optional
         A monitored entity id to use for all alerts in this collection
-    summary : :class:`~verta.operations.monitoring.summaries.summary.Summary`
+    summary : :class:`~verta.operations.monitoring.summaries.summary.Summary`, optional
         A summary for creating and finding alerts in this collection, and finding samples to alert on.
 
     Examples
     --------
     .. code-block:: python
 
-        alerts = monitored_entity.alerts
+        alerts = summary.alerts
 
     """
 
@@ -421,18 +420,17 @@ class Alerts(object):
         --------
         .. code-block:: python
 
-            alert = monitored_entity.alerts.create(
+            alert = summary.alerts.create(
                 name="MSE",
                 alerter=alerter,
-                summary_sample_query=sample_query,
                 notification_channels=[channel],
             )
 
         """
-        if self._monitored_entity_id is None:
+        if self._summary is None:
             raise RuntimeError(
                 "this Alert cannot be used to create because it was not"
-                " obtained via monitored_entity.alerts"
+                " obtained via summary.alerts"
             )
 
         summary_sample_query = SummarySampleQuery(

--- a/client/verta/verta/operations/monitoring/alert/_entities/alert.py
+++ b/client/verta/verta/operations/monitoring/alert/_entities/alert.py
@@ -63,6 +63,8 @@ class Alert(entity._ModelDBEntity):
     def __repr__(self):
         self._refresh_cache()
         msg = self._msg
+        sample_filter = msg.sample_find_base.filter
+
         return "\n\t".join(
             (
                 "Alert",
@@ -75,16 +77,26 @@ class Alert(entity._ModelDBEntity):
                 "last evaluated: {}".format(
                     _utils.timestamp_to_str(msg.last_evaluated_at_millis)
                 ),
-                "alerter: {}".format(
-                    # TODO: use an `alerter` property that returns the actual class
-                    _AlertService.AlerterTypeEnum.AlerterType.Name(msg.alerter_type)
+                "alerter: {}".format(self.alerter),
+                "notification channel ids: {}".format(
+                    list(msg.notification_channels.keys())
+                ),
+                "labels: {}".format(
+                    {
+                        key: values.label_value
+                        for key, values
+                        in sample_filter.labels.items()
+                    }
+                ),
+                "starting from: {}".format(
+                    None
+                    if not sample_filter.time_window_end_at_millis
+                    else _utils.timestamp_to_str(
+                        sample_filter.time_window_end_at_millis
+                    )
                 ),
                 "violating summary sample ids: {}".format(
                     msg.violating_summary_sample_ids
-                ),
-                "summary sample query: {}".format(self.summary_sample_query),
-                "notification channel ids: {}".format(
-                    list(msg.notification_channels.keys())
                 ),
             )
         )

--- a/client/verta/verta/operations/monitoring/alert/_entities/alert.py
+++ b/client/verta/verta/operations/monitoring/alert/_entities/alert.py
@@ -452,7 +452,9 @@ class Alerts(object):
             self._conf,
             ctx,
             name=name,
-            monitored_entity_id=self._monitored_entity_id,
+            monitored_entity_id=(
+                self._monitored_entity_id or self._summary.monitored_entity_id
+            ),
             alerter=alerter,
             summary_sample_query=summary_sample_query,
             notification_channels=notification_channels,

--- a/client/verta/verta/operations/monitoring/monitored_entity.py
+++ b/client/verta/verta/operations/monitoring/monitored_entity.py
@@ -84,10 +84,6 @@ class MonitoredEntity(entity._ModelDBEntity):
             return self._conn._OSS_DEFAULT_WORKSPACE
 
     @property
-    def alerts(self):
-        return Alerts(self._conn, self._conf, self.id)
-
-    @property
     def summaries(self):
         return Summaries(self._conn, self._conf)
 

--- a/client/verta/verta/operations/monitoring/notification_channel/_entities/notification_channel.py
+++ b/client/verta/verta/operations/monitoring/notification_channel/_entities/notification_channel.py
@@ -36,10 +36,9 @@ class NotificationChannel(entity._ModelDBEntity):
             SlackNotificationChannel("https://hooks.slack.com/services/.../.../......"),
         )
 
-        alert = monitored_entity.alerts.create(
+        alert = summary.alerts.create(
             name="MSE",
             alerter=alerter,
-            summary_sample_query=sample_query,
             notification_channels=[channel],
         )
 

--- a/client/verta/verta/operations/monitoring/notification_channel/_notification_channel.py
+++ b/client/verta/verta/operations/monitoring/notification_channel/_notification_channel.py
@@ -47,10 +47,9 @@ class SlackNotificationChannel(_NotificationChannel):
             SlackNotificationChannel("https://hooks.slack.com/services/.../.../......"),
         )
 
-        alert = monitored_entity.alerts.create(
+        alert = summary.alerts.create(
             name="MSE",
             alerter=alerter,
-            summary_sample_query=sample_query,
             notification_channels=[channel],
         )
 

--- a/client/verta/verta/operations/monitoring/summaries/queries.py
+++ b/client/verta/verta/operations/monitoring/summaries/queries.py
@@ -80,6 +80,12 @@ class SummaryQuery(object):
         self._page_number = page_number
         self._page_limit = page_limit
 
+    def __eq__(self, other):
+        if not isinstance(other, type(self)):
+            return NotImplemented
+
+        return self._to_proto_request() == other._to_proto_request()
+
     @property
     def monitored_entity_ids(self):
         return self._monitored_entity_ids
@@ -204,6 +210,12 @@ class SummarySampleQuery(object):
         self._created_after = created_after
         self._page_number = page_number
         self._page_limit = page_limit
+
+    def __eq__(self, other):
+        if not isinstance(other, type(self)):
+            return NotImplemented
+
+        return self._to_proto_request() == other._to_proto_request()
 
     @property
     def summary_query(self):


### PR DESCRIPTION
Instead of passing a `SummarySampleQuery` to `alerts.create()`, we directly surface `labels` and `starting_from` as parameters.

## Changes
- remove `monitored_entity.alerts` (keeping `summary.alerts`)
- privatize and undocument `created_at`, `updated_at`, and `last_evaluated_at` because they're not really for end user consumption
- add `__eq__` to `SummaryQuery` and `SummarySampleQuery`