### PR TITLE
Restore comparison property to reference alerter

### DIFF
--- a/client/verta/tests/monitoring/alerts/test_alerter.py
+++ b/client/verta/tests/monitoring/alerts/test_alerter.py
@@ -61,6 +61,7 @@ class TestReference:
     )
     def test_create(self, comparison, threshold, reference_sample_id):
         alerter = ReferenceAlerter(comparison(threshold), reference_sample_id)
+        assert alerter.comparison is not None
 
         msg = _AlertService.AlertReference(
             threshold=threshold,
@@ -83,6 +84,7 @@ class TestReference:
 
         alerter = _Alerter._from_proto(msg)
         assert type(alerter) is ReferenceAlerter
+        assert alerter.comparison is not None
         assert alerter._as_proto() == msg
 
     @hypothesis.given(

--- a/client/verta/verta/monitoring/alert/_alerter.py
+++ b/client/verta/verta/monitoring/alert/_alerter.py
@@ -167,6 +167,10 @@ class ReferenceAlerter(_Alerter):
         self._comparison = _Alerter._validate_comparison(comparison)
         self._reference_sample_id = utils.extract_id(reference_sample)
 
+    @property
+    def comparison(self):
+        return self._comparison
+
     @classmethod
     def _get_proto_class(self):
         return _AlertService.AlertReference


### PR DESCRIPTION
This property was accidentally removed. Adding it back with a test for its existence.