### PR TITLE
Use get() instead of [] in Endpoint.get_logs()

### DIFF
--- a/client/verta/verta/endpoint/_endpoint.py
+++ b/client/verta/verta/endpoint/_endpoint.py
@@ -429,7 +429,7 @@ class Endpoint(object):
         logs = response.json().get("entries", [])
         # remove duplicate lines
         logs = {
-            log["id"]: log["message"]
+            log.get("id", ""): log.get("message", "")
             for log in logs
         }
         # sort by line number


### PR DESCRIPTION
I got an error once where the log didn't have a message key, so it looks like some extra robustness is needed.