### PR TITLE
Have summary.delete() delete itself

### DIFF
--- a/client/verta/tests/monitoring/conftest.py
+++ b/client/verta/tests/monitoring/conftest.py
@@ -28,10 +28,7 @@ def summary(client, monitored_entity, created_entities):
         monitored_entity,
     )
 
-    yield summary
-
-    # TODO: use `created_entities` if/when Summary reimplements delete()
-    client.monitoring.summaries.delete([summary])
+    return summary
 
 
 @pytest.fixture

--- a/client/verta/verta/monitoring/summaries/summary.py
+++ b/client/verta/verta/monitoring/summaries/summary.py
@@ -155,7 +155,7 @@ class Summary(_entity._ModelDBEntity):
     def has_type(self, data_type_cls):  # TODO: hideme
         return self.type == data_type_cls._type_string()
 
-    def delete(self, summary_samples):
+    def delete_samples(self, summary_samples):
         """Delete summary samples from this summary.
 
         Parameters
@@ -176,4 +176,25 @@ class Summary(_entity._ModelDBEntity):
         msg = DeleteSummarySampleRequest(ids=ids)
         response = self._conn.make_proto_request("DELETE", endpoint, body=msg)
         self._conn.must_proto_response(response, EmptyProto)
+        return True
+
+    def delete(self):
+        """
+        Delete this summary.
+
+        Returns
+        -------
+        bool
+            ``True`` if the delete was successful.
+
+        Raises
+        ------
+        :class:`requests.HTTPError`
+            If the delete failed.
+
+        """
+        msg = SummaryService.DeleteSummaryRequest(ids=[self.id])
+        endpoint = "/api/v1/summaries/deleteSummary"
+        response = self._conn.make_proto_request("DELETE", endpoint, body=msg)
+        self._conn.must_response(response)
         return True


### PR DESCRIPTION
Motivation here is to change `summary.delete()` to delete the `summary` itself, as other `entity.delete()`s also delete themselves.