### PR TITLE
[VR-11633] Enable Kafka configuration on endpoints

### DIFF
--- a/client/verta/tests/test_endpoint/test_kafka.py
+++ b/client/verta/tests/test_endpoint/test_kafka.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+
+import hypothesis
+import hypothesis.strategies as st
+import pytest
+
+from verta.endpoint import KafkaSettings
+from verta.environment import Python
+from verta._internal_utils import _utils
+
+
+class TestKafkaSettings:
+
+    @hypothesis.given(
+        input_topic=st.text(min_size=1),
+        output_topic=st.text(min_size=1),
+        error_topic=st.text(min_size=1),
+    )
+    def test_kafka_settings(self, input_topic, output_topic, error_topic):
+        hypothesis.assume(input_topic != output_topic and input_topic != error_topic)
+
+        kafka_settings = KafkaSettings(input_topic, output_topic, error_topic)
+        assert kafka_settings.input_topic == input_topic
+        assert kafka_settings.output_topic == output_topic
+        assert kafka_settings.error_topic == error_topic
+
+        assert kafka_settings == KafkaSettings._from_dict({
+            "input_topic": input_topic,
+            "output_topic": output_topic,
+            "error_topic": error_topic,
+        })
+
+        assert kafka_settings._as_dict() == {
+            "disabled": False,
+            "input_topic": input_topic,
+            "output_topic": output_topic,
+            "error_topic": error_topic,
+        }
+
+    @hypothesis.given(
+        input_topic=st.text(min_size=1),
+        other_topic=st.text(min_size=1),
+    )
+    def test_different_topics(self, input_topic, other_topic):
+        hypothesis.assume(input_topic != other_topic)
+
+        with pytest.raises(ValueError, match="input_topic must not be equal to either the output or error topics"):
+            KafkaSettings(input_topic, input_topic, other_topic)
+
+        with pytest.raises(ValueError, match="input_topic must not be equal to either the output or error topics"):
+            KafkaSettings(input_topic, other_topic, input_topic)
+
+    @hypothesis.given(
+        input_topic=st.text(),
+        output_topic=st.text(),
+        error_topic=st.text(),
+    )
+    def test_nonempty_topics(self, input_topic, output_topic, error_topic):
+        hypothesis.assume(input_topic != output_topic and input_topic != error_topic)
+        hypothesis.assume(any(len(topic) == 0 for topic in (input_topic, output_topic, error_topic)))
+
+        with pytest.raises(ValueError, match="must be a non-empty string"):
+            KafkaSettings(input_topic, output_topic, error_topic)
+
+
+class TestConfigureEndpoint:
+
+    def test_configure_endpoint(self, client, model_version, strs):
+        LogisticRegression = pytest.importorskip("sklearn.linear_model").LogisticRegression
+        strs = iter(strs)
+
+        model_version.log_model(
+            LogisticRegression, custom_modules=[],
+        )
+        model_version.log_environment(Python(["scikit-learn"]))
+
+        # create
+        kafka_settings = KafkaSettings(next(strs), next(strs), next(strs))
+        endpoint = client.create_endpoint(_utils.generate_default_name(), kafka_settings=kafka_settings)
+        assert endpoint.kafka_settings == kafka_settings
+
+        # update
+        kafka_settings = KafkaSettings(next(strs), next(strs), next(strs))
+        endpoint.update(model_version, kafka_settings=kafka_settings)
+        assert endpoint.kafka_settings == kafka_settings
+
+        # clear
+        endpoint.update(model_version, kafka_settings=False)
+        assert endpoint.kafka_settings is None

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -1166,7 +1166,15 @@ class Client(object):
         )
 
 
-    def create_endpoint(self, path, description=None, workspace=None, public_within_org=None, visibility=None):
+    def create_endpoint(
+        self,
+        path,
+        description=None,
+        workspace=None,
+        public_within_org=None,
+        visibility=None,
+        kafka_settings=None,
+    ):
         """
         Attaches an endpoint to this Client.
 
@@ -1189,6 +1197,8 @@ class Client(object):
             Visibility to set when creating this endpoint. If not provided, an
             appropriate default will be used. This parameter should be
             preferred over `public_within_org`.
+        kafka_settings : :class:`verta.endpoint.KafkaSettings`, optional
+            Kafka settings.
 
         Returns
         -------
@@ -1206,7 +1216,16 @@ class Client(object):
 
         if workspace is None:
             workspace = self.get_workspace()
-        return Endpoint._create(self._conn, self._conf, workspace, path, description, public_within_org, visibility)
+        return Endpoint._create(
+            self._conn,
+            self._conf,
+            workspace,
+            path,
+            description,
+            public_within_org,
+            visibility,
+            kafka_settings,
+        )
 
     @property
     def endpoints(self):

--- a/client/verta/verta/deployment/__init__.py
+++ b/client/verta/verta/deployment/__init__.py
@@ -9,10 +9,12 @@ from ._deployedmodel import (
     prediction_io_cleanup,
 )
 
+from ._kafka_settings import KafkaSettings
 
 documentation.reassign_module(
     [
         DeployedModel,
+        KafkaSettings,
         prediction_input_unpack,
         prediction_io_cleanup,
     ],

--- a/client/verta/verta/deployment/__init__.py
+++ b/client/verta/verta/deployment/__init__.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 """Utilities for defining and interacting with deployable models."""
+# NOTE: This submodule is to be merged into verta.endpoint (VR-5882), and
+#       should not be expanded further.
 
 from verta._internal_utils import documentation
 
@@ -9,12 +11,9 @@ from ._deployedmodel import (
     prediction_io_cleanup,
 )
 
-from ._kafka_settings import KafkaSettings
-
 documentation.reassign_module(
     [
         DeployedModel,
-        KafkaSettings,
         prediction_input_unpack,
         prediction_io_cleanup,
     ],

--- a/client/verta/verta/deployment/__init__.py
+++ b/client/verta/verta/deployment/__init__.py
@@ -11,6 +11,7 @@ from ._deployedmodel import (
     prediction_io_cleanup,
 )
 
+
 documentation.reassign_module(
     [
         DeployedModel,

--- a/client/verta/verta/deployment/_kafka_settings.py
+++ b/client/verta/verta/deployment/_kafka_settings.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from verta.external import six
+
 
 class KafkaSettings(object):
     """
