### PR TITLE
Support long in parse_duration()

### DIFF
--- a/client/verta/verta/_internal_utils/time_utils/__init__.py
+++ b/client/verta/verta/_internal_utils/time_utils/__init__.py
@@ -80,7 +80,7 @@ def parse_duration(value):
             duration = timedelta(seconds=dur_seconds)
         except:
             raise ValueError("cannot convert string argument to timedelta")
-    if isinstance(value, int):
+    if isinstance(value, six.integer_types):
         if value < 0:
             raise ValueError("cannot accept negative integer as a millisecond duration")
         duration = timedelta(milliseconds=value)


### PR DESCRIPTION
These tests were failing in Python 2, because our `aggregation_query_strategy` generates `long`s in addition to `int`s. Since `timedelta` itself supports handling `long`s, our `parse_duration()` may as well too.


```sh
$ pytest monitoring/test_aggregation.py::TestAggregation                                                      
===================================================== test session starts ======================================================
platform darwin -- Python 2.7.18, pytest-4.6.11, py-1.10.0, pluggy-0.13.1                                                       
rootdir: /Users/miliu/Documents/modeldb/client/verta/tests, inifile: pytest.ini                                                 
plugins: hypothesis-4.57.1                                                                                                      
collected 2 items                                                                                                               
                                                                                                                                
monitoring/test_aggregation.py ..                                                                                        [100%] 
                                                                                                                                
=================================================== 2 passed in 0.38 seconds ===================================================
```