### PR TITLE
Metrics are only initialized once

### DIFF
--- a/backend/src/main/java/ai/verta/modeldb/App.java
+++ b/backend/src/main/java/ai/verta/modeldb/App.java
@@ -49,6 +49,7 @@ import java.util.Optional;
 import java.util.TimerTask;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import javax.management.MalformedObjectNameException;
 import liquibase.exception.LiquibaseException;
@@ -107,13 +108,15 @@ public class App implements ApplicationContextAware {
 
   // Export all JMX metrics to Prometheus
   private static final String rules = "---\n" + "rules:\n" + "  - pattern: \".*\"";
-
+  private static final AtomicBoolean metricsInitialized = new AtomicBoolean(false);
   @Bean
   public ServletRegistrationBean<MetricsServlet> servletRegistrationBean()
       throws MalformedObjectNameException {
-    DefaultExports.initialize();
-    new BuildInfoCollector().register();
-    new JmxCollector(rules).register();
+    if (!metricsInitialized.getAndSet(true)) {
+      DefaultExports.initialize();
+      new BuildInfoCollector().register();
+      new JmxCollector(rules).register();
+    }
     return new ServletRegistrationBean<>(new MetricsServlet(), "/metrics");
   }
 

--- a/backend/src/main/java/ai/verta/modeldb/App.java
+++ b/backend/src/main/java/ai/verta/modeldb/App.java
@@ -109,6 +109,7 @@ public class App implements ApplicationContextAware {
   // Export all JMX metrics to Prometheus
   private static final String rules = "---\n" + "rules:\n" + "  - pattern: \".*\"";
   private static final AtomicBoolean metricsInitialized = new AtomicBoolean(false);
+
   @Bean
   public ServletRegistrationBean<MetricsServlet> servletRegistrationBean()
       throws MalformedObjectNameException {


### PR DESCRIPTION
The tests do not properly isolate the initialization sequence.  This causes multiple calls to the metrics collectors, generating errors that break tests.