### PR TITLE
Minor cleanup for test cleanups

### DIFF
--- a/client/verta/tests/test_endpoint/test_endpoint.py
+++ b/client/verta/tests/test_endpoint/test_endpoint.py
@@ -27,16 +27,20 @@ class TestEndpoint:
     def test_create(self, client, created_entities):
         name = _utils.generate_default_name()
         endpoint = client.set_endpoint(name)
-        assert endpoint
         created_entities.append(endpoint)
+        assert endpoint
+
         name = verta._internal_utils._utils.generate_default_name()
         endpoint = client.create_endpoint(name)
+        created_entities.append(endpoint)
         assert endpoint
+
         with pytest.raises(requests.HTTPError) as excinfo:
             assert client.create_endpoint(name)
         excinfo_value = str(excinfo.value).strip()
         assert "409" in excinfo_value
         assert "already in use" in excinfo_value
+
         with pytest.warns(UserWarning, match='.*already exists.*'):
             client.set_endpoint(path=endpoint.path, description="new description")
 

--- a/client/verta/tests/test_model_registry/test_model_version.py
+++ b/client/verta/tests/test_model_registry/test_model_version.py
@@ -71,7 +71,7 @@ class TestMDBIntegration:
         created_entities.append(registered_model)
 
         with pytest.raises(requests.HTTPError) as excinfo:
