### PR TITLE
Install latest available version of NumPy

### DIFF
--- a/client/verta/requirements.txt
+++ b/client/verta/requirements.txt
@@ -18,7 +18,7 @@ google-cloud-bigquery
 h5py<3.0.0; python_version < '3.9'  # https://github.com/tensorflow/tensorflow/issues/44467
 matplotlib<3.0; python_version < '3.8'
 matplotlib>=3.2; python_version >= '3.8'
-numpy<1.17
+numpy
 pandas
 pillow
 scikit-learn<0.21; python_version < '3.8'  # https://scikit-learn.org/stable/install.html


### PR DESCRIPTION
This change is prompted by the freshly-released pandas==1.3.0 rejecting numpy<1.17.3.

The reason me-from-2-years-ago put numpy<1.17 in our requirements was because 1.16 is the last series to support Python 2. Really, we ought to just grab the latest available NumPy for whatever Python version is being run, rather than stick with a ~2-year-old version.

Copied from https://github.com/VertaAI/e2e-testing/pull/60