### PR TITLE
[VR-11319] Fix findHydratedExperimentRuns bug

### DIFF
--- a/backend/src/main/java/ai/verta/modeldb/App.java
+++ b/backend/src/main/java/ai/verta/modeldb/App.java
@@ -283,7 +283,7 @@ public class App implements ApplicationContextAware {
     LOGGER.trace("Dataset serviceImpl initialized");
     wrapService(serverBuilder, new DatasetVersionServiceImpl(services, daos));
     LOGGER.trace("Dataset Version serviceImpl initialized");
-    wrapService(serverBuilder, new AdvancedServiceImpl(services, daos));
+    wrapService(serverBuilder, new AdvancedServiceImpl(services, daos, executor));
     LOGGER.trace("Hydrated serviceImpl initialized");
     wrapService(serverBuilder, new LineageServiceImpl(daos));
     LOGGER.trace("Lineage serviceImpl initialized");


### PR DESCRIPTION
**Jira Ticket:** https://vertaai.atlassian.net/browse/VR-11319

**Bug Reason:** We have implemented `findExperimentRuns` using InternalFuture so while any exception like `PermissionDenied`, etc. thrown from `findExperimentRuns` from line `futureExperimentRunDAO.findExperimentRuns(request).get();` will not handled correctly and throw an internal server error instead of those proper errors.