### PR TITLE
Update tests to check for 404

### DIFF
--- a/client/verta/tests/test_endpoint/test_endpoint.py
+++ b/client/verta/tests/test_endpoint/test_endpoint.py
@@ -655,9 +655,9 @@ class TestEndpoint:
         with pytest.raises(requests.HTTPError) as excinfo:
             endpoint.update(experiment_run, DirectUpdateStrategy(), wait=True)
 
-        excinfo_value = str(excinfo.value).strip()
-        assert "403" in excinfo_value
-        assert "Access Denied" in excinfo_value
+        exc_msg = str(excinfo.value).strip()
+        assert exc_msg.startswith("404")
+        assert "not found" in exc_msg
 
     def test_update_from_version_diff_workspace_no_access_error(self, client_2, model_version, created_entities):
         np = pytest.importorskip("numpy")

--- a/client/verta/tests/test_model_registry/test_model_version.py
+++ b/client/verta/tests/test_model_registry/test_model_version.py
@@ -76,9 +76,9 @@ class TestMDBIntegration:
                 name="From Run {}".format(experiment_run.id)
             )
 
-        excinfo_value = str(excinfo.value).strip()
-        assert "403" in excinfo_value
-        assert "Access Denied" in excinfo_value
+        exc_msg = str(excinfo.value).strip()
+        assert exc_msg.startswith("404")
+        assert "not found" in exc_msg
 
 
 class TestModelVersion:

--- a/client/verta/tests/test_permissions/test_visibility_e2e.py
+++ b/client/verta/tests/test_permissions/test_visibility_e2e.py
@@ -190,7 +190,7 @@ class TestLink:
         # private run
         created_entities.append(client_3.create_project(visibility=Private()))
         run = client_3.create_experiment_run()
-        with pytest.raises(requests.HTTPError, match="Access Denied|Forbidden"):
+        with pytest.raises(requests.HTTPError, match="^404.*not found"):
             reg_model.create_version_from_run(run.id)
 
         # org run
@@ -216,7 +216,7 @@ class TestLink:
         run = client_3.create_experiment_run()
         run.log_model(LogisticRegression(), custom_modules=[])
         run.log_environment(Python(["scikit-learn"]))
-        with pytest.raises(requests.HTTPError, match="Access Denied|Forbidden"):
+        with pytest.raises(requests.HTTPError, match="^404.*not found"):
             endpoint.update(run)
 
         # org run, deploy=False


### PR DESCRIPTION
Some backend entity access checks have been updated to return `404`s instead of `403s`. This PR updates client integration tests accordingly.