### PR TITLE
[VR-9109] Support Windows

### DIFF
--- a/client/verta/tests/conftest.py
+++ b/client/verta/tests/conftest.py
@@ -514,9 +514,9 @@ def organization(client, created_entities):
 
 @pytest.fixture
 def requirements_file():
-    with tempfile.NamedTemporaryFile("w+") as tempf:
+    with tempfile.NamedTemporaryFile("w+", delete=False) as tempf:
         # create requirements file from pip freeze
-        pip_freeze = subprocess.check_output([sys.executable, "-m", "pip", "freeze"])
+        pip_freeze = subprocess.check_output([sys.executable, "-m", "pip", "list", "--format=freeze"])
         pip_freeze = six.ensure_str(pip_freeze)
         tempf.write(pip_freeze)
         tempf.flush()  # flush object buffer

--- a/client/verta/tests/conftest.py
+++ b/client/verta/tests/conftest.py
@@ -294,12 +294,12 @@ def dir_and_files(strs, tmp_path, request):
     dirpath = tmp_path / request.param
 
     filepaths = {
-        os.path.join(strs[0], strs[1], strs[2]),
-        os.path.join(strs[0], strs[1], strs[3]),
-        os.path.join(strs[0], strs[2]),
-        os.path.join(strs[0], strs[4]),
-        os.path.join(strs[2]),
-        os.path.join(strs[5]),
+        "/".join([strs[0], strs[1], strs[2]]),
+        "/".join([strs[0], strs[1], strs[3]]),
+        "/".join([strs[0], strs[2]]),
+        "/".join([strs[0], strs[4]]),
+        "/".join([strs[2]]),
+        "/".join([strs[5]]),
     }
 
     for filepath in filepaths:

