### PR TITLE
Manually set series index in _get_metadata_for_df()

### DIFF
--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -1120,7 +1120,13 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
 
         """
         get_col_metadata = lambda col: {"num_unique": col.value_counts().size, "type": str(col.dtypes)}
-        return df.apply(get_col_metadata).to_dict()
+        s = df.apply(get_col_metadata)
+        # pandas v1.1.* has a bug where the resulting index is just ints
+        # rather than the original column names, so we set manually
+        # https://github.com/pandas-dev/pandas/issues/37544
+        s.index = df.columns
+
+        return s.to_dict()
 
     @staticmethod
     def _add_time_attributes_to_feature_data(feature_data):


### PR DESCRIPTION
pandas v1.1.* has [a bug in `DataFrame.apply()`](https://github.com/pandas-dev/pandas/issues/37544z) where the returned `Series` has its index set to ints (`0`, `1`, ...) instead of the `DataFrame`'s original column names. This change manually sets the new index to the original column names, which is what [pandas's bugfix does](https://github.com/pandas-dev/pandas/pull/37606/files#diff-2257b34410aee27eb14e348b9545fef2e212ff93bd72af02d700ae8df43d97bbR367) as well.