@@ -28,9 +30,14 @@ class KafkaSettings(object):
                 "input_topic must not be equal to either the output or error topics"
             )
 
-        self._input_topic = input_topic
-        self._output_topic = output_topic
-        self._error_topic = error_topic
+        self._input_topic = self._check_non_empty_str("input_topic", input_topic)
+        self._output_topic = self._check_non_empty_str("output_topic", output_topic)
+        self._error_topic = self._check_non_empty_str("error_topic", error_topic)
+
+    def __repr__(self):
+        return "KafkaSettings({}, {}, {})".format(
+            repr(self.input_topic), repr(self.output_topic), repr(self.error_topic)
+        )
 
     @property
     def input_topic(self):
@@ -43,3 +50,11 @@ class KafkaSettings(object):
     @property
     def error_topic(self):
         return self._error_topic
+
+    @staticmethod
+    def _check_non_empty_str(name, value):
+        if not isinstance(value, six.string_types):
+            raise TypeError("`value` must be a string, not {}".format(type(value)))
+        if not value:
+            raise ValueError("`name` must be a non-empty string".format(name))
+        return value

--- a/client/verta/verta/deployment/_kafka_settings.py
+++ b/client/verta/verta/deployment/_kafka_settings.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+
+
+class KafkaSettings(object):
+    """
+    A set of topics to be used with deployed endpoints.
+
+    Attributes
+    ----------
+    input_topic : str
+        The input topic for an endpoint to subscribe to.
+    output_topic : str
+        The output topic for an endpoint to write predictions to.
+    error_topic : str
+        The error topic for an endpoint to write errors to.
+
+    Examples
+    --------
+    .. code-block:: python
+        from verta.deployment import KafkaSettings
+
+        kafka_settings = KafkaSettings("my_input_data", "my_predictions", "my_endpoint_errors")
+    """
+
+    def __init__(self, input_topic, output_topic, error_topic):
+        if input_topic == output_topic or input_topic == error_topic:
+            raise ValueError(
+                "input_topic must not be equal to either the output or error topics"
+            )
+
+        self._input_topic = input_topic
+        self._output_topic = output_topic
+        self._error_topic = error_topic
+
+    @property
+    def input_topic(self):
+        return self._input_topic
+
+    @property
+    def output_topic(self):
+        return self._output_topic
+
+    @property
+    def error_topic(self):
+        return self._error_topic

--- a/client/verta/verta/endpoint/__init__.py
+++ b/client/verta/verta/endpoint/__init__.py
@@ -3,12 +3,14 @@
 
 from verta._internal_utils import documentation
 
