### PR TITLE
Update (most) tests to use run.log_environment instead of log_requirements()

### DIFF
--- a/client/verta/tests/test_artifacts.py
+++ b/client/verta/tests/test_artifacts.py
@@ -719,15 +719,6 @@ class TestOverwrite:
 
         assert experiment_run.get_artifact(_artifact_utils.MODEL_KEY) == new_model
 
-    def test_requirements(self, experiment_run):
-        requirements = ["banana==1"]
-        new_requirements = ["coconut==1"]
-
-        experiment_run.log_requirements(requirements)
-        experiment_run.log_requirements(new_requirements, overwrite=True)
-
-        assert six.ensure_binary('\n'.join(new_requirements)) in experiment_run.get_artifact("requirements.txt").read()
-
     def test_setup_script(self, experiment_run):
         setup_script = "import verta"
         new_setup_script = "import cloudpickle"

--- a/client/verta/tests/test_cli/test_endpoint.py
+++ b/client/verta/tests/test_cli/test_endpoint.py
@@ -82,7 +82,7 @@ class TestCreate:
 class TestGet:
     def test_get(self, client, created_entities, experiment_run, model_for_deployment):
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
-        experiment_run.log_requirements(['scikit-learn'])
+        experiment_run.log_environment(Python(['scikit-learn']))
 
         path = _utils.generate_default_name()
         endpoint = client.set_endpoint(path)
