### PR TITLE
[VR-11191] Add module docstrings

### DIFF
--- a/client/verta/.pydocstyle
+++ b/client/verta/.pydocstyle
@@ -1,3 +1,3 @@
 [pydocstyle]
 convention = numpy
-add-ignore = D100,D104,D105
+add-ignore = D105

--- a/client/verta/verta/endpoint/_endpoints.py
+++ b/client/verta/verta/endpoint/_endpoints.py
@@ -9,6 +9,20 @@ from ._endpoint import Endpoint
 
 # a rough copy of LazyList's API, because Endpoints don't use protos, find, or pagination
 class Endpoints(object):
+    """Collection object for finding endpoints.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        from verta import Client
+
+        client = Client()
+        # delete all endpoints in a given workspace
+        for endpoint in client.endpoints.with_workspace("Demos"):
+            endpoint.delete()
+
+    """
     def __init__(self, conn, conf, workspace_name):
         self._conn = conn
         self._conf = conf

--- a/client/verta/verta/endpoint/autoscaling/__init__.py
+++ b/client/verta/verta/endpoint/autoscaling/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+"""Autoscaling configuration for endpoints."""
 
 from verta._internal_utils import documentation
 

--- a/client/verta/verta/endpoint/autoscaling/metrics.py
+++ b/client/verta/verta/endpoint/autoscaling/metrics.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+"""Endpoint metrics to guide autoscaling behavior."""
 
 import abc
 

--- a/client/verta/verta/endpoint/resources.py
+++ b/client/verta/verta/endpoint/resources.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+"""Resource configuration for endpoints."""
 
 import abc
 import re

--- a/client/verta/verta/endpoint/update/__init__.py
+++ b/client/verta/verta/endpoint/update/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+"""Strategies for endpoint rollouts."""
 
 from verta._internal_utils import documentation
 

--- a/client/verta/verta/endpoint/update/_strategies.py
+++ b/client/verta/verta/endpoint/update/_strategies.py
@@ -23,7 +23,7 @@ class _UpdateStrategy(object):
 
 
 class DirectUpdateStrategy(_UpdateStrategy):
-    """
+    """A direct endpoint update strategy.
 
     The JSON equivalent for this is:
 
@@ -52,12 +52,12 @@ class DirectUpdateStrategy(_UpdateStrategy):
 
 
 class CanaryUpdateStrategy(_UpdateStrategy):
-    """
+    """A rule-based canary endpoint update strategy.
 
     The JSON equivalent for this is:
 
     .. code-block:: json
