### PR TITLE
[VR-9613] Add a delay for endpoint re-update test

### DIFF
--- a/client/verta/tests/test_endpoint/test_endpoint.py
+++ b/client/verta/tests/test_endpoint/test_endpoint.py
@@ -619,6 +619,7 @@ class TestEndpoint:
 
         # updating endpoint
         endpoint.update(new_model_version, DirectUpdateStrategy(), wait=True)
+        time.sleep(60)  # add a delay for API routing to finish transitioning
         assert endpoint.get_deployed_model().predict("foo") == "B"
 
     def test_update_from_run_diff_workspace(self, client, organization, created_entities, experiment_run, model_for_deployment):


### PR DESCRIPTION
This is a test that updates an existing endpoint, and verifies that it returns predictions from the new model rather than the old one.

From comments on the ticket: It's difficult to guarantee in our system today that all new traffic is routed to the new model as soon as our system has deployed it.

Fundamentally, this test is just trying to make sure that the new model is deployed at all, so a delay seems acceptable to me in this context.