+from ._kafka_settings import KafkaSettings
 from ._endpoint import Endpoint
 from ._endpoints import Endpoints
 
 
 documentation.reassign_module(
     [
+        KafkaSettings,
         Endpoint,
         Endpoints,
     ],

--- a/client/verta/verta/endpoint/_endpoint.py
+++ b/client/verta/verta/endpoint/_endpoint.py
@@ -363,15 +363,32 @@ class Endpoint(object):
         return response.json()["id"]
 
     def _set_kafka_settings(self, stage_id, kafka_settings):
+        if not isinstance(stage_id, six.integer_types):
+            raise TypeError("`stage_id` must be int, not {}".format(type(stage_id)))
+        if not isinstance(kafka_settings, KafkaSettings):
+            raise TypeError(
+                "`kafka_settings` must be of type verta.endpoint.KafkaSettings,"
+                " not {}".format(type(kafka_settings))
+            )
+
         url = "{}://{}/api/v1/deployment/stages/{}/kafka".format(
-            self._conn.scheme, self._conn.socket, stage_id,
+            self._conn.scheme,
+            self._conn.socket,
+            stage_id,
         )
-        response = _utils.make_request("PUT", url, self._conn, json=kafka_settings._as_dict())
+        response = _utils.make_request(
+            "PUT", url, self._conn, json=kafka_settings._as_dict()
+        )
         _utils.raise_for_http_error(response)
 
     def _get_kafka_settings(self, stage_id):
+        if not isinstance(stage_id, six.integer_types):
+            raise TypeError("`stage_id` must be int, not {}".format(type(stage_id)))
+
         url = "{}://{}/api/v1/deployment/stages/{}/kafka".format(
-            self._conn.scheme, self._conn.socket, stage_id,
+            self._conn.scheme,
+            self._conn.socket,
+            stage_id,
         )
         response = _utils.make_request("GET", url, self._conn)
         _utils.raise_for_http_error(response)

--- a/client/verta/verta/endpoint/_endpoint.py
+++ b/client/verta/verta/endpoint/_endpoint.py
@@ -59,7 +59,6 @@ class Endpoint(object):
         self._conf = conf
         self.id = id
 
-    # TODO: Add stored kafka_settings to this repr
     def __repr__(self):
         status = self.get_status()
         data = Endpoint._get_json_by_id(self._conn, self.workspace, self.id)
@@ -78,6 +77,7 @@ class Endpoint(object):
                 "id: {}".format(self.id),
                 "curl: {}".format(curl),
                 "status: {}".format(status["status"]),
+                "Kafka settings: {}".format(self.kafka_settings),
                 "date created: {}".format(data["date_created"]),
                 "date updated: {}".format(data["date_updated"]),
                 "stage's date created: {}".format(status["date_created"]),

--- a/client/verta/verta/endpoint/_endpoint.py
+++ b/client/verta/verta/endpoint/_endpoint.py
@@ -434,7 +434,7 @@ class Endpoint(object):
         )
         _utils.raise_for_http_error(response)
 
-    # TODO: add support for KafkaSettings to _update_from_dict below or de-scope
+    # TODO: add support for KafkaSettings to _update_from_dict (VR-12264)
     def update_from_config(self, filepath, wait=False):
         """
         Updates the endpoint via a YAML or JSON config file.

--- a/client/verta/verta/endpoint/_endpoint.py
+++ b/client/verta/verta/endpoint/_endpoint.py
@@ -434,7 +434,7 @@ class Endpoint(object):
         )
         _utils.raise_for_http_error(response)
 
-    # TODO: add support for KafkaSettings to _update_from_dict (VR-12264)
+    # TODO: add support for KafkaSettings to _update_from_dict below or de-scope
     def update_from_config(self, filepath, wait=False):
         """
         Updates the endpoint via a YAML or JSON config file.

--- a/client/verta/verta/endpoint/_endpoint.py
+++ b/client/verta/verta/endpoint/_endpoint.py
@@ -225,7 +225,6 @@ class Endpoint(object):
                 return endpoint
         return None
 
