### PR TITLE
[VR-7717] Propagate usable information when a model being deployed fails at runtime

### DIFF
--- a/client/verta/tests/test_endpoint/test_endpoint.py
+++ b/client/verta/tests/test_endpoint/test_endpoint.py
@@ -217,7 +217,8 @@ class TestEndpoint:
         e_msg = str(excinfo.value).strip()
         assert e_msg.startswith("endpoint update failed;")
         assert "Serving Flask app" in e_msg
-        assert "No module named 'sklearn'" in e_msg
+        assert "No module named" in e_msg
+        assert "sklearn" in e_msg
 
     def test_canary_update(self, client, created_entities, experiment_run, model_for_deployment):
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])

--- a/client/verta/tests/test_endpoint/test_endpoint.py
+++ b/client/verta/tests/test_endpoint/test_endpoint.py
@@ -204,6 +204,21 @@ class TestEndpoint:
         excinfo_value = str(excinfo.value).strip()
         assert "Could not find a version that satisfies the requirement blahblahblah==3.6.0" in excinfo_value
 
+    def test_update_runtime_error(self, client, model_version, endpoint):
+        """Propagate errors from model being initialized at container runtime."""
+        LogisticRegression = pytest.importorskip("sklearn.linear_model").LogisticRegression
+
+        model_version.log_model(LogisticRegression(), custom_modules=[])
+        model_version.log_environment(Python([]))  # missing scikit-learn
+
+        with pytest.raises(RuntimeError) as excinfo:
+            endpoint.update(model_version, wait=True)
+
+        e_msg = str(excinfo.value).strip()
+        assert e_msg.startswith("endpoint update failed;")
+        assert "Serving Flask app" in e_msg
+        assert "No module named 'sklearn'" in e_msg
+
     def test_canary_update(self, client, created_entities, experiment_run, model_for_deployment):
         experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
         experiment_run.log_environment(Python(['scikit-learn']))

--- a/client/verta/verta/endpoint/_endpoint.py
+++ b/client/verta/verta/endpoint/_endpoint.py
@@ -403,6 +403,35 @@ class Endpoint(object):
 
         return response_json
 
+    def get_logs(self):
+        """Get runtime logs of this endpoint.
+
+        Returns
+        -------
+        list of str
+            Lines of this endpoint's runtime logs.
+
+        """
+        url = "{}://{}/api/v1/deployment/workspace/{}/endpoints/{}/stages/{}/logs".format(
+            self._conn.scheme,
+            self._conn.socket,
+            self.workspace,
+            self.id,
+            self._get_or_create_stage()
+        )
+        response = _utils.make_request("GET", url, self._conn)
+        self._conn.must_response(response)
+
+        logs = response.json().get("entries", [])
+        # remove duplicate lines
+        logs = {
+            log["id"]: log["message"]
+            for log in logs
+        }
+        # sort by line number
+        logs = sorted(logs.items(), key=lambda item: item[0])
+        return [item[1] for item in logs]
+
     def get_access_token(self):
         """Gets an arbitrary access token of the endpoint.
 

--- a/client/verta/verta/endpoint/_endpoint.py
+++ b/client/verta/verta/endpoint/_endpoint.py
@@ -245,7 +245,9 @@ class Endpoint(object):
 
             print()
             if status_dict["status"] == "error":
-                failure_msg = status_dict['components'][0].get('message', "no error message available")
+                # TODO: switch back to component "message" when VR-7740 is done
+                # failure_msg = status_dict['components'][0].get('message', "no error message available")
+                failure_msg = "\n".join(self.get_logs())
                 raise RuntimeError("endpoint update failed;\n{}".format(failure_msg))
 
         return self.get_status()


### PR DESCRIPTION
The deployment API's `/endpoints/{}/stages/{}` pathway doesn't consistently populate its response with an error message when model deployment fails at runtime (VR-7740), so we often just get
```python
RuntimeError: endpoint update failed;
Error in model container: 
```

Until that's remedied, we'll instead directly fetch the container logs for the exception message.

## Changes
- add `endpoint.get_logs()`
- use ☝️ runtime logs when raising an exception for a failed deployment