### PR TITLE
Require future in torch deployment test

### DIFF
--- a/client/verta/tests/test_model_registry/test_standard_model.py
+++ b/client/verta/tests/test_model_registry/test_standard_model.py
@@ -5,6 +5,7 @@
 import pytest
 
 from verta.environment import Python
+from verta.external import six
 from verta._internal_utils import model_validator
 
 from ..models import standard_models
@@ -212,9 +213,15 @@ class TestStandardModels:
     def test_torch(self, registered_model, endpoint, model):
         np = pytest.importorskip("numpy")
 
+        # TODO: find a more automatic way to do this for the user (VR-11973)
+        reqs = ["torch"]
+        if six.PY2:
+            # Python 2 torch requires this to deserialize models
+            reqs.append("future")
+
         model_ver = registered_model.create_standard_model_from_torch(
             model,
-            Python(["torch"]),
+            Python(reqs),
         )
 
         endpoint.update(model_ver, wait=True)


### PR DESCRIPTION
This is somewhat of a stopgap to enable testing torch deployment, while a better user-friendly experience is to be determined in VR-11973.