-    # TODO: Add kafka_settings param here
     def update(
         self,
         model_reference,

--- a/client/verta/verta/endpoint/_endpoint.py
+++ b/client/verta/verta/endpoint/_endpoint.py
@@ -15,7 +15,11 @@ from ..endpoint.autoscaling.metrics import _AutoscalingMetric
 from ..endpoint.resources import Resources
 from ..endpoint.update.rules import _UpdateRule
 from ..deployment import DeployedModel
-from ..endpoint.update._strategies import _UpdateStrategy, DirectUpdateStrategy, CanaryUpdateStrategy
+from ..endpoint.update._strategies import (
+    _UpdateStrategy,
+    DirectUpdateStrategy,
+    CanaryUpdateStrategy,
+)
 from .._internal_utils import _utils
 from verta.tracking.entities import ExperimentRun
 from ..registry.entities import RegisteredModelVersion
@@ -44,12 +48,14 @@ class Endpoint(object):
         Path of this endpoint.
 
     """
+
     def __init__(self, conn, conf, workspace, id):
         self.workspace = workspace
         self._conn = conn
         self._conf = conf
         self.id = id
 
+    # TODO: Add stored kafka_settings to this repr
     def __repr__(self):
         status = self.get_status()
         data = Endpoint._get_json_by_id(self._conn, self.workspace, self.id)
@@ -59,54 +65,87 @@ class Endpoint(object):
         except RuntimeError:
             curl = "<endpoint not deployed>"
 
-        return '\n'.join((
-            "path: {}".format(data['creator_request']['path']),
-            "url: {}://{}/{}/endpoints/{}/summary".format(self._conn.scheme, self._conn.socket,
-                                                          self.workspace, self.id),
-            "id: {}".format(self.id),
-            "curl: {}".format(curl),
-            "status: {}".format(status["status"]),
-            "date created: {}".format(data["date_created"]),
-            "date updated: {}".format(data["date_updated"]),
-            "stage's date created: {}".format(status["date_created"]),
-            "stage's date updated: {}".format(status["date_updated"]),
-            "components: {}".format(json.dumps(status["components"], indent=4)),
-        ))
+        return "\n".join(
+            (
+                "path: {}".format(data["creator_request"]["path"]),
+                "url: {}://{}/{}/endpoints/{}/summary".format(
+                    self._conn.scheme, self._conn.socket, self.workspace, self.id
+                ),
+                "id: {}".format(self.id),
+                "curl: {}".format(curl),
+                "status: {}".format(status["status"]),
+                "date created: {}".format(data["date_created"]),
+                "date updated: {}".format(data["date_updated"]),
+                "stage's date created: {}".format(status["date_created"]),
+                "stage's date updated: {}".format(status["date_updated"]),
+                "components: {}".format(json.dumps(status["components"], indent=4)),
+            )
+        )
 
     @property
     def path(self):
         return self._path(Endpoint._get_json_by_id(self._conn, self.workspace, self.id))
 
     def _path(self, data):
-        return data['creator_request']['path']
+        return data["creator_request"]["path"]
 
     def _date_updated(self, data):
-        return data['date_updated']
+        return data["date_updated"]
 
     @classmethod
-    def _create(cls, conn, conf, workspace, path, description=None, public_within_org=None, visibility=None):
-        endpoint_json = cls._create_json(conn, workspace, path, description, public_within_org, visibility)
+    def _create(
+        cls,
+        conn,
+        conf,
+        workspace,
+        path,
+        description=None,
+        public_within_org=None,
+        visibility=None,
+    ):
+        endpoint_json = cls._create_json(
+            conn, workspace, path, description, public_within_org, visibility
+        )
         if endpoint_json:
-            endpoint = cls(conn, conf, workspace, endpoint_json['id'])
+            endpoint = cls(conn, conf, workspace, endpoint_json["id"])
             endpoint._create_stage()  # an endpoint needs a stage to function, so might as well create it here
             return endpoint
         else:
             return None
 
     @classmethod
-    def _create_json(cls, conn, workspace, path, description=None, public_within_org=None, visibility=None):
-        if not path.startswith('/'):
-            path = '/' + path
-        visibility, public_within_org = _visibility._Visibility._translate_public_within_org(visibility, public_within_org)
+    def _create_json(
+        cls,
+        conn,
+        workspace,
+        path,
+        description=None,
+        public_within_org=None,
+        visibility=None,
+    ):
+        if not path.startswith("/"):
+            path = "/" + path
+        (
+            visibility,
+            public_within_org,
+        ) = _visibility._Visibility._translate_public_within_org(
+            visibility, public_within_org
+        )
 
         data = {
-            'path': path,
-            'description': description,
-            'custom_permission': {'collaborator_type': visibility._collaborator_type_str},
-            'visibility': "ORG_SCOPED_PUBLIC" if public_within_org else "PRIVATE",  # TODO: raise if workspace is personal
-            'resource_visibility': visibility._visibility_str,
+            "path": path,
+            "description": description,
+            "custom_permission": {
+                "collaborator_type": visibility._collaborator_type_str
+            },
+            "visibility": "ORG_SCOPED_PUBLIC"
+            if public_within_org
+            else "PRIVATE",  # TODO: raise if workspace is personal
+            "resource_visibility": visibility._visibility_str,
         }
-        url = "{}://{}/api/v1/deployment/workspace/{}/endpoints".format(conn.scheme, conn.socket, workspace)
+        url = "{}://{}/api/v1/deployment/workspace/{}/endpoints".format(
+            conn.scheme, conn.socket, workspace
+        )
         response = _utils.make_request("POST", url, conn, json=data)
         _utils.raise_for_http_error(response)
         return response.json()
@@ -115,7 +154,7 @@ class Endpoint(object):
     def _get_by_id(cls, conn, conf, workspace, id):
         endpoint_json = cls._get_json_by_id(conn, workspace, id)
         if endpoint_json:
-            return cls(conn, conf, workspace, endpoint_json['id'])
+            return cls(conn, conf, workspace, endpoint_json["id"])
         else:
             return None
 
@@ -125,7 +164,9 @@ class Endpoint(object):
 
     @classmethod
     def _get_json_by_id(cls, conn, workspace, id):
-        url = "{}://{}/api/v1/deployment/workspace/{}/endpoints/{}".format(conn.scheme, conn.socket, workspace, id)
+        url = "{}://{}/api/v1/deployment/workspace/{}/endpoints/{}".format(
+            conn.scheme, conn.socket, workspace, id
+        )
         response = _utils.make_request("GET", url, conn)
         _utils.raise_for_http_error(response)
         return response.json()
@@ -144,31 +185,41 @@ class Endpoint(object):
     def _get_by_path(cls, conn, conf, workspace, path):
         endpoint_json = cls._get_json_by_path(conn, workspace, path)
         if endpoint_json:
-            return cls(conn, conf, workspace, endpoint_json['id'])
+            return cls(conn, conf, workspace, endpoint_json["id"])
         else:
             return None
 
     @classmethod
     def _get_endpoints(cls, conn, workspace):
-        url = "{}://{}/api/v1/deployment/workspace/{}/endpoints".format(conn.scheme, conn.socket, workspace)
+        url = "{}://{}/api/v1/deployment/workspace/{}/endpoints".format(
+            conn.scheme, conn.socket, workspace
+        )
         response = _utils.make_request("GET", url, conn)
         _utils.raise_for_http_error(response)
         data_response = response.json()
-        return data_response['endpoints']
+        return data_response["endpoints"]
 
     @classmethod
     def _get_json_by_path(cls, conn, workspace, path):
         endpoints = cls._get_endpoints(conn, workspace)
-        if not path.startswith('/'):
-            path = '/' + path
+        if not path.startswith("/"):
+            path = "/" + path
         for endpoint in endpoints:
-            creator_request = endpoint['creator_request']
-            if creator_request['path'] == path:
+            creator_request = endpoint["creator_request"]
+            if creator_request["path"] == path:
                 return endpoint
         return None
 
-    def update(self, model_reference, strategy=None, wait=False, resources=None,
-               autoscaling=None, env_vars=None):
+    # TODO: Add kafka_settings param here
+    def update(
+        self,
+        model_reference,
+        strategy=None,
+        wait=False,
+        resources=None,
+        autoscaling=None,
+        env_vars=None,
+    ):
         """
         Updates the endpoint with a model logged in an Experiment Run or a Model Version.
 
@@ -193,15 +244,19 @@ class Endpoint(object):
 
         """
         if not isinstance(model_reference, (RegisteredModelVersion, ExperimentRun)):
-            raise TypeError("`model_reference` must be an ExperimentRun or RegisteredModelVersion")
+            raise TypeError(
+                "`model_reference` must be an ExperimentRun or RegisteredModelVersion"
+            )
 
         if not strategy:
             strategy = DirectUpdateStrategy()
 
-        update_body = self._create_update_body(strategy, resources, autoscaling, env_vars)
+        update_body = self._create_update_body(
+            strategy, resources, autoscaling, env_vars
+        )
 
         # create new build
-        update_body['build_id'] = self._create_build(model_reference)
+        update_body["build_id"] = self._create_build(model_reference)
 
         return self._update_from_build(update_body, wait)
 
@@ -218,27 +273,28 @@ class Endpoint(object):
         _utils.raise_for_http_error(response)
 
         if wait:
-            print("waiting for update...", end='')
+            print("waiting for update...", end="")
             sys.stdout.flush()
 
-            build_status = self._get_build_status(update_body['build_id'])
+            build_status = self._get_build_status(update_body["build_id"])
             # have to check using build status, otherwise might never terminate
-            while build_status['status'] not in ("finished", "error"):
-                print(".", end='')
+            while build_status["status"] not in ("finished", "error"):
+                print(".", end="")
                 sys.stdout.flush()
                 time.sleep(5)
-                build_status = self._get_build_status(update_body['build_id'])
+                build_status = self._get_build_status(update_body["build_id"])
 
             if build_status["status"] == "error":
                 print()
-                failure_msg = build_status.get('message', "no error message available")
+                failure_msg = build_status.get("message", "no error message available")
                 raise RuntimeError("endpoint update failed;\n{}".format(failure_msg))
 
             # still need to wait because status might be "creating" even though build status is "finished"
             status_dict = self.get_status()
-            while status_dict["status"] not in ("active", "error") or \
-                    (status_dict['status'] == "active" and len(status_dict['components']) > 1):
-                print(".", end='')
+            while status_dict["status"] not in ("active", "error") or (
+                status_dict["status"] == "active" and len(status_dict["components"]) > 1
+            ):
+                print(".", end="")
                 sys.stdout.flush()
                 time.sleep(5)
                 status_dict = self.get_status()
@@ -262,11 +318,17 @@ class Endpoint(object):
         )
 
         if isinstance(model_reference, RegisteredModelVersion):
-            response = _utils.make_request("POST", url, self._conn, json={"model_version_id": model_reference.id})
+            response = _utils.make_request(
+                "POST", url, self._conn, json={"model_version_id": model_reference.id}
+            )
         elif isinstance(model_reference, ExperimentRun):
-            response = _utils.make_request("POST", url, self._conn, json={"run_id": model_reference.id})
+            response = _utils.make_request(
+                "POST", url, self._conn, json={"run_id": model_reference.id}
+            )
         else:
-            raise TypeError("`model_reference` must be an ExperimentRun or RegisteredModelVersion")
+            raise TypeError(
+                "`model_reference` must be an ExperimentRun or RegisteredModelVersion"
+            )
 
         _utils.raise_for_http_error(response)
         return response.json()["id"]
@@ -275,10 +337,7 @@ class Endpoint(object):
         if name == "production":
             # Check if a stage exists:
             url = "{}://{}/api/v1/deployment/workspace/{}/endpoints/{}/stages".format(
-                self._conn.scheme,
-                self._conn.socket,
-                self.workspace,
-                self.id
+                self._conn.scheme, self._conn.socket, self.workspace, self.id
             )
             response = _utils.make_request("GET", url, self._conn, params={})
 
@@ -295,15 +354,13 @@ class Endpoint(object):
 
     def _create_stage(self, name="production"):
         url = "{}://{}/api/v1/deployment/workspace/{}/endpoints/{}/stages".format(
-            self._conn.scheme,
-            self._conn.socket,
-            self.workspace,
-            self.id
+            self._conn.scheme, self._conn.socket, self.workspace, self.id
         )
         response = _utils.make_request("POST", url, self._conn, json={"name": name})
         _utils.raise_for_http_error(response)
         return response.json()["id"]
 
+    # TODO: add support for KafkaSettings to _update_from_dict below or de-scope
     def update_from_config(self, filepath, wait=False):
         """
         Updates the endpoint via a YAML or JSON config file.
@@ -327,7 +384,7 @@ class Endpoint(object):
         """
         update_dict = None
 
-        with open(filepath, 'r') as f:
+        with open(filepath, "r") as f:
             config = f.read()
 
         try:
@@ -351,17 +408,21 @@ class Endpoint(object):
             strategy = DirectUpdateStrategy()
         elif update_dict["strategy"] == "canary":
             strategy = CanaryUpdateStrategy(
-                interval=int(update_dict["canary_strategy"]["progress_interval_seconds"]),
-                step=float(update_dict["canary_strategy"]["progress_step"])
+                interval=int(
+                    update_dict["canary_strategy"]["progress_interval_seconds"]
+                ),
+                step=float(update_dict["canary_strategy"]["progress_step"]),
             )
 
             for rule in update_dict["canary_strategy"]["rules"]:
                 strategy.add_rule(_UpdateRule._from_dict(rule))
         else:
-            raise ValueError("update strategy must be \"direct\" or \"canary\"")
+            raise ValueError('update strategy must be "direct" or "canary"')
 
         if "autoscaling" in update_dict:
-            autoscaling_obj = Autoscaling._from_dict(update_dict["autoscaling"]["quantities"])
+            autoscaling_obj = Autoscaling._from_dict(
+                update_dict["autoscaling"]["quantities"]
+            )
 
             for metric in update_dict["autoscaling"]["metrics"]:
                 autoscaling_obj.add_metric(_AutoscalingMetric._from_dict(metric))
@@ -376,13 +437,24 @@ class Endpoint(object):
         if "run_id" in update_dict and "model_version_id" in update_dict:
             raise ValueError("cannot provide both run_id and model_version_id")
         elif "run_id" in update_dict:
-            model_reference = ExperimentRun._get_by_id(self._conn, self._conf, id=update_dict["run_id"])
+            model_reference = ExperimentRun._get_by_id(
+                self._conn, self._conf, id=update_dict["run_id"]
+            )
         elif "model_version_id" in update_dict:
-            model_reference = RegisteredModelVersion._get_by_id(self._conn, self._conf, id=update_dict["model_version_id"])
+            model_reference = RegisteredModelVersion._get_by_id(
+                self._conn, self._conf, id=update_dict["model_version_id"]
+            )
         else:
             raise RuntimeError("must provide either model_version_id or run_id")
 
-        return self.update(model_reference, strategy, wait=wait, resources=resources_list, autoscaling=autoscaling_obj, env_vars=update_dict.get("env_vars"))
+        return self.update(
+            model_reference,
+            strategy,
+            wait=wait,
+            resources=resources_list,
+            autoscaling=autoscaling_obj,
+            env_vars=update_dict.get("env_vars"),
+        )
 
     def get_status(self):
         """
@@ -398,7 +470,7 @@ class Endpoint(object):
             self._conn.socket,
             self.workspace,
             self.id,
-            self._get_or_create_stage()
+            self._get_or_create_stage(),
         )
         response = _utils.make_request("GET", url, self._conn)
         _utils.raise_for_http_error(response)
