### PR TITLE
Mark TensorFlow tests

### DIFF
--- a/client/verta/tests/pytest.ini
+++ b/client/verta/tests/pytest.ini
@@ -2,6 +2,7 @@
 markers =
     oss: mark the given test function as only applicable to OSS.
     not_oss: mark the given test function not available in OSS.
+    tensorflow: mark the given test function as covering TensorFlow--useful for comparing 1.X vs 2.X.
 filterwarnings =
     # ignore DeprecationWarning from protobuf generated code
     ignore:.*Create unlinked descriptors is going to go away.*:DeprecationWarning

--- a/client/verta/tests/test_artifacts.py
+++ b/client/verta/tests/test_artifacts.py
@@ -417,6 +417,7 @@ class TestModels:
         for key, weight in net.state_dict().items():
             assert torch.allclose(weight, state_dict[key])
 
+    @pytest.mark.tensorflow
     def test_keras(self, seed, experiment_run, strs):
         np = pytest.importorskip("numpy")
         tf = pytest.importorskip("tensorflow")

--- a/client/verta/tests/test_integrations.py
+++ b/client/verta/tests/test_integrations.py
@@ -10,6 +10,7 @@ import time
 from verta._internal_utils.importer import get_tensorflow_major_version
 
 
+@pytest.mark.tensorflow
 class TestKeras:
     def test_sequential_api(self, experiment_run):
         verta_integrations_keras = pytest.importorskip("verta.integrations.keras")
@@ -183,6 +184,7 @@ class TestScikitLearn:
             assert run.get_hyperparameters()
 
 
+@pytest.mark.tensorflow
 class TestTensorFlow:
     def test_estimator_hook(self, experiment_run):
         verta_integrations_tensorflow = pytest.importorskip("verta.integrations.tensorflow")

--- a/client/verta/tests/test_model_registry/test_standard_model.py
+++ b/client/verta/tests/test_model_registry/test_standard_model.py
@@ -141,6 +141,7 @@ class TestStandardModels:
                 Python([]),
             )
 
+    @pytest.mark.tensorflow
     @pytest.mark.parametrize(
         "model",
         keras_models,
@@ -157,6 +158,7 @@ class TestStandardModels:
         deployed_model = endpoint.get_deployed_model()
         assert deployed_model.predict(np.random.random(size=(3, 3)))
 
+    @pytest.mark.tensorflow
     @pytest.mark.parametrize(
         "model",
         verta_models


### PR DESCRIPTION
To more accurately facilitate re-running TensorFlow-related tests in TF 1.X and 2.X, in conjunction with https://github.com/VertaAI/cluster-setup/pull/3172.