### PR TITLE
[VR-11546] Document what model types we support direct deployment for

### DIFF
--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -264,31 +264,6 @@ class RegisteredModelVersion(_DeployableEntity):
         artifacts=None,
         overwrite=False,
     ):
-        """
-        Logs a model to this Model Version.
-
-        Parameters
-        ----------
-        model : str or file-like or object
-            Model or some representation thereof.
-                - If str, then it will be interpreted as a filesystem path, its contents read as bytes,
-                  and uploaded as an artifact. If it is a directory path, its contents will be zipped.
-                - If file-like, then the contents will be read as bytes and uploaded as an artifact.
-                - Otherwise, the object will be serialized and uploaded as an artifact.
-        custom_modules : list of str, optional
-            Paths to local Python modules and other files that the deployed model depends on.
-                - If directories are provided, all files within—excluding virtual environments—will
-                  be included.
-                - If not provided, all Python files located within `sys.path`—excluding virtual
-                  environments—will be included.
-        model_api : :class:`~verta.utils.ModelAPI`, optional
-            Model API specifying details about the model and its deployment.
-        artifacts : list of str, optional
-            Keys of logged artifacts to be used by a class model.
-        overwrite : bool, default False
-            Whether to allow overwriting an existing artifact with key `key`.
-
-        """
         if self.has_model and not overwrite:
             raise ValueError("model already exists; consider setting overwrite=True")
 

--- a/client/verta/verta/tracking/entities/_deployable_entity.py
+++ b/client/verta/verta/tracking/entities/_deployable_entity.py
@@ -68,12 +68,13 @@ class _DeployableEntity(_ModelDBEntity):
         ----------
         model : str or object
             Model. For deployment, this parameter can be one of the following types:
-                - any scikit-learn model that implements ``predict()``
-                - Keras model from their `Sequential model API <https://keras.io/guides/sequential_model/>`__
+                - any scikit-learn model object that implements ``predict()``
+                - Keras model object from their `Sequential model API <https://keras.io/guides/sequential_model/>`__
                   or `Functional model API <https://keras.io/guides/functional_api/>`__
-                - any PyTorch model
-                - XGBoost model from their `scikit-learn API
+                - any PyTorch model object
+                - XGBoost model object from their `scikit-learn API
                   <https://xgboost.readthedocs.io/en/latest/python/python_api.html#module-xgboost.sklearn>`__
+                - user-defined class that inherits from :class:`~verta.registry.VertaModelBase`
             For more general model logging, the following types are also supported:
                 - ``str`` path to a file or directory
                 - arbitrary ``pickle``\ able object

--- a/client/verta/verta/tracking/entities/_deployable_entity.py
+++ b/client/verta/verta/tracking/entities/_deployable_entity.py
@@ -54,6 +54,42 @@ class _DeployableEntity(_ModelDBEntity):
         raise NotImplementedError
 
     @abc.abstractmethod
+    def log_model(
+        self,
+        model,
+        custom_modules=None,
+        model_api=None,
+        artifacts=None,
+        overwrite=False,
+    ):
+        """Logs a model and associated code dependencies.
+
+        Parameters
+        ----------
+        model : str or object
+            Model for deployment.
+                - If str, then it will be interpreted as a filesystem path to a serialized model file
+                  for upload.
+                - Otherwise, the object will be serialized and uploaded as an artifact.
+        custom_modules : list of str, optional
+            Paths to local Python modules and other files that the deployed model depends on.
+                - If directories are provided, all files within—excluding virtual environments—will
+                  be included.
+                - If module names are provided, all files within the corresponding module inside a
+                  folder in `sys.path` will be included.
+                - If not provided, all Python files located within `sys.path`—excluding virtual
+                  environments—will be included.
+        model_api : :class:`~verta.utils.ModelAPI`, optional
+            Model API specifying details about the model and its deployment.
+        artifacts : list of str, optional
+            Keys of logged artifacts to be used by a class model.
+        overwrite : bool, default False
+            Whether to allow overwriting existing model artifacts.
+
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
     def download_artifact(self, key, download_to_path):
         """Downloads the artifact with name `key` to path `download_to_path`.
 