@@ -416,22 +488,21 @@ class Endpoint(object):
             Lines of this endpoint's runtime logs.
 
         """
-        url = "{}://{}/api/v1/deployment/workspace/{}/endpoints/{}/stages/{}/logs".format(
-            self._conn.scheme,
-            self._conn.socket,
-            self.workspace,
-            self.id,
-            self._get_or_create_stage()
+        url = (
+            "{}://{}/api/v1/deployment/workspace/{}/endpoints/{}/stages/{}/logs".format(
+                self._conn.scheme,
+                self._conn.socket,
+                self.workspace,
+                self.id,
+                self._get_or_create_stage(),
+            )
         )
         response = _utils.make_request("GET", url, self._conn)
         self._conn.must_response(response)
 
         logs = response.json().get("entries", [])
         # remove duplicate lines
-        logs = {
-            log.get("id", ""): log.get("message", "")
-            for log in logs
-        }
+        logs = {log.get("id", ""): log.get("message", "") for log in logs}
         # sort by line number
         logs = sorted(logs.items(), key=lambda item: item[0])
         return [item[1] for item in logs]
@@ -467,11 +538,7 @@ class Endpoint(object):
 
         data = response.json()
         token_items = data.get("tokens", [])
-        tokens = [
-            token["creator_request"]["value"]
-            for token
-            in token_items
-        ]
+        tokens = [token["creator_request"]["value"] for token in token_items]
         return tokens
 
     def create_access_token(self, token):
@@ -504,17 +571,23 @@ class Endpoint(object):
 
         """
         if not isinstance(strategy, _UpdateStrategy):
