### PR TITLE
Fix Python 2 compatibility bugs in log_training_data_profile()

### DIFF
--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -1347,8 +1347,9 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
                 json.loads(feature_data.content),
             )
 
-        with ThreadPool(1) as p:
-            p.map(lambda args: log_attribute(*args), enumerate(feature_data_list))
+        p = ThreadPool(1)
+        p.map(lambda args: log_attribute(*args), enumerate(feature_data_list))
+        p.close()
 
     def log_training_data_profile(self, in_df, out_df):
         """Capture the profiles of training input and output data.

--- a/client/verta/verta/tracking/entities/_entity.py
+++ b/client/verta/verta/tracking/entities/_entity.py
@@ -106,7 +106,7 @@ class _ModelDBEntity(object):
             Sanitized `key`
 
         """
-        return "".join([x for x in key if (str.isalnum(x) or x == '_')])
+        return "".join([x for x in key if (x.isalnum() or x == '_')])
 
     @classmethod
     def _get_by_id(cls, conn, conf, id):


### PR DESCRIPTION
These had gone uncaught because of an XGBoost segfault in our test suite (VR-12149 to resolve) that prevented the tests from being run in Python 2.