### PR TITLE
Use relative import to unblock tests

### DIFF
--- a/client/verta/tests/clean_test_accounts.py
+++ b/client/verta/tests/clean_test_accounts.py
@@ -8,7 +8,7 @@ import sys
 import requests
 from verta import Client
 
-import constants  # pylint: disable=relative-import
+from . import constants
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
I thought I could get away with some slight import hackery to use `clean_test_accounts.get_clients()` in a test fixture, but despite working on my machine it does not work in our automated tests.

I'm changing this to a relative import to unblock our automated tests, but this will break `python clean_test_accounts.py`. I'll need to figure out what to do there a bit later.