### PR TITLE
Block reserved artifact keys in create_standard_model() and document

### DIFF
--- a/client/verta/tests/test_artifacts.py
+++ b/client/verta/tests/test_artifacts.py
@@ -206,9 +206,9 @@ class TestArtifacts:
                       for value in all_values if not isinstance(value, str))
 
         for key, artifact in zip(_artifact_utils.BLOCKLISTED_KEYS, all_values):
-            with pytest.raises(ValueError):
+            with pytest.raises(ValueError, match="please use a different key$"):
                 experiment_run.log_artifact(key, artifact)
-            with pytest.raises(ValueError):
+            with pytest.raises(ValueError, match="please use a different key$"):
                 experiment_run.log_artifact_path(key, artifact)
 
     def test_clientside_storage(self, experiment_run, strs, in_tempdir, random_data):
@@ -698,9 +698,9 @@ class TestImages:
                       for value in all_values if not isinstance(value, str))
 
         for key, artifact in zip(_artifact_utils.BLOCKLISTED_KEYS, all_values):
-            with pytest.raises(ValueError):
+            with pytest.raises(ValueError, match="please use a different key$"):
                 experiment_run.log_image(key, artifact)
-            with pytest.raises(ValueError):
+            with pytest.raises(ValueError, match="please use a different key$"):
                 experiment_run.log_image_path(key, artifact)
 
 

--- a/client/verta/tests/test_model_registry/test_model_version.py
+++ b/client/verta/tests/test_model_registry/test_model_version.py
@@ -497,6 +497,7 @@ class TestArtifacts:
         model_version = registered_model.get_version(id=model_version.id)
         assert (not model_version.has_model)
 
+    @pytest.mark.skip(reason="not implemented (see TODO in log_artifact())")
     def test_blocklisted_key_error(self, model_version):
         value = "foo"
 

--- a/client/verta/tests/test_model_registry/test_model_version.py
+++ b/client/verta/tests/test_model_registry/test_model_version.py
@@ -497,6 +497,13 @@ class TestArtifacts:
         model_version = registered_model.get_version(id=model_version.id)
         assert (not model_version.has_model)
 
+    def test_blocklisted_key_error(self, model_version):
+        value = "foo"
+
+        for key in _artifact_utils.BLOCKLISTED_KEYS:
+            with pytest.raises(ValueError, match="please use a different key$"):
+                model_version.log_artifact(key, value)
+
 
 class TestDeployability:
     """Deployment-related functionality"""

--- a/client/verta/tests/test_model_registry/test_standard_model.py
+++ b/client/verta/tests/test_model_registry/test_standard_model.py
@@ -8,7 +8,7 @@ import pytest
 
 from verta.environment import Python
 from verta.external import six
-from verta._internal_utils import model_validator
+from verta._internal_utils import _artifact_utils, model_validator
 
 from ..models import standard_models
 
@@ -133,6 +133,15 @@ class TestStandardModels:
     )
     def test_verta(self, registered_model, endpoint, model):
         artifact_value = [{"a": 1}]
