### PR TITLE
Only modify created_at when fetching alert's query

### DIFF
--- a/client/verta/tests/monitoring/alerts/test_entities.py
+++ b/client/verta/tests/monitoring/alerts/test_entities.py
@@ -117,7 +117,6 @@ class TestAlert:
         )
         expected_sample_query = SummarySampleQuery(
             summary_query=summary.alerts._build_summary_query(),
-            time_window_start=alert.created_at,
             created_after=alert.created_at,
         )
         assert alert.summary_sample_query == expected_sample_query
@@ -133,7 +132,6 @@ class TestAlert:
         expected_sample_query = SummarySampleQuery(
             summary_query=summary.alerts._build_summary_query(),
             labels=labels,
-            time_window_start=alert.created_at,
             created_after=alert.created_at,
         )
         assert alert.summary_sample_query == expected_sample_query

--- a/client/verta/verta/monitoring/alert/entities/_alert.py
+++ b/client/verta/verta/monitoring/alert/entities/_alert.py
@@ -189,11 +189,6 @@ class Alert(_entity._ModelDBEntity):
         # so as to not re-alert on previously-seen samples
         sample_query_msg.filter.created_at_after_millis = last_evaluated_at
 
-        # if user did not set `starting_from` during alert creation,
-        # only fetch samples pertaining to present, not backfilled samples
-        if not sample_query_msg.filter.time_window_start_at_millis:
-            sample_query_msg.filter.time_window_start_at_millis = last_evaluated_at
-
         return SummarySampleQuery._from_proto_request(sample_query_msg)
 
     @property


### PR DESCRIPTION
Previously, if a user doesn't specify `alerts.create(starting_from=)`, then the alert will basically only consider new samples with time windows set in the present.

This change has the alert consider _all_ newly-created samples. Even if their time windows are set in the past, as long as they were created since the alert was last evaluated then they will be counted (barring race conditions).

At a more technical level: only `created_at_after_millis` will be modified when fetching an alert's sample query.