### PR TITLE
Raise warning when ignoring existing RMV attribute

### DIFF
--- a/client/verta/tests/test_model_registry/test_model_version.py
+++ b/client/verta/tests/test_model_registry/test_model_version.py
@@ -246,6 +246,28 @@ class TestModelVersion:
         # Deleting non-existing key:
         model_version.del_attribute("non-existing")
 
+    def test_attributes_overwrite(self, client, registered_model):
+        old_attr = ("a", 1)
+        new_attr = ("a", 2)
+        second_attr = ("b", 2)
+
+        model_version = registered_model.create_version()
+        model_version.add_attribute(*old_attr)
+
+        # without `overwrite`
+        with pytest.warns(
+            UserWarning,
+            match="^skipping.*{}.*already exists".format(old_attr[0]),
+        ):
+            model_version.add_attributes(dict([new_attr, second_attr]))
+        assert model_version.get_attributes() == dict([old_attr, second_attr])
+
+        # with `overwrite`
+        with pytest.warns(None) as record:
+            model_version.add_attributes(dict([new_attr, second_attr]), overwrite=True)
+        assert not record  # no warning
+        assert model_version.get_attributes() == dict([new_attr, second_attr])
+
     def test_patch(self, registered_model):
         NAME = "name"
         DESCRIPTION = "description"

--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -940,7 +940,7 @@ class RegisteredModelVersion(_DeployableEntity):
         for key, value in six.viewitems(attrs):
             if key in existing_attrs and not overwrite:
                 warnings.warn(
-                    "attribute {} already exists;"
+                    "skipping attribute {} which already exists;"
                     " set `overwrite=True` to overwrite".format(key)
                 )
                 continue


### PR DESCRIPTION
Currently, when a duplicate model version attribute is logged with `overwrite=False` (default), it is silently ignored. This change raises a warning and suggestion when this occurs.