### PR TITLE
Enable adding+getting data types as RMV attrs

### DIFF
--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -926,6 +926,10 @@ class RegisteredModelVersion(_DeployableEntity):
         # validate all keys first
         for key in six.viewkeys(attrs):
             _utils.validate_flat_key(key)
+        # convert data_types to dicts
+        for key, value in attrs.items():
+            if isinstance(value, data_types._VertaDataType):
+                attrs[key] = value._as_dict()
 
         # build KeyValues
         attribute_keyvals = []
@@ -981,7 +985,13 @@ class RegisteredModelVersion(_DeployableEntity):
 
         """
         self._refresh_cache()
-        return _utils.unravel_key_values(self._msg.attributes)
+        attributes = _utils.unravel_key_values(self._msg.attributes)
+        for key, attribute in attributes.items():
+            try:
+                attributes[key] = data_types._VertaDataType._from_dict(attribute)
+            except (KeyError, TypeError, ValueError):
+                pass
+        return attributes
 
     def _get_attribute_keys(self):
         return list(map(lambda attribute: attribute.key, self.get_attributes()))


### PR DESCRIPTION
## Changes
- allow `RegisteredModelVersion`'s `add_attributes()` and `get_attributes()` to de/serialize `verta.data_type`s like `ExperimentRun`s can

## Tests
```bash
$ pytest test_model_registry/test_model_version.py::TestComplexAttributes test_model_registry/test_model_version.py::TestAutoMonitoring::test_profile_training_data
==================================================== test session starts ====================================================
platform darwin -- Python 3.7.10, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /Users/miliu/Documents/modeldb/client/verta/tests, configfile: pytest.ini
plugins: hypothesis-6.14.0
collected 4 items                                                                                                           

test_model_registry/test_model_version.py ....                                                                        [100%]

============================================== 4 passed, 9 warnings in 53.56s ===============================================
```