### PR TITLE
[VR-11356] Return path from download_model()

### DIFF
--- a/client/verta/tests/test_artifacts.py
+++ b/client/verta/tests/test_artifacts.py
@@ -519,17 +519,18 @@ class TestModels:
     def test_download_sklearn(self, experiment_run, in_tempdir):
         LogisticRegression = pytest.importorskip("sklearn.linear_model").LogisticRegression
 
-        upload_filepath = "model.pkl"
-        download_filepath = "retrieved_model.pkl"
+        upload_path = "model.pkl"
+        download_path = "retrieved_model.pkl"
 
         model = LogisticRegression(C=0.67, max_iter=178)  # set some non-default values
-        with open(upload_filepath, 'wb') as f:
+        with open(upload_path, 'wb') as f:
             pickle.dump(model, f)
 
         experiment_run.log_model(model, custom_modules=[])
-        experiment_run.download_model(download_filepath)
+        returned_path = experiment_run.download_model(download_path)
+        assert returned_path == os.path.abspath(download_path)
 
-        with open(download_filepath, 'rb') as f:
+        with open(download_path, 'rb') as f:
             downloaded_model = pickle.load(f)
 
         assert downloaded_model.get_params() == model.get_params()
@@ -578,7 +579,8 @@ class TestArbitraryModels:
         download_path = strs[0]
 
         experiment_run.log_model(dirpath)
-        experiment_run.download_model(download_path)
+        returned_path = experiment_run.download_model(download_path)
+        assert returned_path == os.path.abspath(download_path)
 
         # contents match
         utils.assert_dirs_match(dirpath, download_path)
@@ -596,7 +598,8 @@ class TestArbitraryModels:
             )
 
         experiment_run.log_model(upload_path)
-        experiment_run.download_model(download_path)
+        returned_path = experiment_run.download_model(download_path)
+        assert returned_path == os.path.abspath(download_path)
 
         assert zipfile.is_zipfile(download_path)
         assert filecmp.cmp(upload_path, download_path)

--- a/client/verta/tests/test_artifacts.py
+++ b/client/verta/tests/test_artifacts.py
@@ -282,10 +282,10 @@ class TestArtifacts:
         dirpath, _ = dir_and_files
 
         experiment_run.log_artifact(key, dirpath)
-        experiment_run.download_artifact(key, download_path)
+        retrieved_path = experiment_run.download_artifact(key, download_path)
 
         # contents match
-        utils.assert_dirs_match(dirpath, download_path)
+        utils.assert_dirs_match(dirpath, retrieved_path)
 
     def test_download_path_only_error(self, experiment_run, strs, in_tempdir):
         key = strs[0]

--- a/client/verta/tests/test_model_registry/test_model_version.py
+++ b/client/verta/tests/test_model_registry/test_model_version.py
@@ -527,17 +527,18 @@ class TestDeployability:
     def test_download_sklearn(self, model_version, in_tempdir):
         LogisticRegression = pytest.importorskip("sklearn.linear_model").LogisticRegression
 
-        upload_filepath = "model.pkl"
-        download_filepath = "retrieved_model.pkl"
+        upload_path = "model.pkl"
+        download_path = "retrieved_model.pkl"
 
         model = LogisticRegression(C=0.67, max_iter=178)  # set some non-default values
-        with open(upload_filepath, 'wb') as f:
+        with open(upload_path, 'wb') as f:
             pickle.dump(model, f)
 
         model_version.log_model(model, custom_modules=[])
-        model_version.download_model(download_filepath)
+        returned_path = model_version.download_model(download_path)
+        assert returned_path == os.path.abspath(download_path)
 
-        with open(download_filepath, 'rb') as f:
+        with open(download_path, 'rb') as f:
             downloaded_model = pickle.load(f)
 
         assert downloaded_model.get_params() == model.get_params()
@@ -676,7 +677,8 @@ class TestArbitraryModels:
         download_path = strs[0]
 
         model_version.log_model(dirpath)
-        model_version.download_model(download_path)
+        returned_path = model_version.download_model(download_path)
+        assert returned_path == os.path.abspath(download_path)
 
         # contents match
         utils.assert_dirs_match(dirpath, download_path)
@@ -698,7 +700,8 @@ class TestArbitraryModels:
             run_id=experiment_run.id,
             name="From Run {}".format(experiment_run.id),
         )
-        model_version.download_model(download_path)
+        returned_path = model_version.download_model(download_path)
+        assert returned_path == os.path.abspath(download_path)
 
         utils.assert_dirs_match(dirpath, download_path)
 
@@ -715,7 +718,8 @@ class TestArbitraryModels:
             )
 
         model_version.log_model(upload_path)
-        model_version.download_model(download_path)
+        returned_path = model_version.download_model(download_path)
+        assert returned_path == os.path.abspath(download_path)
 
         assert zipfile.is_zipfile(download_path)
         assert filecmp.cmp(upload_path, download_path)

--- a/client/verta/tests/test_model_registry/test_model_version.py
+++ b/client/verta/tests/test_model_registry/test_model_version.py
@@ -398,10 +398,10 @@ class TestArtifacts:
         dirpath, _ = dir_and_files
 
         model_version.log_artifact(key, dirpath)
-        model_version.download_artifact(key, download_path)
+        retrieved_path = model_version.download_artifact(key, download_path)
 
         # contents match
-        utils.assert_dirs_match(dirpath, download_path)
+        utils.assert_dirs_match(dirpath, retrieved_path)
 
     def test_wrong_key(self, model_version):
         with pytest.raises(KeyError) as excinfo:

--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -320,7 +320,7 @@ class RegisteredModelVersion(_DeployableEntity):
         return _artifact_utils.deserialize_model(model_artifact, error_ok=True)
 
     def download_model(self, download_to_path):
-        self.download_artifact(_artifact_utils.REGISTRY_MODEL_KEY, download_to_path)
+        return self.download_artifact(_artifact_utils.REGISTRY_MODEL_KEY, download_to_path)
 
     def del_model(self):
         """

--- a/client/verta/verta/tracking/entities/_experimentrun.py
+++ b/client/verta/verta/tracking/entities/_experimentrun.py
@@ -1675,7 +1675,7 @@ class ExperimentRun(_DeployableEntity):
         return download_to_path
 
     def download_model(self, download_to_path):
-        self.download_artifact(_artifact_utils.MODEL_KEY, download_to_path)
+        return self.download_artifact(_artifact_utils.MODEL_KEY, download_to_path)
 
     def get_artifact_parts(self, key):
         endpoint = "{}://{}/api/v1/modeldb/experiment-run/getCommittedArtifactParts".format(


### PR DESCRIPTION
## Changes
- add missing `return` to `ExperimentRun.download_model()` and `ModelVersion.download_model()`
- assert in tests that the path is being returned as expected