--- a/client/verta/tests/test_artifacts.py
+++ b/client/verta/tests/test_artifacts.py
@@ -123,7 +123,7 @@ class TestArtifacts:
 
         # log using file handle
         for key, artifact_filepath in artifacts[:len(artifacts)//2]:
-            with open(artifact_filepath, 'r') as artifact_file:  # does not need to be 'rb'
+            with open(artifact_filepath, 'rb') as artifact_file:
                 experiment_run.log_artifact(key, artifact_file)
 
         # log using filepath

--- a/client/verta/tests/test_artifacts.py
+++ b/client/verta/tests/test_artifacts.py
@@ -63,7 +63,7 @@ class TestUtils:
         assert filepath != downloaded_filepath
         # contents match
         assert filecmp.cmp(filepath, downloaded_filepath)
-        os.unlink(temp_zip.name)
+        os.remove(temp_zip.name)
 
     def test_download_zipped_dir_no_collision(self, experiment_run, dir_and_files, in_tempdir):
         source_dirpath, _ = dir_and_files

--- a/client/verta/tests/test_deployment.py
+++ b/client/verta/tests/test_deployment.py
@@ -293,8 +293,8 @@ class TestFetchArtifacts:
             retrieved_filepaths = set()
             for root, _, files in os.walk(dirpath):
                 for filename in files:
-                    filepath = os.path.join(root, filename)
-                    filepath = os.path.relpath(filepath, dirpath)
+                    filepath = "/".join([root, filename])
+                    filepath = os.path.relpath(filepath, dirpath).replace('\\', '/') 
                     retrieved_filepaths.add(filepath)
 
             assert filepaths == retrieved_filepaths
@@ -321,16 +321,17 @@ class TestFetchArtifacts:
     def test_fetch_tgz(self, experiment_run, strs, dir_and_files):
         dirpath, filepaths = dir_and_files
         key = strs[0]
+        tempf  = tempfile.NamedTemporaryFile(suffix='.tgz', delete=False)
+        
+        # make archive
+        with tarfile.open(tempf.name, 'w:gz') as tarf:
+            tarf.add(dirpath, "")
+        tempf.flush()  # flush object buffer
+        os.fsync(tempf.fileno())  # flush OS buffer
+        tempf.seek(0)
+        tempf.close()
 
-        with tempfile.NamedTemporaryFile(suffix='.tgz') as tempf:
-            # make archive
-            with tarfile.open(tempf.name, 'w:gz') as tarf:
-                tarf.add(dirpath, "")
-            tempf.flush()  # flush object buffer
-            os.fsync(tempf.fileno())  # flush OS buffer
-            tempf.seek(0)
-
-            experiment_run.log_artifact(key, tempf.name)
+        experiment_run.log_artifact(key, tempf.name)
 
         try:
             dirpath = experiment_run.fetch_artifacts([key])[key]
@@ -340,27 +341,28 @@ class TestFetchArtifacts:
             retrieved_filepaths = set()
             for root, _, files in os.walk(dirpath):
                 for filename in files:
-                    filepath = os.path.join(root, filename)
-                    filepath = os.path.relpath(filepath, dirpath)
+                    filepath = "/".join([root, filename])
+                    filepath = os.path.relpath(filepath, dirpath).replace("\\", "/")
                     retrieved_filepaths.add(filepath)
 
             assert filepaths == retrieved_filepaths
+            os.remove(tempf.name)
         finally:
             shutil.rmtree(_CACHE_DIR, ignore_errors=True)
 
     def test_fetch_tar(self, experiment_run, strs, dir_and_files):
         dirpath, filepaths = dir_and_files
         key = strs[0]
+        tempf = tempfile.NamedTemporaryFile(suffix='.tar', delete=False)
+        # make archive
+        with tarfile.open(tempf.name, 'w') as tarf:
+            tarf.add(dirpath, "")
+        tempf.flush()  # flush object buffer
+        os.fsync(tempf.fileno())  # flush OS buffer
+        tempf.seek(0)
+        tempf.close()
 
-        with tempfile.NamedTemporaryFile(suffix='.tar') as tempf:
-            # make archive
-            with tarfile.open(tempf.name, 'w') as tarf:
-                tarf.add(dirpath, "")
-            tempf.flush()  # flush object buffer
-            os.fsync(tempf.fileno())  # flush OS buffer
-            tempf.seek(0)
-
-            experiment_run.log_artifact(key, tempf.name)
+        experiment_run.log_artifact(key, tempf.name)
 
         try:
             dirpath = experiment_run.fetch_artifacts([key])[key]
@@ -370,27 +372,28 @@ class TestFetchArtifacts:
             retrieved_filepaths = set()
             for root, _, files in os.walk(dirpath):
                 for filename in files:
-                    filepath = os.path.join(root, filename)
-                    filepath = os.path.relpath(filepath, dirpath)
+                    filepath = "/".join([root, filename])
+                    filepath = os.path.relpath(filepath, dirpath).replace("\\",  "/")
                     retrieved_filepaths.add(filepath)
 
             assert filepaths == retrieved_filepaths
+            os.remove(tempf.name)
         finally:
             shutil.rmtree(_CACHE_DIR, ignore_errors=True)
 
     def test_fetch_tar_gz(self, experiment_run, strs, dir_and_files):
         dirpath, filepaths = dir_and_files
         key = strs[0]
+        tempf = tempfile.NamedTemporaryFile(suffix='.tar.gz', delete=False)
+        # make archive
+        with tarfile.open(tempf.name, 'w:gz') as tarf:
+            tarf.add(dirpath, "")
+        tempf.flush()  # flush object buffer
+        os.fsync(tempf.fileno())  # flush OS buffer
+        tempf.seek(0)
+        tempf.close()
 
-        with tempfile.NamedTemporaryFile(suffix='.tar.gz') as tempf:
-            # make archive
-            with tarfile.open(tempf.name, 'w:gz') as tarf:
-                tarf.add(dirpath, "")
-            tempf.flush()  # flush object buffer
-            os.fsync(tempf.fileno())  # flush OS buffer
-            tempf.seek(0)
-
-            experiment_run.log_artifact(key, tempf.name)
+        experiment_run.log_artifact(key, tempf.name)
 
         try:
             dirpath = experiment_run.fetch_artifacts([key])[key]
@@ -400,11 +403,12 @@ class TestFetchArtifacts:
             retrieved_filepaths = set()
             for root, _, files in os.walk(dirpath):
                 for filename in files:
-                    filepath = os.path.join(root, filename)
-                    filepath = os.path.relpath(filepath, dirpath)
+                    filepath = "/".join([root, filename])
+                    filepath = os.path.relpath(filepath, dirpath).replace("\\", "/")
                     retrieved_filepaths.add(filepath)
 
             assert filepaths == retrieved_filepaths
+            os.remove(tempf.name)
         finally:
             shutil.rmtree(_CACHE_DIR, ignore_errors=True)
 

--- a/client/verta/tests/test_experimentrun/test_requirements.py
+++ b/client/verta/tests/test_experimentrun/test_requirements.py
@@ -43,60 +43,70 @@ class TestLogRequirements:
             experiment_run.log_requirements([self.NONSPECIFIC_REQ])
 
     def test_nonspecific_ver_file_warning(self, experiment_run):
-        with tempfile.NamedTemporaryFile('w+') as tempf:
-            tempf.write(self.NONSPECIFIC_REQ)
-            tempf.seek(0)
+        tempf = tempfile.NamedTemporaryFile('w+', delete=False)
+        tempf.write(self.NONSPECIFIC_REQ)
+        tempf.seek(0)
+        tempf.close()
 
-            with pytest.warns(UserWarning):
-                experiment_run.log_requirements(tempf.name)
+        with pytest.warns(UserWarning):
+            experiment_run.log_requirements(tempf.name)
+        os.remove(tempf.name)
 
     def test_invalid_pkg_name_list_error(self, experiment_run):
         with pytest.raises(ValueError):
             experiment_run.log_requirements([self.INVALID_REQ])
 
     def test_invalid_pkg_name_file_error(self, experiment_run):
-        with tempfile.NamedTemporaryFile('w+') as tempf:
-            tempf.write(self.INVALID_REQ)
-            tempf.seek(0)
+        tempf = tempfile.NamedTemporaryFile('w+', delete=False)
+        tempf.write(self.INVALID_REQ)
+        tempf.seek(0)
+        tempf.close()
 
-            with pytest.raises(ValueError):
-                experiment_run.log_requirements(tempf.name)
+        with pytest.raises(ValueError):
+            experiment_run.log_requirements(tempf.name)
+        os.remove(tempf.name)
 
     def test_unimportable_pkg_list_error(self, experiment_run):
         with pytest.raises(ValueError):
             experiment_run.log_requirements([self.UNIMPORTABLE_REQ])
 
     def test_unimportable_pkg_file_error(self, experiment_run):
-        with tempfile.NamedTemporaryFile('w+') as tempf:
-            tempf.write(self.UNIMPORTABLE_REQ)
-            tempf.seek(0)
+        tempf = tempfile.NamedTemporaryFile('w+', delete=False)
+        tempf.write(self.UNIMPORTABLE_REQ)
+        tempf.seek(0)
+        tempf.close()
 
-            with pytest.raises(ValueError):
-                experiment_run.log_requirements(tempf.name)
+        with pytest.raises(ValueError):
+            experiment_run.log_requirements(tempf.name)
+        os.remove(tempf.name)
 
     def test_verta_ver_mismatch_list_error(self, experiment_run):
         with pytest.raises(ValueError):
             experiment_run.log_requirements([self.VERTA_MISMATCH_REQ])
 
     def test_verta_ver_mismatch_file_error(self, experiment_run):
-        with tempfile.NamedTemporaryFile('w+') as tempf:
-            tempf.write(self.VERTA_MISMATCH_REQ)
-            tempf.seek(0)
+        tempf = tempfile.NamedTemporaryFile('w+', delete=False)
+        tempf.write(self.VERTA_MISMATCH_REQ)
+        tempf.seek(0)
+        tempf.close()
 
-            with pytest.raises(ValueError):
-                experiment_run.log_requirements(tempf.name)
+        with pytest.raises(ValueError):
+            experiment_run.log_requirements(tempf.name)
+        os.remove(tempf.name)
 
     def test_cloudpickle_ver_mismatch_list_error(self, experiment_run):
         with pytest.raises(ValueError):
             experiment_run.log_requirements([self.CLOUDPICKLE_MISMATCH_REQ])
 
     def test_cloudpickle_ver_mismatch_file_error(self, experiment_run):
-        with tempfile.NamedTemporaryFile('w+') as tempf:
-            tempf.write(self.CLOUDPICKLE_MISMATCH_REQ)
-            tempf.seek(0)
+        tempf = tempfile.NamedTemporaryFile('w+', delete=False)
+        tempf.write(self.CLOUDPICKLE_MISMATCH_REQ)
+        tempf.seek(0)
+        tempf.close()
 
-            with pytest.raises(ValueError):
-                experiment_run.log_requirements(tempf.name)
+        with pytest.raises(ValueError):
+            experiment_run.log_requirements(tempf.name)
+        os.remove(tempf.name)
 
     def test_injection_list(self, experiment_run):
         experiment_run.log_requirements([])
@@ -107,13 +117,15 @@ class TestLogRequirements:
         assert {'cloudpickle', 'verta'} == reqs
 
     def test_injection_file(self, experiment_run):
-        with tempfile.NamedTemporaryFile('w+') as tempf:
-            experiment_run.log_requirements(tempf.name)
+        tempf = tempfile.NamedTemporaryFile('w+', delete=False)
+        tempf.close()
+        experiment_run.log_requirements(tempf.name)
 
         reqs_txt = experiment_run.get_artifact(
             "requirements.txt").read().decode()
         reqs = set(req.split('==')[0].strip() for req in reqs_txt.splitlines())
         assert {'cloudpickle', 'verta'} == reqs
+        os.remove(tempf.name)
 
     def test_list(self, experiment_run):
         experiment_run.log_requirements(self.VALID_REQS)
@@ -124,16 +136,17 @@ class TestLogRequirements:
         assert set(self.VALID_REQS) == reqs
 
     def test_file(self, experiment_run):
-        with tempfile.NamedTemporaryFile('w+') as tempf:
-            tempf.write('\n'.join(self.VALID_REQS))
-            tempf.seek(0)
+        tempf = tempfile.NamedTemporaryFile('w+', delete=False)
+        tempf.write('\n'.join(self.VALID_REQS))
+        tempf.seek(0)
+        tempf.close()
 
-            experiment_run.log_requirements(tempf.name)
-
+        experiment_run.log_requirements(tempf.name)
         reqs_txt = experiment_run.get_artifact(
             "requirements.txt").read().decode()
         reqs = set(req.split('==')[0].strip() for req in reqs_txt.splitlines())
         assert set(self.VALID_REQS) == reqs
+        os.remove(tempf.name)
 
     def test_implicit_log_environment(self, experiment_run):
         assert not experiment_run.has_environment

--- a/client/verta/tests/test_utils/test_pip_requirements.py
+++ b/client/verta/tests/test_utils/test_pip_requirements.py
@@ -21,7 +21,7 @@ class TestPipRequirementsUtils:
             filter(
                 _pip_requirements_utils.SPACY_MODEL_REGEX.match,
                 six.ensure_str(
-                    subprocess.check_output([sys.executable, "-m", "pip", "freeze"]),
+                    subprocess.check_output([sys.executable, "-m", "pip", "list", "--format=freeze"]),
                 ).splitlines(),
             )
         )

