### PR TITLE
Mark internal _histogram_utils as deprecated

### DIFF
--- a/client/verta/verta/_internal_utils/_histogram_utils.py
+++ b/client/verta/verta/_internal_utils/_histogram_utils.py
@@ -1,4 +1,12 @@
 # -*- coding: utf-8 -*-
+"""
+Utilities for generating histograms from pandas DataFrames.
+
+.. deprecated:: 0.18.0
+    With the deprecation of :meth:`~verta.tracking.entities._deployable_entity._DeployableEntity.log_training_data`,
+    this module is effectively defunct and remains solely for reference.
+
+"""
 
 from ..external import six
 


### PR DESCRIPTION
Since we're working on new histogram-related functionality, it may help to explicitly mark the old implementation as no longer in use.