-            raise TypeError("`strategy` must be an object from verta.endpoint.update._strategies")
+            raise TypeError(
+                "`strategy` must be an object from verta.endpoint.update._strategies"
+            )
 
         if autoscaling and not isinstance(autoscaling, Autoscaling):
             raise TypeError("`autoscaling` must be an Autoscaling object")
 
         if env_vars:
-            env_vars_err_msg = "`env_vars` must be dictionary of str keys and str values"
+            env_vars_err_msg = (
+                "`env_vars` must be dictionary of str keys and str values"
+            )
             if not isinstance(env_vars, dict):
                 raise TypeError(env_vars_err_msg)
             for key, value in env_vars.items():
-                if not isinstance(key, six.string_types) or not isinstance(value, six.string_types):
+                if not isinstance(key, six.string_types) or not isinstance(
+                    value, six.string_types
+                ):
                     raise TypeError(env_vars_err_msg)
 
         update_body = strategy._as_build_update_req_body()
@@ -527,8 +600,14 @@ class Endpoint(object):
 
         if env_vars is not None:
             update_body["env"] = list(
-                sorted(map(lambda env_var: {"name": env_var, "value": env_vars[env_var]}, env_vars),
-                       key=lambda env_elem: env_elem["name"]))
+                sorted(
+                    map(
+                        lambda env_var: {"name": env_var, "value": env_vars[env_var]},
+                        env_vars,
+                    ),
+                    key=lambda env_elem: env_elem["name"],
+                )
+            )
 
         return update_body
 
