### PR TITLE
Update endpoint test

### DIFF
--- a/client/verta/tests/test_endpoint/test_endpoint.py
+++ b/client/verta/tests/test_endpoint/test_endpoint.py
@@ -115,7 +115,7 @@ class TestEndpoint:
         assert "path: {}".format(endpoint.path) in str_repr
         assert "url" in str_repr
         assert "id: {}".format(endpoint.id) in str_repr
-        assert "curl: <Endpoint not deployed>" in str_repr
+        assert "curl: <endpoint not deployed>" in str_repr
 
         # these fields might have changed:
         assert "status" in str_repr


### PR DESCRIPTION
My cleanups in https://github.com/VertaAI/modeldb/pull/2375 had a side effect I did not foresee.

```sh
$ pytest test_endpoint/
===================================================== test session starts ======================================================
platform darwin -- Python 3.9.2, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /Users/miliu/Documents/modeldb/client/verta/tests, configfile: pytest.ini
plugins: xdist-2.2.1, forked-1.3.0, hypothesis-6.8.3
collected 48 items                                                                                                             

test_endpoint/test_endpoint.py ...........................                                                               [ 56%]
test_endpoint/test_resources.py .....................                                                                    [100%]

========================================= 48 passed, 40 warnings in 2080.91s (0:34:40) =========================================
```