### PR TITLE
Add integration test to verify dataset timestamp is updated on version creation

### DIFF
--- a/client/verta/tests/test_dataset_versioning/conftest.py
+++ b/client/verta/tests/test_dataset_versioning/conftest.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+
+
+@pytest.fixture
+def dataset(client, created_entities):
+    dataset = client.create_dataset()
+    created_entities.append(dataset)
+
+    return dataset

--- a/client/verta/tests/test_dataset_versioning/test_dataset.py
+++ b/client/verta/tests/test_dataset_versioning/test_dataset.py
@@ -1,4 +1,5 @@
 import collections
+import time
 
 import pytest
 import requests
@@ -78,9 +79,9 @@ class TestCreateGet:
 
         dataset_version = dataset.create_version(Path(["conftest.py"]))
 
+        time.sleep(30)  # wait for reconciler
         dataset._fetch_with_no_cache()
         assert dataset._msg.time_updated > time_updated
-        # TODO: might be close but not equal
         assert dataset._msg.time_updated == dataset_version._msg.time_logged
 
     def test_create(self, client, created_entities):

--- a/client/verta/tests/test_dataset_versioning/test_dataset.py
+++ b/client/verta/tests/test_dataset_versioning/test_dataset.py
@@ -4,6 +4,7 @@ import pytest
 import requests
 
 import verta
+from verta.dataset import Path
 
 
 class TestMetadata:
@@ -71,6 +72,17 @@ class TestMetadata:
 
 
 class TestCreateGet:
+    def test_creation_updates_dataset_timestamp(self, client, dataset):
+        """Version creation should update its dataset's time_updated field."""
+        time_updated = dataset._msg.time_updated
+
+        dataset_version = dataset.create_version(Path(["conftest.py"]))
+
+        dataset._fetch_with_no_cache()
+        assert dataset._msg.time_updated > time_updated
+        # TODO: might be close but not equal
+        assert dataset._msg.time_updated == dataset_version._msg.time_logged
+
     def test_create(self, client, created_entities):
         dataset = client.set_dataset()
         assert dataset

--- a/client/verta/tests/test_dataset_versioning/test_dataset.py
+++ b/client/verta/tests/test_dataset_versioning/test_dataset.py
@@ -79,7 +79,7 @@ class TestCreateGet:
 
         dataset_version = dataset.create_version(Path(["conftest.py"]))
 
-        time.sleep(30)  # wait for reconciler
+        time.sleep(60)  # wait for reconciler
         dataset._fetch_with_no_cache()
         assert dataset._msg.time_updated > time_updated
         assert dataset._msg.time_updated == dataset_version._msg.time_logged

--- a/client/verta/tests/test_dataset_versioning/test_dataset_version.py
+++ b/client/verta/tests/test_dataset_versioning/test_dataset_version.py
@@ -86,6 +86,7 @@ class TestMetadata:  # essentially copied from test_dataset.py
 
 class TestCreateGet:
     def test_creation_updates_dataset_timestamp(self, client, dataset):
+        """Version creation should update its dataset's time_updated field."""
         time_updated = dataset._msg.time_updated
 
         dataset_version = dataset.create_version(Path(["conftest.py"]))

--- a/client/verta/tests/test_dataset_versioning/test_dataset_version.py
+++ b/client/verta/tests/test_dataset_versioning/test_dataset_version.py
@@ -85,6 +85,16 @@ class TestMetadata:  # essentially copied from test_dataset.py
 
 
 class TestCreateGet:
+    def test_creation_updates_dataset_timestamp(self, client, dataset):
+        time_updated = dataset._msg.time_updated
+
+        dataset_version = dataset.create_version(Path(["conftest.py"]))
+
+        dataset._fetch_with_no_cache()
+        assert dataset._msg.time_updated > time_updated
+        # TODO: might be close but not equal
+        assert dataset._msg.time_updated == dataset_version._msg.time_logged
+
     def test_create_get_path(self, client, created_entities):
         name = verta._internal_utils._utils.generate_default_name()
         dataset = client.set_dataset(name)

--- a/client/verta/tests/test_dataset_versioning/test_dataset_version.py
+++ b/client/verta/tests/test_dataset_versioning/test_dataset_version.py
@@ -85,17 +85,6 @@ class TestMetadata:  # essentially copied from test_dataset.py
 
 
 class TestCreateGet:
-    def test_creation_updates_dataset_timestamp(self, client, dataset):
-        """Version creation should update its dataset's time_updated field."""
-        time_updated = dataset._msg.time_updated
-
-        dataset_version = dataset.create_version(Path(["conftest.py"]))
-
-        dataset._fetch_with_no_cache()
-        assert dataset._msg.time_updated > time_updated
-        # TODO: might be close but not equal
-        assert dataset._msg.time_updated == dataset_version._msg.time_logged
-
     def test_create_get_path(self, client, created_entities):
         name = verta._internal_utils._utils.generate_default_name()
         dataset = client.set_dataset(name)


### PR DESCRIPTION
For https://github.com/VertaAI/modeldb/pull/2349

```sh
$ pytest test_dataset_versioning/test_dataset.py::TestCreateGet::test_creation_updates_dataset_timestamp   
==================================================== test session starts ====================================================
platform darwin -- Python 3.7.10, pytest-6.2.4, py-1.10.0, pluggy-0.13.1                                                     
rootdir: /Users/miliu/Documents/modeldb/client/verta/tests, configfile: pytest.ini                                           
collected 1 item                                                                                                             
                                                                                                                             
test_dataset_versioning/test_dataset.py .                                                                             [100%] 
                                                                                                                             
========================================== 1 passed, 1 warning in 62.88s (0:01:02) ==========================================
```