### PR TITLE
Verify that a user's custom model has completely implemented VertaModelBase

### DIFF
--- a/client/verta/tests/models/standard_models.py
+++ b/client/verta/tests/models/standard_models.py
@@ -18,10 +18,36 @@ class VertaModel(VertaModelBase):
         return self.artifact
 
 
+class VertaModelNoImpl(VertaModelBase):
+    pass
+
+
+class VertaModelOnlyInit(VertaModelBase):
+    def __init__(self, artifacts):
+        pass
+
+
+class VertaModelOnlyPredict(VertaModelBase):
+    def predict(self, input):
+        pass
+
+
 def verta_models():
     models = []
 
     models.append(VertaModel)
+
+    return models
+
+
+def incomplete_verta_models():
+    models = []
+
+    models.extend([
+        VertaModelNoImpl,
+        VertaModelOnlyInit,
+        VertaModelOnlyPredict,
+    ])
 
     return models
 

--- a/client/verta/tests/test_model_registry/test_standard_model.py
+++ b/client/verta/tests/test_model_registry/test_standard_model.py
@@ -39,7 +39,7 @@ class TestModelValidator:
     )
     def test_incomplete_verta(self, model):
         msg_match = r"^model must finish implementing the following methods of VertaModelBase: "
-        msg_match += re.escape(str(list(model.__abstractmethods__)))
+        msg_match += re.escape(str(list(sorted(model.__abstractmethods__))))
         with pytest.raises(TypeError, match=msg_match):
             model_validator.must_verta(model)
 

--- a/client/verta/tests/test_model_registry/test_standard_model.py
+++ b/client/verta/tests/test_model_registry/test_standard_model.py
@@ -2,6 +2,8 @@
 
 """ModelVersion.create_version_from_*() methods"""
 
+import re
+
 import pytest
 
 from verta.environment import Python
@@ -11,6 +13,7 @@ from ..models import standard_models
 
 
 verta_models = standard_models.verta_models()
+incomplete_verta_models = standard_models.incomplete_verta_models()
 keras_models = standard_models.keras_models()
 unsupported_keras_models = standard_models.unsupported_keras_models()
 sklearn_models = standard_models.sklearn_models()
@@ -29,6 +32,16 @@ class TestModelValidator:
     )
     def test_verta(self, model):
         assert model_validator.must_verta(model)
+
+    @pytest.mark.parametrize(
+        "model",
+        incomplete_verta_models,
+    )
+    def test_incomplete_verta(self, model):
+        msg_match = r"^model must finish implementing the following methods of VertaModelBase: "
+        msg_match += re.escape(str(list(model.__abstractmethods__)))
+        with pytest.raises(TypeError, match=msg_match):
+            model_validator.must_verta(model)
 
     @pytest.mark.parametrize(
         "model",
@@ -129,6 +142,17 @@ class TestStandardModels:
         endpoint.update(model_ver, wait=True)
         deployed_model = endpoint.get_deployed_model()
         assert deployed_model.predict(artifact_value) == artifact_value
+
+    @pytest.mark.parametrize(
+        "model",
+        incomplete_verta_models,
+    )
+    def test_incomplete_verta(self, registered_model, model):
+        with pytest.raises(TypeError):
+            registered_model.create_standard_model(
+                model,
+                Python([]),
+            )
 
     @pytest.mark.parametrize(
         "model",

--- a/client/verta/verta/_internal_utils/model_validator.py
+++ b/client/verta/verta/_internal_utils/model_validator.py
@@ -67,9 +67,14 @@ def must_xgboost_sklearn(model):
 def must_verta(model):
     if not (isinstance(model, type) and issubclass(model, VertaModelBase)):
         raise TypeError(
-            "model must be a subclass of"
-            " verta.registry.VertaModelBase, not"
-            " {}".format(model)
+            "model must be a subclass of verta.registry.VertaModelBase,"
+            " not {}".format(model)
+        )
+    remaining_abstract_methods = list(getattr(model, "__abstractmethods__", []))
+    if remaining_abstract_methods:
+        raise TypeError(
+            "model must finish implementing the following methods of"
+            " VertaModelBase: {}".format(remaining_abstract_methods)
         )
 
     return True

--- a/client/verta/verta/_internal_utils/model_validator.py
+++ b/client/verta/verta/_internal_utils/model_validator.py
@@ -70,7 +70,7 @@ def must_verta(model):
             "model must be a subclass of verta.registry.VertaModelBase,"
             " not {}".format(model)
         )
-    remaining_abstract_methods = list(getattr(model, "__abstractmethods__", []))
+    remaining_abstract_methods = list(sorted(getattr(model, "__abstractmethods__", [])))
     if remaining_abstract_methods:
         raise TypeError(
             "model must finish implementing the following methods of"


### PR DESCRIPTION
The code we have today to validate a user's subclass of `VertaModelBase` doesn't actually check whether every abstract method is overridden.

I've learned that abstract classes have an ``__abstractmethods__`` attribute that is a source of truth for whether the class is instantiable:

> If the resulting ``__abstractmethods__`` set is non-empty, the class is considered abstract, and attempts to instantiate it will raise TypeError.

—[PEP 3119](https://www.python.org/dev/peps/pep-3119/)

This PR adds a check for that attribute.

## Tests
```bash
$ pytest test_model_registry/test_model_base.py \
> test_model_registry/test_standard_model.py::TestModelValidator::test_incomplete_verta \
> test_model_registry/test_standard_model.py::TestStandardModels::test_incomplete_verta
==================================================== test session starts ====================================================
platform darwin -- Python 3.7.10, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /Users/miliu/Documents/modeldb/client/verta/tests, configfile: pytest.ini
plugins: hypothesis-6.14.0
collected 7 items                                                                                                           

test_model_registry/test_model_base.py .                                                                              [ 14%]
test_model_registry/test_standard_model.py ......                                                                     [100%]

============================================== 7 passed, 7 warnings in 25.69s ===============================================
```