--- a/client/verta/tests/test_versioning/test_dataset.py
+++ b/client/verta/tests/test_versioning/test_dataset.py
@@ -332,7 +332,7 @@ class TestPath:
     def test_base_path(self, paths, base_path):
         filepaths = _file_utils.flatten_file_trees(paths)
         expected_paths = set(
-            os.path.relpath(path, base_path)
+            os.path.relpath(path, base_path).replace("\\", "/")
             for path in filepaths
         )
 
@@ -836,7 +836,7 @@ class TestPathManagedVersioning:
         os.mkdir(reference_dir)
         # three .file files in tiny-files/
         for filename in ["tiny{}.file".format(i) for i in range(3)]:
-            with open(os.path.join(reference_dir, filename), 'wb') as f:
+            with open("/".join([reference_dir, filename]), 'wb') as f:
                 f.write(os.urandom(2**16))
 
         sub_dir = "bin/"

--- a/client/verta/verta/_internal_utils/_artifact_utils.py
+++ b/client/verta/verta/_internal_utils/_artifact_utils.py
@@ -520,7 +520,7 @@ def zip_dir(dirpath, followlinks=True):
 
     os.path.expanduser(dirpath)
 
-    tempf = tempfile.NamedTemporaryFile(suffix='.'+ZIP_EXTENSION)
+    tempf = tempfile.NamedTemporaryFile(suffix='.'+ZIP_EXTENSION, delete=False)
     with zipfile.ZipFile(tempf, 'w') as zipf:
         for root, _, files in os.walk(dirpath, followlinks=followlinks):
             for filename in files:

