### PR TITLE
Fix floating point error in computing millis for time delta

### DIFF
--- a/client/verta/tests/test_utils/test_time_utils.py
+++ b/client/verta/tests/test_utils/test_time_utils.py
@@ -60,6 +60,13 @@ class TestDurationMillis:
         with pytest.raises(ValueError):
             time_utils.duration_millis(negative_int)
 
+    @given(millis=millis_uint64_strategy)
+    def test_round_trip_from_delta(self, millis):
+        delta = timedelta(milliseconds=millis)
+        delta_millis = time_utils.duration_millis(delta)
+        delta_parsed = time_utils.parse_duration(delta_millis)
+        assert delta == delta_parsed
+
 
 class TestParseDuration:
     def test_parse_duration(self):

--- a/client/verta/verta/_internal_utils/time_utils/__init__.py
+++ b/client/verta/verta/_internal_utils/time_utils/__init__.py
@@ -57,6 +57,8 @@ def _force_millisecond_resolution(delta):
 
 def duration_millis(delta):
     if isinstance(delta, timedelta):
+        # NB: The following explicitly avoids floating point errors
+        # which occur when computing millis via delta.total_seconds() * 1000
         delta = _force_millisecond_resolution(delta)
         millis_from_seconds = int(delta.total_seconds()) * 1000
         millis_from_micro = int(delta.microseconds / 1000)

--- a/client/verta/verta/_internal_utils/time_utils/__init__.py
+++ b/client/verta/verta/_internal_utils/time_utils/__init__.py
@@ -58,7 +58,9 @@ def _force_millisecond_resolution(delta):
 def duration_millis(delta):
     if isinstance(delta, timedelta):
         delta = _force_millisecond_resolution(delta)
-        return int(delta.total_seconds() * 1000)
+        millis_from_seconds = int(delta.total_seconds()) * 1000
+        millis_from_micro = int(delta.microseconds / 1000)
+        return millis_from_seconds + millis_from_micro
     elif isinstance(delta, int) and delta >= 0:
         return delta
     raise ValueError("cannot convert argument to duration milliseconds")


### PR DESCRIPTION
Computing milliseconds for a `timedelta` by multiplying the floating point `total_seconds` by 1000 doesn't guarantee that the round trip of "to milliseconds" and "from milliseconds" isn't broken by floating point math. I've fixed this and added a test for the bug.