+
+        # blocklisted artifact keys raise error
+        for key in _artifact_utils.BLOCKLISTED_KEYS:
+            with pytest.raises(ValueError, match="please use a different key$"):
+                registered_model.create_standard_model(
+                    model,
+                    Python([]),
+                    artifacts={key: artifact_value},
+                )
 
         model_ver = registered_model.create_standard_model(
             model,

--- a/client/verta/verta/_internal_utils/_artifact_utils.py
+++ b/client/verta/verta/_internal_utils/_artifact_utils.py
@@ -34,6 +34,10 @@ REGISTRY_MODEL_KEY = "model"
 MODEL_KEY = "model.pkl"  # currently used by experiment run
 MODEL_API_KEY = "model_api.json"
 # TODO: maybe bind constants for other keys used throughout client
+# NOTE: if blocklisting more keys, update the docstrings of
+#       - RegisteredModel.create_standard_model()
+#       - RegisteredModelVersion.log_artifact()
+#       - ExperimentRun.log_artifact()
 BLOCKLISTED_KEYS = {
     CUSTOM_MODULES_KEY,
     MODEL_KEY,

--- a/client/verta/verta/registry/entities/_model.py
+++ b/client/verta/verta/registry/entities/_model.py
@@ -229,9 +229,17 @@ class RegisteredModel(_entity._ModelDBEntity):
 
         .. note::
 
-            Certain artifact keys are reserved for internal use within the
-            Verta system. The full list of reserved keys may be viewed
-            `here <https://github.com/VertaAI/modeldb/blob/ca8907d/client/verta/verta/_internal_utils/_artifact_utils.py#L32-L45>`__.
+            The following artifact keys are reserved for internal use within the
+            Verta system:
+
+            - ``"custom_modules"``
+            - ``"model"``
+            - ``"model.pkl"``
+            - ``"model_api.json"``
+            - ``"requirements.txt"``
+            - ``"train_data"``
+            - ``"tf_saved_model"``
+            - ``"setup_script"``
 
         .. note::
 

--- a/client/verta/verta/registry/entities/_model.py
+++ b/client/verta/verta/registry/entities/_model.py
@@ -6,7 +6,7 @@ import requests
 from verta._internal_utils._utils import check_unnecessary_params_warning
 from verta.tracking import _Context
 from verta.tracking.entities import _entity
-from verta._internal_utils import _utils, model_validator
+from verta._internal_utils import _artifact_utils, _utils, model_validator
 
 from verta._protos.public.common import CommonService_pb2 as _CommonCommonService
 from verta._protos.public.registry import RegistryService_pb2 as _RegistryService
@@ -179,6 +179,8 @@ class RegisteredModel(_entity._ModelDBEntity):
         lock_level=None,
     ):
         artifacts = artifacts or {}
+        for key in artifacts.keys():
+            _artifact_utils.validate_key(key)
         attrs = attrs or {}
         attrs.update({
             "__verta_reserved__model_language": "Python",

--- a/client/verta/verta/registry/entities/_model.py
+++ b/client/verta/verta/registry/entities/_model.py
@@ -227,6 +227,12 @@ class RegisteredModel(_entity._ModelDBEntity):
 
         .. note::
 
+            Certain artifact keys are reserved for internal use within the
+            Verta system. The full list of reserved keys may be viewed
+            `here <https://github.com/VertaAI/modeldb/blob/ca8907d/client/verta/verta/_internal_utils/_artifact_utils.py#L32-L45>`__.
+
+        .. note::
+
             If using an XGBoost model from their scikit-learn API,
             ``"scikit-learn"`` must also be specified in `environment`
             (in addition to ``"xgboost"``).

--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -430,7 +430,9 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
             Whether to allow overwriting an existing artifact with key `key`.
 
         """
-        _artifact_utils.validate_key(key)
+        # TODO: should validate keys, but can't here because this public
+        #       method is also used to log internal artifacts
+        # _artifact_utils.validate_key(key)
         if key == _artifact_utils.REGISTRY_MODEL_KEY:
             raise ValueError(
                 'the key "{}" is reserved for model;'

--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -424,6 +424,7 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
             Whether to allow overwriting an existing artifact with key `key`.
 
         """
+        _artifact_utils.validate_key(key)
         if key == _artifact_utils.REGISTRY_MODEL_KEY:
             raise ValueError(
                 'the key "{}" is reserved for model;'

--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -410,6 +410,12 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
         """
         Logs an artifact to this Model Version.
 
+        .. note::
+
+            Certain artifact keys are reserved for internal use within the
+            Verta system. The full list of reserved keys may be viewed
+            `here <https://github.com/VertaAI/modeldb/blob/ca8907d/client/verta/verta/_internal_utils/_artifact_utils.py#L32-L45>`__.
+
         Parameters
         ----------
         key : str

--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -412,9 +412,17 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
 
         .. note::
 
-            Certain artifact keys are reserved for internal use within the
-            Verta system. The full list of reserved keys may be viewed
-            `here <https://github.com/VertaAI/modeldb/blob/ca8907d/client/verta/verta/_internal_utils/_artifact_utils.py#L32-L45>`__.
+            The following artifact keys are reserved for internal use within the
+            Verta system:
+
+            - ``"custom_modules"``
+            - ``"model"``
+            - ``"model.pkl"``
+            - ``"model_api.json"``
+            - ``"requirements.txt"``
+            - ``"train_data"``
+            - ``"tf_saved_model"``
+            - ``"setup_script"``
 
         Parameters
         ----------

--- a/client/verta/verta/tracking/entities/_experimentrun.py
+++ b/client/verta/verta/tracking/entities/_experimentrun.py
@@ -1482,9 +1482,17 @@ class ExperimentRun(_DeployableEntity):
 
         .. note::
 
-            Certain artifact keys are reserved for internal use within the
-            Verta system. The full list of reserved keys may be viewed
-            `here <https://github.com/VertaAI/modeldb/blob/ca8907d/client/verta/verta/_internal_utils/_artifact_utils.py#L32-L45>`__.
+            The following artifact keys are reserved for internal use within the
+            Verta system:
+
+            - ``"custom_modules"``
+            - ``"model"``
+            - ``"model.pkl"``
+            - ``"model_api.json"``
+            - ``"requirements.txt"``
+            - ``"train_data"``
+            - ``"tf_saved_model"``
+            - ``"setup_script"``
 
         Parameters
         ----------

--- a/client/verta/verta/tracking/entities/_experimentrun.py
+++ b/client/verta/verta/tracking/entities/_experimentrun.py
@@ -1480,6 +1480,12 @@ class ExperimentRun(_DeployableEntity):
         The ``VERTA_ARTIFACT_DIR`` environment variable can be used to specify a locally-accessible
         directory to store artifacts.
 
+        .. note::
+
+            Certain artifact keys are reserved for internal use within the
+            Verta system. The full list of reserved keys may be viewed
+            `here <https://github.com/VertaAI/modeldb/blob/ca8907d/client/verta/verta/_internal_utils/_artifact_utils.py#L32-L45>`__.
+
         Parameters
         ----------
         key : str


### PR DESCRIPTION
If a user tries logging a TensorFlow SavedModel artifact using the key `"tf_saved_model"` as a part of a custom model, they'll encounter a very difficult-to-debug error during model deployment.

## Changes
- document reserved artifact keys in `run.log_artifact()`, `model_ver.log_artifact()`, and `reg_model.create_standard_model()`
- block reserved artifact keys in `reg_model.create_standard_model()`
- robustify tests

![Screen Shot 2021-07-14 at 12 50 08 PM](https://user-images.githubusercontent.com/7754936/125684074-c0fd7d6e-118a-466c-8f17-f5e0345db53c.png)

## Testing
```bash
$ pytest test_artifacts.py::TestArtifacts::test_blocklisted_key_error \
> test_artifacts.py::TestImages::test_blocklisted_key_error \
> test_model_registry/test_standard_model.py::TestStandardModels::test_verta
==================================================== test session starts ====================================================
platform darwin -- Python 3.7.10, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /Users/miliu/Documents/modeldb/client/verta/tests, configfile: pytest.ini
plugins: hypothesis-6.14.0
collected 3 items                                                                                                           

test_artifacts.py ..                                                                                                  [ 66%]
test_model_registry/test_standard_model.py .                                                                          [100%]

========================================= 3 passed, 7 warnings in 182.27s (0:03:02) =========================================
```