--- a/client/verta/verta/_internal_utils/_artifact_utils.py
+++ b/client/verta/verta/_internal_utils/_artifact_utils.py
@@ -327,7 +327,7 @@ def serialize_model(model):
             break
         elif module_name.startswith("tensorflow.python.keras"):
             model_type = "tensorflow"
-            tempf = tempfile.NamedTemporaryFile()
+            tempf = tempfile.NamedTemporaryFile(delete=False)
             try:
                 if get_tensorflow_major_version() == 2:  # save_format param may not exist in TF 1.X
                     model.save(tempf.name, save_format='h5')  # TF 2.X uses SavedModel by default
@@ -387,7 +387,7 @@ def deserialize_model(bytestring, error_ok=False):
     keras = maybe_dependency("tensorflow.keras")
     if keras is not None:
         # try deserializing with Keras (HDF5)
-        with tempfile.NamedTemporaryFile() as tempf:
+        with tempfile.NamedTemporaryFile(delete=False) as tempf:
             tempf.write(bytestring)
             tempf.seek(0)
             try:

--- a/client/verta/verta/_internal_utils/_pip_requirements_utils.py
+++ b/client/verta/verta/_internal_utils/_pip_requirements_utils.py
@@ -44,7 +44,7 @@ SPACY_MODEL_REGEX = re.compile(SPACY_MODEL_PATTERN)
 
 
 def get_pip_freeze():