@@ -547,11 +626,15 @@ class Endpoint(object):
 
         """
         status = self.get_status()
-        if status['status'] not in ("active", "updating"):
-            raise RuntimeError("model is not currently deployed (status: {})".format(status))
+        if status["status"] not in ("active", "updating"):
+            raise RuntimeError(
+                "model is not currently deployed (status: {})".format(status)
+            )
 
         access_token = self.get_access_token()
-        url = "{}://{}/api/v1/predict{}".format(self._conn.scheme, self._conn.socket, self.path)
+        url = "{}://{}/api/v1/predict{}".format(
+            self._conn.scheme, self._conn.socket, self.path
+        )
         return DeployedModel.from_url(url, access_token)
 
     def get_update_status(self):
@@ -568,7 +651,7 @@ class Endpoint(object):
             self._conn.socket,
             self.workspace,
             self.id,
-            self._get_or_create_stage()
+            self._get_or_create_stage(),
         )
         response = _utils.make_request("GET", url, self._conn)
         _utils.raise_for_http_error(response)
@@ -576,10 +659,7 @@ class Endpoint(object):
 
     def _get_build_status(self, build_id):
         url = "{}://{}/api/v1/deployment/workspace/{}/builds/{}".format(
-            self._conn.scheme,
-            self._conn.socket,
-            self.workspace,
-            build_id
+            self._conn.scheme, self._conn.socket, self.workspace, build_id
         )
 
         response = _utils.make_request("GET", url, self._conn)
@@ -592,6 +672,8 @@ class Endpoint(object):
         Deletes this endpoint.
 
         """
-        request_url = "{}://{}/api/v1/deployment/workspace/{}/endpoints/{}".format(self._conn.scheme, self._conn.socket, self.workspace, self.id)
+        request_url = "{}://{}/api/v1/deployment/workspace/{}/endpoints/{}".format(
+            self._conn.scheme, self._conn.socket, self.workspace, self.id
+        )
         response = requests.delete(request_url, headers=self._conn.auth)
         _utils.raise_for_http_error(response)

--- a/client/verta/verta/endpoint/_endpoint.py
+++ b/client/verta/verta/endpoint/_endpoint.py
@@ -111,13 +111,19 @@ class Endpoint(object):
         description=None,
         public_within_org=None,
         visibility=None,
+        kafka_settings=None,
     ):
         endpoint_json = cls._create_json(
             conn, workspace, path, description, public_within_org, visibility
         )
         if endpoint_json:
             endpoint = cls(conn, conf, workspace, endpoint_json["id"])
-            endpoint._create_stage()  # an endpoint needs a stage to function, so might as well create it here
+
+            # an endpoint needs a stage to function, so might as well create it here
+            stage_id = endpoint._create_stage()
+            if kafka_settings:
+                endpoint._set_kafka_settings(stage_id, kafka_settings)
+
             return endpoint
         else:
             return None

--- a/client/verta/verta/endpoint/_endpoint.py
+++ b/client/verta/verta/endpoint/_endpoint.py
@@ -88,7 +88,7 @@ class Endpoint(object):
 
     @property
     def kafka_settings(self):
-        # NOTE: assumes "production" is the only stage (true at time of writing)
+        # NOTE: assumes endpoints only have one stage (true at time of writing)
         return self._get_kafka_settings(self._get_or_create_stage())
 
     @property

--- a/client/verta/verta/endpoint/_endpoint.py
+++ b/client/verta/verta/endpoint/_endpoint.py
@@ -46,6 +46,8 @@ class Endpoint(object):
     ----------
     id : int
         ID of this endpoint.
+    kafka_settings : :class:`verta.endpoint.KafkaSettings` or None
+        Kafka settings on this endpoint.
     path : str
         Path of this endpoint.
 