-    
+
         {
             "strategy": "canary",
             "canary_strategy": {

--- a/client/verta/verta/endpoint/update/rules.py
+++ b/client/verta/verta/endpoint/update/rules.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+"""Rules to guide canary endpoint updates."""
 
 import abc
 import json

--- a/client/verta/verta/integrations/keras/__init__.py
+++ b/client/verta/verta/integrations/keras/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+"""Keras callback for automatic experiment run logging."""
 
 from ...external import six
 

--- a/client/verta/verta/integrations/sklearn/__init__.py
+++ b/client/verta/verta/integrations/sklearn/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 """
 scikit-learn dynamic patch that automates logging to Verta during training.
 

--- a/client/verta/verta/integrations/tensorflow/__init__.py
+++ b/client/verta/verta/integrations/tensorflow/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+"""TensorFlow and TensorBoard integrations for automatic experiment run logging."""
 
 from ...external import six
 

--- a/client/verta/verta/integrations/torch/__init__.py
+++ b/client/verta/verta/integrations/torch/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+"""PyTorch module hook for automatic experiment run logging."""
 
 from ...external import six
 

--- a/client/verta/verta/integrations/xgboost/__init__.py
+++ b/client/verta/verta/integrations/xgboost/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+"""XGBoost callback for automatic experiment run logging."""
 
 from ...external import six
 

--- a/client/verta/verta/monitoring/alert/__init__.py
+++ b/client/verta/verta/monitoring/alert/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+"""Monitoring alerts."""
 
 from verta._internal_utils import documentation
 

--- a/client/verta/verta/monitoring/alert/entities/__init__.py
+++ b/client/verta/verta/monitoring/alert/entities/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+"""Entities for defining alerts in the Verta backend."""
 
 from verta._internal_utils import documentation
 

--- a/client/verta/verta/monitoring/alert/status/__init__.py
+++ b/client/verta/verta/monitoring/alert/status/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+"""Alert statuses."""
 
 from verta._internal_utils import documentation
 

--- a/client/verta/verta/monitoring/client.py
+++ b/client/verta/verta/monitoring/client.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+"""Monitoring sub-client."""
 
 from __future__ import print_function
 

--- a/client/verta/verta/monitoring/labels.py
+++ b/client/verta/verta/monitoring/labels.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+"""Summary labels."""
 
 from verta._protos.public.monitoring.Summary_pb2 import FilterQuerySummarySample
 

--- a/client/verta/verta/monitoring/monitored_entity.py
+++ b/client/verta/verta/monitoring/monitored_entity.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+"""A entity with associated data summaries and alerts."""
 
 from __future__ import print_function
 

--- a/client/verta/verta/monitoring/notification_channel/__init__.py
+++ b/client/verta/verta/monitoring/notification_channel/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+"""Notification channels to which to propagate alert messages."""
 
 from verta._internal_utils import documentation
 

--- a/client/verta/verta/monitoring/notification_channel/entities/__init__.py
+++ b/client/verta/verta/monitoring/notification_channel/entities/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+"""Entities for defining notification channels in the Verta backend."""
 
 from verta._internal_utils import documentation
 

--- a/client/verta/verta/monitoring/profiler.py
+++ b/client/verta/verta/monitoring/profiler.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+"""Data profilers."""
+
 import abc
 import collections
 

--- a/client/verta/verta/monitoring/summaries/__init__.py
+++ b/client/verta/verta/monitoring/summaries/__init__.py
@@ -1,0 +1,1 @@
+"""Data summaries."""

--- a/client/verta/verta/monitoring/summaries/queries.py
+++ b/client/verta/verta/monitoring/summaries/queries.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+"""Queries for summaries and summary samples."""
 
 from __future__ import print_function
 

--- a/client/verta/verta/monitoring/summaries/summaries.py
+++ b/client/verta/verta/monitoring/summaries/summaries.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+"""A collection of summaries."""
 
 from __future__ import print_function
 import warnings

--- a/client/verta/verta/monitoring/summaries/summary.py
+++ b/client/verta/verta/monitoring/summaries/summary.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+"""An entity to create and contain samples, persisted to Verta."""
 
 from __future__ import print_function
 

--- a/client/verta/verta/monitoring/summaries/summary_sample.py
+++ b/client/verta/verta/monitoring/summaries/summary_sample.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+"""A snapshot or window of data."""
 
 from __future__ import print_function
 

--- a/client/verta/verta/monitoring/summaries/summary_samples.py
+++ b/client/verta/verta/monitoring/summaries/summary_samples.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+"""A collection of summary samples."""
 
 from __future__ import print_function
 

--- a/client/verta/verta/registry/entities/__init__.py
+++ b/client/verta/verta/registry/entities/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+"Entities for registering ML models to the Verta backend."
 
 from verta._internal_utils import documentation
 

--- a/client/verta/verta/registry/lock/__init__.py
+++ b/client/verta/verta/registry/lock/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+"""Lock levels for registered models."""
 
 from verta._internal_utils import documentation
 

--- a/client/verta/verta/tracking/entities/__init__.py
+++ b/client/verta/verta/tracking/entities/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+"""Entities for logging projects and experiments to the Verta backend."""
 
 from verta._internal_utils import documentation
 


### PR DESCRIPTION
Our `autosummary`-based API documentation is visually sparse without module docstrings. I've added barebones descriptions so that page tables aren't spotty/blank.
![Screen Shot 2021-05-26 at 10 12 21 PM](https://user-images.githubusercontent.com/7754936/119769810-06862000-be70-11eb-8b94-617f7915bfc8.png)
