### PR TITLE
Add tests and bugfixes for profilers

### DIFF
--- a/client/verta/tests/monitoring/strategies.py
+++ b/client/verta/tests/monitoring/strategies.py
@@ -59,8 +59,8 @@ def series(draw, num_rows, data_type, name=None, has_missing=True):
         value_strategies.extend([
             st.floats(
                 # NumPy has limits on what values it can handle for histograms
-                min_value=-2**8,
-                max_value=2**8,
+                min_value=-2**32,
+                max_value=2**32,
                 allow_nan=False,
                 allow_infinity=False,
             ),

--- a/client/verta/tests/monitoring/strategies.py
+++ b/client/verta/tests/monitoring/strategies.py
@@ -1,12 +1,8 @@
 # -*- coding: utf-8 -*-
 
-import sys
-from datetime import timedelta
-
+import hypothesis
 import hypothesis.strategies as st
 import pytest
-from hypothesis import given
-from verta._internal_utils.time_utils import duration_millis
 from verta._protos.public.monitoring.Summary_pb2 import AggregationQuerySummary
 from verta.monitoring.summaries.aggregation import Aggregation
 from ..time_strategies import millis_timedelta_strategy, millis_uint64_strategy
@@ -34,3 +30,83 @@ ops_strategy = st.one_of(
     aggregation_ops_strategy,
     st.sampled_from(AggregationQuerySummary.AggregationOperation.keys()),
 )
+
+
+@st.composite
+def series(draw, num_rows, data_type, name=None, has_missing=True):
+    """Generate Series.
+
+    Parameters
+    ----------
+    num_rows : int
+    data_type : str
+        ``"continuous"`` or ``"discrete"``.
+    name : str, optional
+    has_missing : bool, default True
+        Whether to sprinkle missing values into the series.
+
+    Returns
+    -------
+    pd.Series
+
+    """
+    pd = pytest.importorskip("pandas")
+
+    value_strategies = []
+    if has_missing:
+        value_strategies.append(st.just(None))
+    if data_type == "continuous":
+        value_strategies.extend([
+            st.floats(
+                # NumPy has limits on what values it can handle for histograms
+                min_value=-2**8,
+                max_value=2**8,
+                allow_nan=False,
+                allow_infinity=False,
+            ),
+        ])
+    elif data_type == "discrete":
+        value_strategies.extend([
+            st.integers(),
+            st.text(),
+        ])
+    else:
+        raise ValueError("invalid data type {}".format(data_type))
+
+    values = draw(
+        st.lists(
+            st.one_of(value_strategies),
+            min_size=num_rows,
+            max_size=num_rows,
+        )
+    )
+    return pd.Series(values, name=name)
+
+
+@st.composite
+def dataframes(draw):
+    """Generate DataFrames with a "continuous" and "discrete" column.
+
+    Returns
+    -------
+    pd.DataFrame
+
+    """
+    pd = pytest.importorskip("pandas")
+
+    # Hypothesis suggests a limit on example sizes
+    num_rows = draw(st.integers(min_value=1, max_value=2**8))
+
+    continuous_col = "continuous"
+    discrete_col = "discrete"
+
+    continuous_series = draw(series(num_rows, continuous_col, continuous_col))
+    discrete_series = draw(series(num_rows, discrete_col, discrete_col))
+
+    # our profiler heuristics assume <= 20 unique values is discrete
+    hypothesis.assume(len(set(continuous_series)) > 20)
+
+    return pd.DataFrame({
+        continuous_col: continuous_series,
+        discrete_col: discrete_series,
+    })

--- a/client/verta/tests/monitoring/strategies.py
+++ b/client/verta/tests/monitoring/strategies.py
@@ -56,20 +56,24 @@ def series(draw, num_rows, data_type, name=None, has_missing=True):
     if has_missing:
         value_strategies.append(st.just(None))
     if data_type == "continuous":
-        value_strategies.extend([
-            st.floats(
-                # NumPy has limits on what values it can handle for histograms
-                min_value=-2**32,
-                max_value=2**32,
-                allow_nan=False,
-                allow_infinity=False,
-            ),
-        ])
+        value_strategies.extend(
+            [
+                st.floats(
+                    # NumPy has limits on what values it can handle for histograms
+                    min_value=-(2 ** 32),
+                    max_value=2 ** 32,
+                    allow_nan=False,
+                    allow_infinity=False,
+                ),
+            ]
+        )
     elif data_type == "discrete":
-        value_strategies.extend([
-            st.integers(),
-            st.text(),
-        ])
+        value_strategies.extend(
+            [
+                st.integers(),
+                st.text(),
+            ]
+        )
     else:
         raise ValueError("invalid data type {}".format(data_type))
 
@@ -95,7 +99,7 @@ def dataframes(draw):
     pd = pytest.importorskip("pandas")
 
     # Hypothesis suggests a limit on example sizes
-    num_rows = draw(st.integers(min_value=1, max_value=2**8))
+    num_rows = draw(st.integers(min_value=1, max_value=2 ** 8))
 
     continuous_col = "continuous"
     discrete_col = "discrete"
@@ -106,7 +110,9 @@ def dataframes(draw):
     # our profiler heuristics assume <= 20 unique values is discrete
     hypothesis.assume(len(set(continuous_series)) > 20)
 
-    return pd.DataFrame({
-        continuous_col: continuous_series,
-        discrete_col: discrete_series,
-    })
+    return pd.DataFrame(
+        {
+            continuous_col: continuous_series,
+            discrete_col: discrete_series,
+        }
+    )

--- a/client/verta/tests/pytest.ini
+++ b/client/verta/tests/pytest.ini
@@ -5,3 +5,5 @@ markers =
 filterwarnings =
     # ignore DeprecationWarning from protobuf generated code
     ignore:.*Create unlinked descriptors is going to go away.*:DeprecationWarning
+    # ignore certain versions of NumPy complaining about internal C machinery
+    ignore:.*numpy\.ufunc size changed, may indicate binary incompatibility.*:RuntimeWarning

--- a/client/verta/verta/monitoring/profiler.py
+++ b/client/verta/verta/monitoring/profiler.py
@@ -204,9 +204,9 @@ class ContinuousHistogramProfiler(Profiler):
             bins = self._bins[column]
         else:
             bins = self._bins
-        values, limits = self._np.histogram(df[column], bins=bins)
-        values = [v.item() for v in values]
-        limits = [lim.item() for lim in limits]
+        values, limits = self._np.histogram(df[column].dropna(), bins=bins)
+        values = values.tolist()
+        limits = limits.tolist()
         return (column + "_histogram", FloatHistogram(limits, values))
 
     # TODO: consider the case where the data is outside of the bucket list

--- a/client/verta/verta/monitoring/profiler.py
+++ b/client/verta/verta/monitoring/profiler.py
@@ -165,7 +165,7 @@ class BinaryHistogramProfiler(Profiler):
         dict
             A dictionary from summary data names to DiscreteHistogram instances.
         """
-        content = df[column].value_counts()
+        content = df[column].value_counts(dropna=True)
         keys = list(content.keys())
         values = [content[k] for k in keys]
         values = [v.item() for v in values]


### PR DESCRIPTION
## Changes
- add Hypothesis strategies for generating `pd.Series` and `pd.DataFrame`s
- add property-based tests for `ContinuousHistogramProfiler`, `BinaryHistogramProfiler,` and MissingValuesProfiler`
- fix bugs in how `ContinuousHistogramProfiler` handles and returns data
  - use `dropna()` to prevent missing values from breaking `np.histogram()`
  - use `tolist()` to more safely convert NumPy array to a `list` of Python builtins

## Tests
```bash
$ pytest monitoring/test_profilers.py::TestProfilers
==================================================== test session starts ====================================================
platform darwin -- Python 3.7.10, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /Users/miliu/Documents/modeldb/client/verta/tests, configfile: pytest.ini
plugins: hypothesis-6.14.0
collected 3 items                                                                                                           

monitoring/test_profilers.py ...                                                                                      [100%]

============================================== 3 passed, 5 warnings in 51.87s ===============================================
```