@@ -122,7 +122,7 @@ class TestUpdate:
         original_build_ids = get_build_ids(original_status)
 
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
-        experiment_run.log_requirements(['scikit-learn'])
+        experiment_run.log_environment(Python(['scikit-learn']))
 
         runner = CliRunner()
         result = runner.invoke(
@@ -143,7 +143,7 @@ class TestUpdate:
         original_build_ids = get_build_ids(original_status)
 
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
-        experiment_run.log_requirements(['scikit-learn'])
+        experiment_run.log_environment(Python(['scikit-learn']))
 
         canary_rule = json.dumps({
             "rule": "latency_avg_max",
@@ -175,7 +175,7 @@ class TestUpdate:
         original_build_ids = get_build_ids(original_status)
 
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
-        experiment_run.log_requirements(['scikit-learn'])
+        experiment_run.log_environment(Python(['scikit-learn']))
 
         canary_rule = json.dumps({
             "rule": "latency_avg_max",
@@ -310,7 +310,7 @@ class TestUpdate:
         json = pytest.importorskip("json")
 
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
-        experiment_run.log_requirements(['scikit-learn'])
+        experiment_run.log_environment(Python(['scikit-learn']))
 
         path = _utils.generate_default_name()
         endpoint = client.set_endpoint(path)
@@ -365,7 +365,7 @@ class TestUpdate:
         original_build_ids = get_build_ids(original_status)
 
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
-        experiment_run.log_requirements(['scikit-learn'])
+        experiment_run.log_environment(Python(['scikit-learn']))
 
         resources = '{"cpu": 0.25, "memory": "100M"}'
 
@@ -381,7 +381,7 @@ class TestUpdate:
 
     def test_update_autoscaling(self, client, created_entities, experiment_run, model_for_deployment):
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
-        experiment_run.log_requirements(['scikit-learn'])
+        experiment_run.log_environment(Python(['scikit-learn']))
 
         path = _utils.generate_default_name()
         endpoint = client.set_endpoint(path)
@@ -421,7 +421,7 @@ class TestDownload:
     def test_download_context(self, experiment_run, model_for_deployment, registered_model, in_tempdir, created_entities, model_version):
         np = pytest.importorskip("numpy")
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
-        experiment_run.log_requirements(['scikit-learn'])
+        experiment_run.log_environment(Python(['scikit-learn']))
 
         artifact = np.random.random((36, 12))
         experiment_run.log_artifact("some-artifact", artifact)
@@ -475,7 +475,7 @@ class TestPredict:
         test_data_str = json.dumps(test_data.tolist())
 
         experiment_run.log_model(classifier, custom_modules=[])
-        experiment_run.log_requirements(['scikit-learn'])
+        experiment_run.log_environment(Python(['scikit-learn']))
 
         path = _utils.generate_default_name()
         endpoint = client.set_endpoint(path)

--- a/client/verta/tests/test_cli/test_registry.py
+++ b/client/verta/tests/test_cli/test_registry.py
@@ -119,7 +119,7 @@ class TestCreate:
         version_name = "from_run"
 
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
-        experiment_run.log_requirements(['scikit-learn'])
+        experiment_run.log_environment(Python(['scikit-learn']))
 
         artifact = np.random.random((36, 12))
         experiment_run.log_artifact("some-artifact", artifact)

--- a/client/verta/tests/test_deployment.py
+++ b/client/verta/tests/test_deployment.py
@@ -25,6 +25,7 @@ from verta._internal_utils import (
     _utils,
 )
 from verta.endpoint.update import DirectUpdateStrategy
+from verta.environment import Python
 
 pytestmark = pytest.mark.not_oss
 
@@ -235,7 +236,7 @@ class TestLogModel:
         # log real artifact using `overwrite`
         experiment_run.log_artifact(key, val)
         experiment_run.log_model(ModelWithDependency, custom_modules=[], artifacts=[key], overwrite=True)
-        experiment_run.log_requirements(requirements=[])
+        experiment_run.log_environment(Python([]))
 
         endpoint.update(experiment_run, DirectUpdateStrategy(), wait=True)
         assert val == endpoint.get_deployed_model().predict(val)
@@ -573,7 +574,7 @@ class TestHistogram:
 class TestDeploy:
     def test_auto_path_auto_token_deploy(self, experiment_run, model_for_deployment):
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
-        experiment_run.log_requirements(['scikit-learn'])
+        experiment_run.log_environment(Python(['scikit-learn']))
 
         status = experiment_run.deploy()
 
@@ -590,7 +591,7 @@ class TestDeploy:
         token = "coconut"
 
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
-        experiment_run.log_requirements(['scikit-learn'])
+        experiment_run.log_environment(Python(['scikit-learn']))
 
         status = experiment_run.deploy(token=token)
 
@@ -605,7 +606,7 @@ class TestDeploy:
 
     def test_auto_path_no_token_deploy(self, experiment_run, model_for_deployment):
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
-        experiment_run.log_requirements(['scikit-learn'])
+        experiment_run.log_environment(Python(['scikit-learn']))
 
         status = experiment_run.deploy(no_token=True)
 
@@ -622,7 +623,7 @@ class TestDeploy:
         path = "banana"
 
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
-        experiment_run.log_requirements(['scikit-learn'])
+        experiment_run.log_environment(Python(['scikit-learn']))
 
         status = experiment_run.deploy(path=path)
 
@@ -639,7 +640,7 @@ class TestDeploy:
         path, token = "banana", "coconut"
 
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
-        experiment_run.log_requirements(['scikit-learn'])
+        experiment_run.log_environment(Python(['scikit-learn']))
 
         status = experiment_run.deploy(path=path, token=token)
 
@@ -656,7 +657,7 @@ class TestDeploy:
         path = "banana"
 
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
-        experiment_run.log_requirements(['scikit-learn'])
+        experiment_run.log_environment(Python(['scikit-learn']))
 
         status = experiment_run.deploy(path=path, no_token=True)
 
@@ -671,7 +672,7 @@ class TestDeploy:
 
     def test_wait_deploy(self, experiment_run, model_for_deployment):
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
-        experiment_run.log_requirements(['scikit-learn'])
+        experiment_run.log_environment(Python(['scikit-learn']))
 
         status = experiment_run.deploy(wait=True)
 
@@ -687,7 +688,7 @@ class TestDeploy:
 
     def test_already_deployed_deploy(self, experiment_run, model_for_deployment):
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
-        experiment_run.log_requirements(['scikit-learn'])
+        experiment_run.log_environment(Python(['scikit-learn']))
 
         experiment_run.deploy()
 
@@ -702,7 +703,7 @@ class TestDeploy:
 
     def test_no_model_deploy_error(self, experiment_run, model_for_deployment):
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
-        experiment_run.log_requirements(['scikit-learn'])
+        experiment_run.log_environment(Python(['scikit-learn']))
 
         # delete model
         response = _utils.make_request(
@@ -725,7 +726,7 @@ class TestDeploy:
 
     def test_no_api_deploy_error(self, experiment_run, model_for_deployment):
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
-        experiment_run.log_requirements(['scikit-learn'])
+        experiment_run.log_environment(Python(['scikit-learn']))
 
         # delete model API
         response = _utils.make_request(
@@ -761,7 +762,7 @@ class TestDeploy:
 
     def test_deployment_failure_deploy_error(self, experiment_run, model_for_deployment):
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
-        experiment_run.log_requirements([])
+        experiment_run.log_environment(Python([]))
 
         with pytest.raises(RuntimeError) as excinfo:
             experiment_run.deploy(wait=True)
@@ -780,7 +781,7 @@ class TestDeploy:
 class TestUndeploy:
     def test_undeploy(self, experiment_run, model_for_deployment):
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
-        experiment_run.log_requirements(['scikit-learn'])
+        experiment_run.log_environment(Python(['scikit-learn']))
 
         experiment_run.deploy(wait=True)
 
@@ -808,7 +809,7 @@ class TestGetDeployedModel:
         )
 
         experiment_run.log_model(model, custom_modules=[])
-        experiment_run.log_requirements(['scikit-learn'])
+        experiment_run.log_environment(Python(['scikit-learn']))
 
         experiment_run.deploy(wait=True)
 
@@ -833,7 +834,7 @@ class TestGetDeployedModel:
 
     def test_undeployed_get_error(self, experiment_run, model_for_deployment):
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
-        experiment_run.log_requirements(['scikit-learn'])
+        experiment_run.log_environment(Python(['scikit-learn']))
 
         experiment_run.deploy(wait=True)
         experiment_run.undeploy(wait=True)
@@ -857,7 +858,7 @@ class TestGitOps:
             custom_modules=[],
             model_api=model_for_deployment['model_api'],
         )
-        experiment_run.log_requirements(['scikit-learn'])
+        experiment_run.log_environment(Python(['scikit-learn']))
 
         filepath = experiment_run.download_deployment_yaml(download_to_path)
         assert filepath == os.path.abspath(download_to_path)
@@ -873,7 +874,7 @@ class TestGitOps:
         download_to_path = "context.tgz"
 
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
-        experiment_run.log_requirements(['scikit-learn'])
+        experiment_run.log_environment(Python(['scikit-learn']))
 
         filepath = experiment_run.download_docker_context(download_to_path)
         assert filepath == os.path.abspath(download_to_path)

--- a/client/verta/tests/test_endpoint/test_endpoint.py
+++ b/client/verta/tests/test_endpoint/test_endpoint.py
@@ -101,7 +101,7 @@ class TestEndpoint:
 
     def test_repr(self, client, created_entities, experiment_run, model_for_deployment):
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
-        experiment_run.log_requirements(['scikit-learn'])
+        experiment_run.log_environment(Python(['scikit-learn']))
 
         path = verta._internal_utils._utils.generate_default_name()
         endpoint = client.set_endpoint(path)
@@ -164,7 +164,7 @@ class TestEndpoint:
 
     def test_direct_update(self, client, created_entities, experiment_run, model_for_deployment):
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
-        experiment_run.log_requirements(['scikit-learn'])
+        experiment_run.log_environment(Python(['scikit-learn']))
 
         path = verta._internal_utils._utils.generate_default_name()
         endpoint = client.set_endpoint(path)
@@ -181,7 +181,7 @@ class TestEndpoint:
     def test_update_wait(self, client, created_entities, experiment_run, model_version, model_for_deployment):
         """This tests endpoint.update(..., wait=True), including the case of build error"""
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
-        experiment_run.log_requirements(['scikit-learn'])
+        experiment_run.log_environment(Python(['scikit-learn']))
 
         path = verta._internal_utils._utils.generate_default_name()
         endpoint = client.set_endpoint(path)
@@ -202,7 +202,7 @@ class TestEndpoint:
 
     def test_canary_update(self, client, created_entities, experiment_run, model_for_deployment):
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
-        experiment_run.log_requirements(['scikit-learn'])
+        experiment_run.log_environment(Python(['scikit-learn']))
 
         path = verta._internal_utils._utils.generate_default_name()
         endpoint = client.set_endpoint(path)
@@ -228,7 +228,7 @@ class TestEndpoint:
     def test_update_from_json_config(self, client, in_tempdir, created_entities, experiment_run, model_for_deployment):
         json = pytest.importorskip("json")
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
-        experiment_run.log_requirements(['scikit-learn'])
+        experiment_run.log_environment(Python(['scikit-learn']))
 
         path = verta._internal_utils._utils.generate_default_name()
         endpoint = client.set_endpoint(path)
@@ -270,7 +270,7 @@ class TestEndpoint:
     def test_update_from_yaml_config(self, client, in_tempdir, created_entities, experiment_run, model_for_deployment):
         yaml = pytest.importorskip("yaml")
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
-        experiment_run.log_requirements(['scikit-learn'])
+        experiment_run.log_environment(Python(['scikit-learn']))
 
         path = verta._internal_utils._utils.generate_default_name()
         endpoint = client.set_endpoint(path)
@@ -311,7 +311,7 @@ class TestEndpoint:
 
     def test_update_with_parameters(self, client, created_entities, experiment_run, model_for_deployment):
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
-        experiment_run.log_requirements(['scikit-learn'])
+        experiment_run.log_environment(Python(['scikit-learn']))
 
         path = verta._internal_utils._utils.generate_default_name()
         endpoint = client.set_endpoint(path)
@@ -371,7 +371,7 @@ class TestEndpoint:
             model_for_deployment['train_targets'],
         )
         experiment_run.log_model(model, custom_modules=[])
-        experiment_run.log_requirements(['scikit-learn'])
+        experiment_run.log_environment(Python(['scikit-learn']))
 
         path = verta._internal_utils._utils.generate_default_name()
         endpoint = client.set_endpoint(path)
@@ -472,7 +472,7 @@ class TestEndpoint:
 
     def test_update_autoscaling(self, client, created_entities, experiment_run, model_for_deployment):
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
-        experiment_run.log_requirements(['scikit-learn'])
+        experiment_run.log_environment(Python(['scikit-learn']))
 
         path = verta._internal_utils._utils.generate_default_name()
         endpoint = client.set_endpoint(path)
@@ -529,7 +529,7 @@ class TestEndpoint:
     def test_update_from_json_config_with_params(self, client, in_tempdir, created_entities, experiment_run, model_for_deployment):
         yaml = pytest.importorskip("yaml")
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
-        experiment_run.log_requirements(['scikit-learn'])
+        experiment_run.log_environment(Python(['scikit-learn']))
 
 
         path = verta._internal_utils._utils.generate_default_name()
@@ -616,7 +616,7 @@ class TestEndpoint:
 
     def test_update_from_run_diff_workspace(self, client, organization, created_entities, experiment_run, model_for_deployment):
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
-        experiment_run.log_requirements(['scikit-learn'])
+        experiment_run.log_environment(Python(['scikit-learn']))
 
         path = verta._internal_utils._utils.generate_default_name()
         endpoint = client.create_endpoint(path, workspace=organization.name)
@@ -646,7 +646,7 @@ class TestEndpoint:
 
     def test_update_from_run_diff_workspace_no_access_error(self, client_2, created_entities, experiment_run, model_for_deployment):
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
-        experiment_run.log_requirements(['scikit-learn'])
+        experiment_run.log_environment(Python(['scikit-learn']))
 
         path = verta._internal_utils._utils.generate_default_name()
         endpoint = client_2.create_endpoint(path)

--- a/client/verta/tests/test_model_registry/test_model_version.py
+++ b/client/verta/tests/test_model_registry/test_model_version.py
@@ -38,7 +38,7 @@ class TestMDBIntegration:
         np = pytest.importorskip("numpy")
 
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
-        experiment_run.log_requirements(['scikit-learn'])
+        experiment_run.log_environment(Python(['scikit-learn']))
 
         artifact = np.random.random((36, 12))
         experiment_run.log_artifact("some-artifact", artifact)
@@ -568,7 +568,7 @@ class TestDeployability:
         download_to_path = "context.tgz"
 
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
-        experiment_run.log_requirements(['scikit-learn'])
+        experiment_run.log_environment(Python(['scikit-learn']))
         model_version = registered_model.create_version_from_run(
             run_id=experiment_run.id,
             name="From Run {}".format(experiment_run.id),

--- a/client/verta/tests/test_permissions/test_visibility_e2e.py
+++ b/client/verta/tests/test_permissions/test_visibility_e2e.py
@@ -215,7 +215,7 @@ class TestLink:
         created_entities.append(client_3.create_project(visibility=Private()))
         run = client_3.create_experiment_run()
         run.log_model(LogisticRegression(), custom_modules=[])
-        run.log_requirements(["scikit-learn"])
+        run.log_environment(Python(["scikit-learn"]))
         with pytest.raises(requests.HTTPError, match="Access Denied|Forbidden"):
             endpoint.update(run)
 
@@ -223,7 +223,7 @@ class TestLink:
         created_entities.append(client_3.create_project(visibility=OrgCustom(deploy=False)))
         run = client_3.create_experiment_run()
         run.log_model(LogisticRegression(), custom_modules=[])
-        run.log_requirements(["scikit-learn"])
+        run.log_environment(Python(["scikit-learn"]))
         with pytest.raises(requests.HTTPError, match="Access Denied|Forbidden"):
             endpoint.update(run)
 
@@ -231,7 +231,7 @@ class TestLink:
         created_entities.append(client_3.create_project(visibility=OrgCustom(deploy=True)))
         run = client_3.create_experiment_run()
         run.log_model(LogisticRegression(), custom_modules=[])
-        run.log_requirements(["scikit-learn"])
+        run.log_environment(Python(["scikit-learn"]))
         assert endpoint.update(run)
 
     def test_endpoint_update_model_version(self, client_2, client_3, organization, created_entities):


### PR DESCRIPTION
`run.log_requirements()` has been deprecated (https://github.com/VertaAI/modeldb/pull/2258), so this PR updates most tests to make sure new functionality is covered. Specifically, this will help cover VR-11157 (https://github.com/VertaAI/registry/pull/561).

I'm holding off on updating test_experimentrun/test_requirements.py, which has tests specific to the old method that require slightly more thought to figure out what to keep/change.