### PR TITLE
Hide internal attributes on histogram data types

### DIFF
--- a/client/verta/verta/data_types/_discrete_histogram.py
+++ b/client/verta/verta/data_types/_discrete_histogram.py
@@ -100,11 +100,11 @@ class DiscreteHistogram(_VertaDataType):
             )
         keys = list(set(self._buckets + other._buckets))
         return self._scipy_spatial.distance.cosine(
-            self._normalized_data(keys),
-            other._normalized_data(keys),
+            self.normalized_data(keys),
+            other.normalized_data(keys),
         )
 
-    def _normalized_data(self, keys=None):
+    def normalized_data(self, keys=None):
         total = sum(self._data)
         keys = keys if keys else self._buckets
         return [self._data_dict[k] / total for k in keys]

--- a/client/verta/verta/data_types/_discrete_histogram.py
+++ b/client/verta/verta/data_types/_discrete_histogram.py
@@ -92,11 +92,11 @@ class DiscreteHistogram(_VertaDataType):
             )
         keys = list(set(self._buckets + other._buckets))
         return self._scipy_spatial.distance.cosine(
-            self.normalized_data(keys),
-            other.normalized_data(keys),
+            self._normalized_data(keys),
+            other._normalized_data(keys),
         )
 
-    def normalized_data(self, keys=None):
+    def _normalized_data(self, keys=None):
         total = sum(self._data)
         keys = keys if keys else self._buckets
         return [self._data_dict[k] / total for k in keys]

--- a/client/verta/verta/data_types/_discrete_histogram.py
+++ b/client/verta/verta/data_types/_discrete_histogram.py
@@ -46,7 +46,7 @@ class DiscreteHistogram(_VertaDataType):
             raise ImportError("scipy is not installed; try `pip install scipy`")
 
         if len(buckets) != len(set(buckets)):
-            raise ValueError("`bucekts` elements must all be unique")
+            raise ValueError("`buckets` elements must all be unique")
         if len(buckets) != len(data):
             raise ValueError("`buckets` and `data` must have the same length")
         if not all(isinstance(count, six.integer_types) for count in data):

--- a/client/verta/verta/data_types/_discrete_histogram.py
+++ b/client/verta/verta/data_types/_discrete_histogram.py
@@ -56,6 +56,14 @@ class DiscreteHistogram(_VertaDataType):
         self._data = data
         self._data_dict = defaultdict(int, zip(buckets, data))
 
+    def __repr__(self):
+        attrs = {
+            "buckets": self._buckets,
+            "data": self._data,
+        }
+        lines = ["{}: {}".format(key, value) for key, value in sorted(attrs.items())]
+        return "\n\t".join([type(self).__name__] + lines)
+
     def _as_dict(self):
         return self._as_dict_inner(
             {

--- a/client/verta/verta/data_types/_float_histogram.py
+++ b/client/verta/verta/data_types/_float_histogram.py
@@ -107,10 +107,10 @@ class FloatHistogram(_VertaDataType):
             )
 
         return self._scipy_spatial.distance.cosine(
-            self._normalized_data(),
-            other._normalized_data(),
+            self.normalized_data(),
+            other.normalized_data(),
         )
 
-    def _normalized_data(self):
+    def normalized_data(self):
         total = sum(self._data)
         return [x / total for x in self._data]

--- a/client/verta/verta/data_types/_float_histogram.py
+++ b/client/verta/verta/data_types/_float_histogram.py
@@ -99,10 +99,10 @@ class FloatHistogram(_VertaDataType):
             )
 
         return self._scipy_spatial.distance.cosine(
-            self.normalized_data(),
-            other.normalized_data(),
+            self._normalized_data(),
+            other._normalized_data(),
         )
 
-    def normalized_data(self):
+    def _normalized_data(self):
         total = sum(self._data)
         return [x / total for x in self._data]

--- a/client/verta/verta/data_types/_float_histogram.py
+++ b/client/verta/verta/data_types/_float_histogram.py
@@ -59,6 +59,14 @@ class FloatHistogram(_VertaDataType):
         self._bucket_limits = bucket_limits
         self._data = data
 
+    def __repr__(self):
+        attrs = {
+            "bucket_limits": self._bucket_limits,
+            "data": self._data,
+        }
+        lines = ["{}: {}".format(key, value) for key, value in sorted(attrs.items())]
+        return "\n\t".join([type(self).__name__] + lines)
+
     def _as_dict(self):
         return self._as_dict_inner(
             {


### PR DESCRIPTION
## Changes
- hide `_scipy_spatial` and `_data_dict` from histogram representations by overriding the base class's `__repr__()`