### PR TITLE
Revert unintended test fixture changes

### DIFF
--- a/client/verta/tests/conftest.py
+++ b/client/verta/tests/conftest.py
@@ -345,9 +345,6 @@ def in_tempdir(tempdir_root):
 @pytest.fixture
 def client(host, port, email, dev_key, created_entities):
     client = Client(host, port, email, dev_key, debug=True)
-    client._conn._set_default_workspace(
-        client._conn.get_personal_workspace(),
-    )
 
     yield client
 
@@ -376,9 +373,6 @@ def client_2(host, port, email_2, dev_key_2, created_entities):
         pytest.skip("second account credentials not present")
 
     client = Client(host, port, email_2, dev_key_2, debug=True)
-    client._conn._set_default_workspace(
-        client._conn.get_personal_workspace(),
-    )
 
     yield client
 
@@ -395,9 +389,6 @@ def client_3(host, port, email_3, dev_key_3, created_entities):
         pytest.skip("second account credentials not present")
 
     client = Client(host, port, email_3, dev_key_3, debug=True)
-    client._conn._set_default_workspace(
-        client._conn.get_personal_workspace(),
-    )
 
     yield client
 

--- a/client/verta/tests/conftest.py
+++ b/client/verta/tests/conftest.py
@@ -374,12 +374,7 @@ def client_2(host, port, email_2, dev_key_2, created_entities):
 
     client = Client(host, port, email_2, dev_key_2, debug=True)
 
-    yield client
-
-    proj = client._ctx.proj
-    if (proj is not None
-            and proj.id not in {entity.id for entity in created_entities}):
-        proj.delete()
+    return client
 
 
 @pytest.fixture
@@ -390,12 +385,7 @@ def client_3(host, port, email_3, dev_key_3, created_entities):
 
     client = Client(host, port, email_3, dev_key_3, debug=True)
 
-    yield client
-
-    proj = client._ctx.proj
-    if (proj is not None
-            and proj.id not in {entity.id for entity in created_entities}):
-        proj.delete()
+    return client
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR basically reverts [these lines](https://github.com/VertaAI/modeldb/pull/2395/files#diff-8d105224a574535507b29e892eb2171f2096c788362f47da0c4d31cf3a72b3c0R307-R369) from #2398. 

## Changes
- Don't force personal workspace as default workspace. This was a change I was experimenting with, and didn't intend to actually go in the PR! I don't think the tests should deliberately alter accounts' default workspaces (i.e. if I run tests with my personal account, resetting my default workspace shouldn't be an intentional side effect), and its purpose is already fulfilled by #2417.
- Don't delete `client_2.proj` and `client_3.proj`. These are nearly always going to be projects owned by `client` that were fetched to test permissions, and the secondary clients encounter `403`s because either it's already deleted, or they don't have permission to delete.