-            model_version = registered_model.create_version_from_run(
+            registered_model.create_version_from_run(
                 run_id=experiment_run.id,
                 name="From Run {}".format(experiment_run.id)
             )
@@ -190,10 +190,8 @@ class TestModelVersion:
         model_version.add_labels(["tag2", "tag4", "tag1", "tag5"])
         assert model_version.get_labels() == ["tag1", "tag2", "tag3", "tag4", "tag5"]
 
-    def test_description(self, client, created_entities):
+    def test_description(self, client, registered_model):
         desc = "description"
-        registered_model = client.get_or_create_registered_model()
-        created_entities.append(registered_model)
         model_version = registered_model.get_or_create_version(name="my version")
         model_version.set_description(desc)
         assert desc == model_version.get_description()
@@ -315,14 +313,13 @@ class TestFind:
             assert labels1 == labels2
             assert item._msg == msg_other
 
-    def test_find_stage(self, client, created_entities):
+    def test_find_stage(self, registered_model):
         # TODO: expand with other stages once client impls version transition
-        reg_model = client.create_registered_model()
-        assert len(reg_model.versions.find("stage == development")) == 0
+        assert len(registered_model.versions.find("stage == development")) == 0
 
-        reg_model.create_version()
-        assert len(reg_model.versions.find("stage == development")) == 1
-        assert len(reg_model.versions.find("stage == staging")) == 0
+        registered_model.create_version()
+        assert len(registered_model.versions.find("stage == development")) == 1
+        assert len(registered_model.versions.find("stage == staging")) == 0
 
 
 class TestArtifacts:

--- a/client/verta/tests/test_organization.py
+++ b/client/verta/tests/test_organization.py
@@ -67,6 +67,7 @@ class TestOrganization:
 
         # create entities with same name, but different workspace:
         new_model = client.create_registered_model(name=model_name, workspace=organization.name)
+        created_entities.append(new_model)
         new_version = new_model.create_version(name=version_name)
         # new_endpoint = client.create_endpoint(path=endpoint_path, workspace=organization.name)  TODO: uncomment after VR-6053
         # TODO: remove followinng three lines after VR-6053; until then, endpoints with same name diff workspace is a 409
@@ -85,7 +86,6 @@ class TestOrganization:
         created_entities.append(new_dataset)
 
         # created_entities.append(new_endpoint)  TODO: uncomment after VR-6053
-        created_entities.append(new_model)
 
         assert model.id != new_model.id
         assert version.id != new_version.id

--- a/client/verta/tests/test_organization.py
+++ b/client/verta/tests/test_organization.py
@@ -70,6 +70,7 @@ class TestOrganization:
         created_entities.append(new_model)
         new_version = new_model.create_version(name=version_name)
         # new_endpoint = client.create_endpoint(path=endpoint_path, workspace=organization.name)  TODO: uncomment after VR-6053
+        # created_entities.append(new_endpoint)  TODO: uncomment after VR-6053
         # TODO: remove followinng three lines after VR-6053; until then, endpoints with same name diff workspace is a 409
         with pytest.raises(requests.HTTPError) as excinfo:
             client.create_endpoint(path=endpoint_path, workspace=organization.name)
@@ -85,7 +86,6 @@ class TestOrganization:
         new_dataset = client.create_dataset(dataset_name, workspace=organization.name)
         created_entities.append(new_dataset)
 
-        # created_entities.append(new_endpoint)  TODO: uncomment after VR-6053
 
         assert model.id != new_model.id
         assert version.id != new_version.id

--- a/client/verta/tests/test_permissions/test_sharing_old.py
+++ b/client/verta/tests/test_permissions/test_sharing_old.py
@@ -61,26 +61,26 @@ class TestProject:
 
 
 class TestDataset:
-    def test_org_public_dataset(self, client, organization, client_2, email_2):
+    def test_org_public_dataset(self, client, organization, client_2, email_2, created_entities):
         """
         User 2 tries to access a org-public dataset created by a user in the same organization.
         """
         dataset_name = _utils.generate_default_name()
         dataset = client.create_dataset(dataset_name, workspace=organization.name, public_within_org=True)
+        created_entities.append(dataset)
 
         organization.add_member(email_2)
 
         assert client_2.get_dataset(id=dataset.id)
         assert client_2.get_dataset(name=dataset.name, workspace=organization.name)
 
-        dataset.delete()
-
-    def test_non_org_public_dataset_access_error(self, client, organization, client_2, email_2):
+    def test_non_org_public_dataset_access_error(self, client, organization, client_2, email_2, created_entities):
         """
         User 2 tries to access a non-org-public dataset created by a user in the same organization.
         """
         dataset_name = _utils.generate_default_name()
         dataset = client.create_dataset(dataset_name, workspace=organization.name, public_within_org=False)
+        created_entities.append(dataset)
 
         organization.add_member(email_2)
 
@@ -88,30 +88,28 @@ class TestDataset:
         with pytest.raises(ValueError, match="not found"):
             client_2.get_dataset(id=dataset.id)
 
-        dataset.delete()
-
 
 class TestRegisteredModel:
-    def test_org_public_registered_model(self, client, organization, client_2, email_2):
+    def test_org_public_registered_model(self, client, organization, client_2, email_2, created_entities):
         """
         User 2 tries to access a org-public registered_model created by a user in the same organization.
         """
         registered_model_name = _utils.generate_default_name()
         registered_model = client.create_registered_model(registered_model_name, workspace=organization.name, public_within_org=True)
+        created_entities.append(registered_model)
 
         organization.add_member(email_2)
 
         assert client_2.get_registered_model(id=registered_model.id)
         assert client_2.get_registered_model(name=registered_model.name, workspace=organization.name)
 
-        registered_model.delete()
-
-    def test_non_org_public_registered_model_access_error(self, client, organization, client_2, email_2):
+    def test_non_org_public_registered_model_access_error(self, client, organization, client_2, email_2, created_entities):
         """
         User 2 tries to access a non-org-public registered_model created by a user in the same organization.
         """
         registered_model_name = _utils.generate_default_name()
         registered_model = client.create_registered_model(registered_model_name, workspace=organization.name, public_within_org=False)
+        created_entities.append(registered_model)
 
         organization.add_member(email_2)
 
@@ -119,30 +117,28 @@ class TestRegisteredModel:
         with pytest.raises(ValueError, match="not found"):
             client_2.get_registered_model(id=registered_model.id)
 
-        registered_model.delete()
-
 
 class TestRepository:
-    def test_org_public_repository(self, client, organization, client_2, email_2):
+    def test_org_public_repository(self, client, organization, client_2, email_2, created_entities):
         """
         User 2 tries to access a org-public repository created by a user in the same organization.
         """
         repository_name = _utils.generate_default_name()
         repository = client.set_repository(repository_name, workspace=organization.name, public_within_org=True)
+        created_entities.append(repository)
 
         organization.add_member(email_2)
 
         assert client_2.get_or_create_repository(id=repository.id)
         assert client_2.get_or_create_repository(name=repository.name, workspace=organization.name).id == repository.id
 
-        repository.delete()
-
-    def test_non_org_public_repository_access_error(self, client, organization, client_2, email_2):
+    def test_non_org_public_repository_access_error(self, client, organization, client_2, email_2, created_entities):
         """
         User 2 tries to access a non-org-public repository created by a user in the same organization.
         """
         repository_name = _utils.generate_default_name()
         repository = client.set_repository(repository_name, workspace=organization.name, public_within_org=False)
+        created_entities.append(repository)
 
         organization.add_member(email_2)
 
@@ -150,11 +146,9 @@ class TestRepository:
         with pytest.raises(ValueError, match="no Repository found"):
             client_2.get_or_create_repository(id=repository.id)
 
-        repository.delete()
-
 
 class TestEndpoint:
-    def test_org_endpoint(self, client, organization, client_2, email_2):
+    def test_org_endpoint(self, client, organization, client_2, email_2, created_entities):
         """
         Non-owner access to org-public endpoint and private endpoint within an org.
         """
@@ -164,12 +158,12 @@ class TestEndpoint:
         # ORG_SCOPED_PUBLIC
         public_path = "public-{}".format(path)
         endpoint = client.create_endpoint(public_path, workspace=organization.name, public_within_org=True)
+        created_entities.append(endpoint)
         client_2.get_endpoint(public_path, workspace=organization.name)
-        endpoint.delete()
 
         # PRIVATE
         private_path = "private-{}".format(path)
         endpoint = client.create_endpoint(private_path, workspace=organization.name, public_within_org=False)
+        created_entities.append(endpoint)
         with pytest.raises(ValueError, match="Endpoint not found"):
             client_2.get_endpoint(private_path, workspace=organization.name)
-        endpoint.delete()

--- a/client/verta/tests/test_permissions/test_visibility_api.py
+++ b/client/verta/tests/test_permissions/test_visibility_api.py
@@ -70,17 +70,15 @@ class TestCreate:
             entity.delete()
             client._ctx.proj = None  # otherwise client teardown tries to delete
 
-    def test_endpoint(self, client, organization):
+    def test_endpoint(self, client, organization, created_entities):
         visibility = OrgCustom(write=True)
 
         endpoint = client.create_endpoint(
             path=_utils.generate_default_name(),
             workspace=organization.name, visibility=visibility,
         )
-        try:
-            assert_endpoint_visibility(endpoint, visibility)
-        finally:
-            endpoint.delete()
+        created_entities.append(endpoint)
+        assert_endpoint_visibility(endpoint, visibility)
 
     @pytest.mark.skip(reason="client.create_repository() does not yet exist")
     def test_repository(self, client, organization):
@@ -111,38 +109,36 @@ class TestSet:
             entity.delete()
             client._ctx.proj = None  # otherwise client teardown tries to delete
 
-    def test_endpoint(self, client, organization):
+    def test_endpoint(self, client, organization, created_entities):
         visibility = OrgCustom(write=True)
 
         endpoint = client.set_endpoint(
             path=_utils.generate_default_name(),
             workspace=organization.name, visibility=visibility,
         )
-        try:
-            assert_endpoint_visibility(endpoint, visibility)
+        created_entities.append(endpoint)
 
-            # second set ignores visibility
-            with pytest.warns(UserWarning, match="cannot set"):
-                endpoint = client.set_endpoint(path=endpoint.path, workspace=organization.name, visibility=Private())
-            assert_endpoint_visibility(endpoint, visibility)
-        finally:
-            endpoint.delete()
+        assert_endpoint_visibility(endpoint, visibility)
 
-    def test_repository(self, client, organization):
+        # second set ignores visibility
+        with pytest.warns(UserWarning, match="cannot set"):
+            endpoint = client.set_endpoint(path=endpoint.path, workspace=organization.name, visibility=Private())
+        assert_endpoint_visibility(endpoint, visibility)
+
+    def test_repository(self, client, organization, created_entities):
         visibility = OrgCustom(write=True)
 
         repo = client.set_repository(
             name=_utils.generate_default_name(),
             workspace=organization.name, visibility=visibility,
         )
-        try:
-            assert_repository_visibility(repo, visibility)
+        created_entities.append(repo)
 
-            # second set ignores visibility
-            repo = client.set_repository(name=repo.name, workspace=organization.name, visibility=Private())
-            assert_repository_visibility(repo, visibility)
-        finally:
-            repo.delete()
+        assert_repository_visibility(repo, visibility)
+
+        # second set ignores visibility
+        repo = client.set_repository(name=repo.name, workspace=organization.name, visibility=Private())
+        assert_repository_visibility(repo, visibility)
 
 
 class TestPublicWithinOrg:
@@ -151,31 +147,29 @@ class TestPublicWithinOrg:
     compatibility with older backends.
 
     """
-    def test_dataset(self, client, organization):
+    def test_dataset(self, client, organization, created_entities):
         visibility = OrgCustom(write=True)
-        entity = client.set_dataset(workspace=organization.name, visibility=visibility)
-        try:
-            if visibility._to_public_within_org():
-                assert entity._msg.dataset_visibility == _DatasetService.DatasetVisibilityEnum.ORG_SCOPED_PUBLIC
-            else:
-                assert entity._msg.dataset_visibility == _DatasetService.DatasetVisibilityEnum.PRIVATE
-        finally:
-            entity.delete()
+        dataset = client.set_dataset(workspace=organization.name, visibility=visibility)
+        created_entities.append(dataset)
 
-    def test_endpoint(self, client, organization):
+        if visibility._to_public_within_org():
+            assert dataset._msg.dataset_visibility == _DatasetService.DatasetVisibilityEnum.ORG_SCOPED_PUBLIC
+        else:
+            assert dataset._msg.dataset_visibility == _DatasetService.DatasetVisibilityEnum.PRIVATE
+
+    def test_endpoint(self, client, organization, created_entities):
         visibility = OrgCustom(write=True)
         endpoint = client.set_endpoint(
             path=_utils.generate_default_name(),
             workspace=organization.name, visibility=visibility,
         )
-        try:
-            endpoint_json = endpoint._get_json_by_id(endpoint._conn, endpoint.workspace, endpoint.id)
-            if visibility._to_public_within_org():
-                assert endpoint_json['creator_request']['visibility'] == "ORG_SCOPED_PUBLIC"
-            else:
-                assert endpoint_json['creator_request']['visibility'] == "PRIVATE"
-        finally:
-            endpoint.delete()
+        created_entities.append(endpoint)
+
+        endpoint_json = endpoint._get_json_by_id(endpoint._conn, endpoint.workspace, endpoint.id)
+        if visibility._to_public_within_org():
+            assert endpoint_json['creator_request']['visibility'] == "ORG_SCOPED_PUBLIC"
+        else:
+            assert endpoint_json['creator_request']['visibility'] == "PRIVATE"
 
     def test_project(self, client, organization):
         visibility = OrgCustom(write=True)
@@ -189,28 +183,26 @@ class TestPublicWithinOrg:
             entity.delete()
             client._ctx.proj = None  # otherwise client teardown tries to delete
 
-    def test_registered_model(self, client, organization):
+    def test_registered_model(self, client, organization, created_entities):
         visibility = OrgCustom(write=True)
         entity = client.set_registered_model(workspace=organization.name, visibility=visibility)
-        try:
-            if visibility._to_public_within_org():
-                assert entity._msg.visibility == _CommonCommonService.VisibilityEnum.ORG_SCOPED_PUBLIC
-            else:
-                assert entity._msg.visibility == _CommonCommonService.VisibilityEnum.PRIVATE
-        finally:
-            entity.delete()
+        created_entities.append(entity)
 
-    def test_repository(self, client, organization):
+        if visibility._to_public_within_org():
+            assert entity._msg.visibility == _CommonCommonService.VisibilityEnum.ORG_SCOPED_PUBLIC
+        else:
+            assert entity._msg.visibility == _CommonCommonService.VisibilityEnum.PRIVATE
+
+    def test_repository(self, client, organization, created_entities):
         visibility = OrgCustom(write=True)
         repo = client.set_repository(
             name=_utils.generate_default_name(),
             workspace=organization.name, visibility=visibility,
         )
-        try:
-            retrieved_visibility = repo._get_proto_by_id(repo._conn, repo.id).repository_visibility
-            if visibility._to_public_within_org():
-                assert retrieved_visibility == _VersioningService.RepositoryVisibilityEnum.ORG_SCOPED_PUBLIC
-            else:
-                assert retrieved_visibility == _VersioningService.RepositoryVisibilityEnum.PRIVATE
-        finally:
-            repo.delete()
+        created_entities.append(repo)
+
+        retrieved_visibility = repo._get_proto_by_id(repo._conn, repo.id).repository_visibility
+        if visibility._to_public_within_org():
+            assert retrieved_visibility == _VersioningService.RepositoryVisibilityEnum.ORG_SCOPED_PUBLIC
+        else:
+            assert retrieved_visibility == _VersioningService.RepositoryVisibilityEnum.PRIVATE


### PR DESCRIPTION
Recommend viewing the diff with ✅ Hide whitespace changes

## Changes
- replaces a few explicit `.delete()` calls with `created_entities.append()` to ensure the entity is deleted on test teardown
- replaces a few explicit `create_registered_model()` with the `registered_model` fixture.