@@ -83,6 +85,11 @@ class Endpoint(object):
                 "components: {}".format(json.dumps(status["components"], indent=4)),
             )
         )
+
+    @property
+    def kafka_settings(self):
+        # NOTE: assumes "production" is the only stage (true at time of writing)
+        return self._get_kafka_settings(self._get_or_create_stage())
 
     @property
     def path(self):
@@ -394,6 +401,8 @@ class Endpoint(object):
         _utils.raise_for_http_error(response)
 
         kafka_settings_dict = response.json().get("update_request", {})
+        if not kafka_settings_dict:
+            return None
         return KafkaSettings._from_dict(kafka_settings_dict)
 
     # TODO: add support for KafkaSettings to _update_from_dict below or de-scope

--- a/client/verta/verta/endpoint/_kafka_settings.py
+++ b/client/verta/verta/endpoint/_kafka_settings.py
@@ -57,5 +57,5 @@ class KafkaSettings(object):
         if not isinstance(value, six.string_types):
             raise TypeError("`value` must be a string, not {}".format(type(value)))
         if not value:
-            raise ValueError("`name` must be a non-empty string".format(name))
+            raise ValueError("`value` must be a non-empty string")
         return value

--- a/client/verta/verta/endpoint/_kafka_settings.py
+++ b/client/verta/verta/endpoint/_kafka_settings.py
@@ -19,7 +19,7 @@ class KafkaSettings(object):
     Examples
     --------
     .. code-block:: python
-        from verta.deployment import KafkaSettings
+        from verta.endpoint import KafkaSettings
 
         kafka_settings = KafkaSettings("my_input_data", "my_predictions", "my_endpoint_errors")
     """

--- a/client/verta/verta/endpoint/_kafka_settings.py
+++ b/client/verta/verta/endpoint/_kafka_settings.py
@@ -19,6 +19,7 @@ class KafkaSettings(object):
     Examples
     --------
     .. code-block:: python
+
         from verta.endpoint import KafkaSettings
 
         kafka_settings = KafkaSettings("my_input_data", "my_predictions", "my_endpoint_errors")

--- a/client/verta/verta/endpoint/_kafka_settings.py
+++ b/client/verta/verta/endpoint/_kafka_settings.py
@@ -62,6 +62,7 @@ class KafkaSettings(object):
 
     def _as_dict(self):
         return {
+            "disabled": False,
             "input_topic": self.input_topic,
             "output_topic": self.output_topic,
             "error_topic": self.error_topic,

--- a/client/verta/verta/endpoint/_kafka_settings.py
+++ b/client/verta/verta/endpoint/_kafka_settings.py
@@ -59,3 +59,23 @@ class KafkaSettings(object):
         if not value:
             raise ValueError("`value` must be a non-empty string")
         return value
+
+    def _as_dict(self):
+        return {
+            "input_topic": self.input_topic,
+            "output_topic": self.output_topic,
+            "error_topic": self.error_topic,
+        }
+
+    @classmethod
+    def _from_dict(cls, d):
+        # NOTE: ignores extraneous keys in `d`
+        try:
+            input_topic = d["input_topic"]
+            output_topic = d["output_topic"]
+            error_topic = d["error_topic"]
+        except KeyError as e:
+            msg = 'expected but did not find key "{}"'.format(e.args[0])
+            six.raise_from(RuntimeError(msg), None)
+
+        return cls(input_topic, output_topic, error_topic)

--- a/client/verta/verta/endpoint/_kafka_settings.py
+++ b/client/verta/verta/endpoint/_kafka_settings.py
@@ -35,6 +35,16 @@ class KafkaSettings(object):
         self._output_topic = self._check_non_empty_str("output_topic", output_topic)
         self._error_topic = self._check_non_empty_str("error_topic", error_topic)
 
+    def __eq__(self, other):
+        if not isinstance(other, type(self)):
+            return NotImplemented
+
+        return (
+            self._input_topic == other._input_topic
+            and self._output_topic == other._output_topic
+            and self._error_topic == other._error_topic
+        )
+
     def __repr__(self):
         return "KafkaSettings({}, {}, {})".format(
             repr(self.input_topic), repr(self.output_topic), repr(self.error_topic)


### PR DESCRIPTION
Enables:
- setting Kafka on endpoint creation
- modifying Kafka on endpoint update
- removing Kafka on endpoint update

Does not support disabling Kafka while keeping the stream values (they are deleted entirely in the third bullet point ☝🏼).

![Screen Shot 2021-07-14 at 4 46 09 PM](https://user-images.githubusercontent.com/7754936/125707289-e0c69f74-72c3-416e-bc0f-9e48a3054f0d.png)

## Tests
```bash
$ pytest test_endpoint/test_kafka.py
==================================================== test session starts ====================================================
platform darwin -- Python 3.7.10, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /Users/miliu/Documents/modeldb/client/verta/tests, configfile: pytest.ini
plugins: hypothesis-6.14.0
collected 4 items                                                                                                           

test_endpoint/test_kafka.py ....                                                                                      [100%]

============================================== 4 passed, 4 warnings in 58.09s ===============================================
```