### PR TITLE
[VR-11858] Fix bug where zip-unzip magic was broken for directory names with periods

### DIFF
--- a/client/verta/tests/conftest.py
+++ b/client/verta/tests/conftest.py
@@ -240,8 +240,13 @@ def output_path():
     shutil.rmtree(dirpath)
 
 
-@pytest.fixture
-def dir_and_files(strs, tmp_path):
+@pytest.fixture(
+    params=[  # directory name
+        "foo",
+        "foo.bar",  # ensure we can handle directories with periods
+    ]
+)
+def dir_and_files(strs, tmp_path, request):
     """
     Creates nested directory of empty files.
 
@@ -251,6 +256,8 @@ def dir_and_files(strs, tmp_path):
     filepaths : set of str
 
     """
+    dirpath = tmp_path / request.param
+
     filepaths = {
         os.path.join(strs[0], strs[1], strs[2]),
         os.path.join(strs[0], strs[1], strs[3]),
@@ -261,11 +268,11 @@ def dir_and_files(strs, tmp_path):
     }
 
     for filepath in filepaths:
-        p = tmp_path / filepath
+        p = dirpath / filepath
         p.parent.mkdir(parents=True, exist_ok=True)
         p.touch()
 
-    return str(tmp_path), filepaths
+    return str(dirpath), filepaths
 
 
 @pytest.fixture

--- a/client/verta/verta/_internal_utils/_artifact_utils.py
+++ b/client/verta/verta/_internal_utils/_artifact_utils.py
@@ -75,6 +75,8 @@ def get_file_ext(file):
     """
     Obtain the filename extension of `file`.
 
+    This method assumes `file` is accessible on the user's filesystem.
+
     Parameters
     ----------
     file : str or file handle
@@ -93,7 +95,7 @@ def get_file_ext(file):
         If the filepath lacks an extension.
 
     """
-    if isinstance(file, six.string_types):
+    if isinstance(file, six.string_types) and not os.path.isdir(file):
         filepath = file
     elif hasattr(file, 'read') and hasattr(file, 'name'):  # `open()` object
         filepath = file.name

--- a/client/verta/verta/tracking/entities/_experimentrun.py
+++ b/client/verta/verta/tracking/entities/_experimentrun.py
@@ -1305,17 +1305,15 @@ class ExperimentRun(_DeployableEntity):
                     sorted(unlogged_artifact_keys)))
 
         # serialize model
-        try:
-            extension = _artifact_utils.get_file_ext(model)
-        except (TypeError, ValueError):
-            extension = None
         _utils.THREAD_LOCALS.active_experiment_run = self
         try:
             serialized_model, method, model_type = _artifact_utils.serialize_model(
                 model)
         finally:
             _utils.THREAD_LOCALS.active_experiment_run = None
-        if extension is None:
+        try:
+            extension = _artifact_utils.get_file_ext(serialized_model)
+        except (TypeError, ValueError):
             extension = _artifact_utils.ext_from_method(method)
         if self._conf.debug:
             print("[DEBUG] model is type {}".format(model_type))


### PR DESCRIPTION
## Problem

```python
experiment_run.log_model("./my.directory")  # period(s) in directory name
experiment_run.download_model("dst")
```
gives the user a `zip` rather than a directory.

This is proximately because `ExperimentRun.log_model()` tries to glean a filename extension from the model's source file/directory, and then ignores the special zip-unzip magic extension provided later on.

### Before

```bash
$ pytest test_artifacts.py::TestArbitraryModels::test_download_arbitrary_directory -v                      
==================================================== test session starts ====================================================
platform darwin -- Python 3.7.10, pytest-6.2.4, py-1.10.0, pluggy-0.13.1 -- /Users/miliu/.pyenv/versions/3.7.10/envs/dev3/bin
/python3.7                                                                                                
collected 2 items                                                                                                            
                                                                                                                             
test_artifacts.py::TestArbitraryModels::test_download_arbitrary_directory[foo] PASSED                                 [ 50%] 
test_artifacts.py::TestArbitraryModels::test_download_arbitrary_directory[foo.bar] FAILED                             [100%] 
                                                                                                                             
========================================================= FAILURES ==========================================================
______________________________ TestArbitraryModels.test_download_arbitrary_directory[foo.bar] _______________________________
                                                                                                                                                                                                                                                      
    def test_download_arbitrary_directory(self, experiment_run, dir_and_files, strs, in_tempdir):                            
        """Model that was originally a dir is unpacked on download."""                                                       
        dirpath, _ = dir_and_files                                                                                           
        download_path = strs[0]                                                                                              
                                                                                                                             
        experiment_run.log_model(dirpath)                                                                                    
        returned_path = experiment_run.download_model(download_path)                                                         
        assert returned_path == os.path.abspath(download_path) 
     
        # contents match
>       utils.assert_dirs_match(dirpath, download_path)

/Users/miliu/Documents/modeldb/client/verta/tests/test_artifacts.py:586: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

    def assert_dirs_match(dir1, dir2):
        assert os.path.isdir(dir1)
>       assert os.path.isdir(dir2)
E       AssertionError

/Users/miliu/Documents/modeldb/client/verta/tests/utils.py:133: AssertionError

================================================== short test summary info ==================================================
FAILED test_artifacts.py::TestArbitraryModels::test_download_arbitrary_directory[foo.bar] - AssertionError
========================================= 1 failed, 1 passed, 2 warnings in 16.98s ==========================================
```

### After

```bash
$ pytest test_artifacts.py::TestArbitraryModels::test_download_arbitrary_directory -v
==================================================== test session starts ====================================================
platform darwin -- Python 3.7.10, pytest-6.2.4, py-1.10.0, pluggy-0.13.1 -- /Users/miliu/.pyenv/versions/3.7.10/envs/dev3/bin
/python3.7
collected 2 items                                                                                                           

test_artifacts.py::TestArbitraryModels::test_download_arbitrary_directory[foo] PASSED                                 [ 50%]
test_artifacts.py::TestArbitraryModels::test_download_arbitrary_directory[foo.bar] PASSED                             [100%]

============================================== 2 passed, 2 warnings in 15.31s ===============================================
```

## Changes
- get file extension _after_ serialization
- reject directories in `get_file_ext()`
- validate directory names with periods in tests that deal with directories-as-artifacts
  - from my testing, this adds two minutes to the tests' total runtime.