--- a/client/verta/verta/tracking/entities/_deployable_entity.py
+++ b/client/verta/verta/tracking/entities/_deployable_entity.py
@@ -62,22 +62,28 @@ class _DeployableEntity(_ModelDBEntity):
         artifacts=None,
         overwrite=False,
     ):
-        """Logs a model and associated code dependencies.
+        r"""Logs a model and associated code dependencies.
 
         Parameters
         ----------
         model : str or object
-            Model for deployment.
-                - If str, then it will be interpreted as a filesystem path to a serialized model file
-                  for upload.
-                - Otherwise, the object will be serialized and uploaded as an artifact.
+            Model. For deployment, this parameter can be one of the following types:
+                - any scikit-learn model that implements ``predict()``
+                - Keras model from their `Sequential model API <https://keras.io/guides/sequential_model/>`__
+                  or `Functional model API <https://keras.io/guides/functional_api/>`__
+                - any PyTorch model
+                - XGBoost model from their `scikit-learn API
+                  <https://xgboost.readthedocs.io/en/latest/python/python_api.html#module-xgboost.sklearn>`__
+            For more general model logging, the following types are also supported:
+                - ``str`` path to a file or directory
+                - arbitrary ``pickle``\ able object
         custom_modules : list of str, optional
             Paths to local Python modules and other files that the deployed model depends on.
                 - If directories are provided, all files within—excluding virtual environments—will
                   be included.
                 - If module names are provided, all files within the corresponding module inside a
-                  folder in `sys.path` will be included.
-                - If not provided, all Python files located within `sys.path`—excluding virtual
+                  folder in ``sys.path`` will be included.
+                - If not provided, all Python files located within ``sys.path``—excluding virtual
                   environments—will be included.
         model_api : :class:`~verta.utils.ModelAPI`, optional
             Model API specifying details about the model and its deployment.

--- a/client/verta/verta/tracking/entities/_experimentrun.py
+++ b/client/verta/verta/tracking/entities/_experimentrun.py
@@ -1284,32 +1284,6 @@ class ExperimentRun(_DeployableEntity):
                            _CommonCommonService.ArtifactTypeEnum.BLOB, 'zip')
 
     def log_model(self, model, custom_modules=None, model_api=None, artifacts=None, overwrite=False):
-        """
-        Logs a model artifact for Verta model deployment.
-
-        Parameters
-        ----------
-        model : str or object
-            Model for deployment.
-                - If str, then it will be interpreted as a filesystem path to a serialized model file
-                  for upload.
-                - Otherwise, the object will be serialized and uploaded as an artifact.
-        custom_modules : list of str, optional
-            Paths to local Python modules and other files that the deployed model depends on.
-                - If directories are provided, all files within—excluding virtual environments—will
-                  be included.
-                - If module names are provided, all files within the corresponding module inside a
-                  folder in `sys.path` will be included.
-                - If not provided, all Python files located within `sys.path`—excluding virtual
-                  environments—will be included.
-        model_api : :class:`~verta.utils.ModelAPI`, optional
-            Model API specifying details about the model and its deployment.
-        artifacts : list of str, optional
-            Keys of logged artifacts to be used by a class model.
-        overwrite : bool, default False
-            Whether to allow overwriting existing artifacts.
-
-        """
         if model_api and not isinstance(model_api, utils.ModelAPI):
             raise ValueError(
                 "`model_api` must be `verta.utils.ModelAPI`, not {}".format(type(model_api)))


### PR DESCRIPTION
![Screen Shot 2021-06-14 at 6 13 11 PM](https://user-images.githubusercontent.com/7754936/122084501-bb986200-cdb6-11eb-8861-379ea1fad18e.png)


## Changes
- move `log_model()` docstring to base class
- document what model types are supported for deployment