### PR TITLE
[VR-11492] Allow parse_duration() to handle value=0

### DIFF
--- a/client/verta/verta/_internal_utils/time_utils/__init__.py
+++ b/client/verta/verta/_internal_utils/time_utils/__init__.py
@@ -73,7 +73,7 @@ def parse_duration(value):
         duration = timedelta(milliseconds=value)
     if isinstance(value, timedelta):
         duration = value
-    if duration:
+    if duration is not None:
         duration = _force_millisecond_resolution(duration)
         return duration
-    raise ValueError("cannot convert argument to a time duration")
+    raise ValueError("cannot convert {} to a time duration".format(value))


### PR DESCRIPTION
```
SummarySampleQuery._from_proto_request()
-> Aggregation._from_proto()
```
fails if `granularity = 0` (which is the default for an non-set proto value)