-    pip_freeze = subprocess.check_output([sys.executable, '-m', 'pip', 'freeze'])
+    pip_freeze = subprocess.check_output([sys.executable, '-m', 'pip', 'list', '--format=freeze'])
     pip_freeze = six.ensure_str(pip_freeze)
 
     req_specs = pip_freeze.splitlines()
@@ -217,7 +217,7 @@ def set_version_pins(requirements):
     pip_pkg_vers = dict(
         req_spec.split('==')
         for req_spec
-        in six.ensure_str(subprocess.check_output([sys.executable, '-m', 'pip', 'freeze'])).splitlines()
+        in six.ensure_str(subprocess.check_output([sys.executable, '-m', 'pip', 'list', '--format=freeze'])).splitlines()
         if '==' in req_spec
     )
 

--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -724,7 +724,7 @@ class RegisteredModelVersion(_DeployableEntity):
             basename = key + os.extsep + extension
 
         # build upload path from checksum and basename
-        artifact_path = os.path.join(artifact_hash, basename)
+        artifact_path = "/".join([artifact_hash, basename])
 
         # TODO: support VERTA_ARTIFACT_DIR
 

--- a/client/verta/verta/tracking/entities/_experimentrun.py
+++ b/client/verta/verta/tracking/entities/_experimentrun.py
@@ -221,7 +221,7 @@ class ExperimentRun(_DeployableEntity):
             basename = key + os.extsep + extension
 
         # build upload path from checksum and basename
-        artifact_path = os.path.join(artifact_hash, basename)
+        artifact_path = "/".join([artifact_hash, basename])
 
         # TODO: incorporate into config
         VERTA_ARTIFACT_DIR = os.environ.get('VERTA_ARTIFACT_DIR', "")


### PR DESCRIPTION
Various fixes for log_artifacts for windows

## Changes
- close `NamedTemporaryFile`s before passing them downstream (with `delete=False`) to make Windows happy
- use `pip list --format=freeze` instead of `pip freeze` for Windows environment compatibility