### PR TITLE
Change with_workspace(workspace_name) param to workspace

### DIFF
--- a/client/verta/verta/dataset/entities/_datasets.py
+++ b/client/verta/verta/dataset/entities/_datasets.py
@@ -52,14 +52,13 @@ class Datasets(_utils.LazyList):
     def _create_element(self, msg):
         return _dataset.Dataset(self._conn, self._conf, msg)
 
-    def with_workspace(self, workspace_name=None):
-        """
-        Returns datasets in the specified workspace.
+    def with_workspace(self, workspace=None):
+        """Returns datasets in the specified workspace.
 
         Parameters
         ----------
-        workspace_name : str or None, default None
-            Workspace name. If ``None``, uses personal workspace.
+        workspace : str, optional
+            Workspace name. If not provided, uses personal workspace.
 
         Returns
         -------
@@ -68,12 +67,11 @@ class Datasets(_utils.LazyList):
 
         """
         new_list = copy.deepcopy(self)
-        new_list._msg.workspace_name = workspace_name
+        new_list._msg.workspace_name = workspace
         return new_list
 
     def with_ids(self, ids):
-        """
-        Returns datasets with the specified IDs.
+        """Returns datasets with the specified IDs.
 
         Parameters
         ----------

--- a/client/verta/verta/endpoint/_endpoints.py
+++ b/client/verta/verta/endpoint/_endpoints.py
@@ -30,9 +30,22 @@ class Endpoints(object):
     def __len__(self):
         return len(self._ids)
 
-    def with_workspace(self, workspace_name):  # unlike MDB endpoints, workspace required
+    def with_workspace(self, workspace):  # unlike MDB endpoints, workspace required
+        """Returns endpoints in the specified workspace.
+
+        Parameters
+        ----------
+        workspace : str, optional
+            Workspace name. If not provided, uses personal workspace.
+
+        Returns
+        -------
+        :class:`Endpoints`
+            Filtered endpoints.
+
+        """
         new_list = copy.deepcopy(self)
-        new_list._workspace_name = workspace_name
+        new_list._workspace_name = workspace
         # store state Clientside because we can't make paginated calls anyway
         new_list._ids = new_list._get_ids()
         return new_list

--- a/client/verta/verta/registry/entities/_models.py
+++ b/client/verta/verta/registry/entities/_models.py
@@ -41,10 +41,23 @@ class RegisteredModels(_utils.LazyList):
     def _create_element(self, msg):
         return RegisteredModel(self._conn, self._conf, msg)
 
-    def with_workspace(self, workspace_name=None):
+    def with_workspace(self, workspace=None):
+        """Returns registered models in the specified workspace.
+
+        Parameters
+        ----------
+        workspace : str, optional
+            Workspace name. If not provided, uses personal workspace.
+
+        Returns
+        -------
+        :class:`RegisteredModels`
+            Filtered registered models.
+
+        """
         new_list = copy.deepcopy(self)
-        if workspace_name is not None:
-            new_list._msg.workspace_name = workspace_name
+        if workspace is not None:
+            new_list._msg.workspace_name = workspace
         else:
             new_list._msg.workspace_name = ''
         return new_list

--- a/client/verta/verta/registry/entities/_modelversions.py
+++ b/client/verta/verta/registry/entities/_modelversions.py
@@ -70,8 +70,21 @@ class RegisteredModelVersions(_utils.LazyList):
     def _page_number(self, msg):
         return msg.pagination.page_number
 
-    def with_workspace(self, workspace_name=None):
+    def with_workspace(self, workspace=None):
+        """Returns model versions in the specified workspace.
+
+        Parameters
+        ----------
+        workspace : str, optional
+            Workspace name. If not provided, uses personal workspace.
+
+        Returns
+        -------
+        :class:`RegisteredModelVersions`
+            Filtered model versions.
+
+        """
         new_list = copy.deepcopy(self)
         new_list._msg.id.ClearField('registered_model_id')
-        new_list._msg.id.named_id.workspace_name = workspace_name or ''
+        new_list._msg.id.named_id.workspace_name = workspace or ''
         return new_list

--- a/client/verta/verta/tracking/entities/_experimentruns.py
+++ b/client/verta/verta/tracking/entities/_experimentruns.py
@@ -238,9 +238,22 @@ class ExperimentRuns(_utils.LazyList):
 
         return new_runs
 
-    def with_workspace(self, workspace_name=None):
+    def with_workspace(self, workspace=None):
+        """Returns experiment runs in the specified workspace.
+
+        Parameters
+        ----------
+        workspace : str, optional
+            Workspace name. If not provided, uses personal workspace.
+
+        Returns
+        -------
+        :class:`ExperimentRuns`
+            Filtered experiment runs.
+
+        """
         new_list = copy.deepcopy(self)
         new_list._msg.ClearField('project_id')
         new_list._msg.ClearField('experiment_id')
-        new_list._msg.workspace_name = workspace_name or ''
+        new_list._msg.workspace_name = workspace or ''
         return new_list

--- a/client/verta/verta/tracking/entities/_experiments.py
+++ b/client/verta/verta/tracking/entities/_experiments.py
@@ -49,8 +49,21 @@ class Experiments(_utils.LazyList):
             new_list._msg.project_id = ''
         return new_list
 
-    def with_workspace(self, workspace_name=None):
+    def with_workspace(self, workspace=None):
+        """Returns experiments in the specified workspace.
+
+        Parameters
+        ----------
+        workspace : str, optional
+            Workspace name. If not provided, uses personal workspace.
+
+        Returns
+        -------
+        :class:`Experiments`
+            Filtered experiments.
+
+        """
         new_list = copy.deepcopy(self)
         new_list._msg.ClearField('project_id')
-        new_list._msg.workspace_name = workspace_name or ''
+        new_list._msg.workspace_name = workspace or ''
         return new_list

--- a/client/verta/verta/tracking/entities/_projects.py
+++ b/client/verta/verta/tracking/entities/_projects.py
@@ -41,7 +41,20 @@ class Projects(_utils.LazyList):
     def _create_element(self, msg):
         return Project(self._conn, self._conf, msg)
 
-    def with_workspace(self, workspace_name=None):
+    def with_workspace(self, workspace=None):
+        """Returns projects in the specified workspace.
+
+        Parameters
+        ----------
+        workspace : str, optional
+            Workspace name. If not provided, uses personal workspace.
+
+        Returns
+        -------
+        :class:`Projects`
+            Filtered projects.
+
+        """
         new_list = copy.deepcopy(self)
-        new_list._msg.workspace_name = workspace_name or ''
+        new_list._msg.workspace_name = workspace or ''
         return new_list


### PR DESCRIPTION
## Changes
- change `workspace_name` param to `workspace` for consistency with other client methods.
- add docstrings to `with_workspace()`s
  This is notably a breaking change, but I believe it's acceptable because
  1. It's the only parameter for this method, making it unlikely (though not impossible) that users are passing it by keyword.
  2. It's for the sake of API consistency, which should be done sooner rather than later.
  3. The upcoming client release is likely to be a minor one (rather than a patch) with the large addition of monitoring functionality, which for us is an appropriate time for breaking API changes.