### PR TITLE
[VR-12150] Update registry profiling tests for bugfix

### DIFF
--- a/client/verta/tests/test_model_registry/test_model_version.py
+++ b/client/verta/tests/test_model_registry/test_model_version.py
@@ -960,7 +960,7 @@ class TestAutoMonitoring:
             assert feature_data.feature_name == col
             assert feature_data.profiler_name == "MissingValuesProfiler"
             assert json.loads(feature_data.profiler_parameters) == {"columns": [col]}
-            assert feature_data.summary_type_name == _histogram._type_string()
+            assert feature_data.summary_type_name == "verta.discreteHistogram.v1"
             assert feature_data.labels == labels
             assert json.loads(feature_data.content) == _histogram._as_dict()
 
@@ -976,7 +976,7 @@ class TestAutoMonitoring:
             "columns": ["continuous"],
             "bins": _histogram._bucket_limits,
         }
-        assert feature_data.summary_type_name == _histogram._type_string()
+        assert feature_data.summary_type_name == "verta.floatHistogram.v1"
         assert feature_data.labels == labels
         assert json.loads(feature_data.content) == _histogram._as_dict()
 
@@ -989,7 +989,7 @@ class TestAutoMonitoring:
         assert feature_data.feature_name == "discrete"
         assert feature_data.profiler_name == "BinaryHistogramProfiler"
         assert json.loads(feature_data.profiler_parameters) == {"columns": ["discrete"]}
-        assert feature_data.summary_type_name == _histogram._type_string()
+        assert feature_data.summary_type_name == "verta.discreteHistogram.v1"
         assert feature_data.labels == labels
         assert json.loads(feature_data.content) == _histogram._as_dict()
 

--- a/client/verta/tests/test_model_registry/test_model_version.py
+++ b/client/verta/tests/test_model_registry/test_model_version.py
@@ -960,7 +960,7 @@ class TestAutoMonitoring:
             assert feature_data.feature_name == col
             assert feature_data.profiler_name == "MissingValuesProfiler"
             assert json.loads(feature_data.profiler_parameters) == {"columns": [col]}
-            assert feature_data.summary_type_name == "DiscreteHistogram"
+            assert feature_data.summary_type_name == _histogram._type_string()
             assert feature_data.labels == labels
             assert json.loads(feature_data.content) == _histogram._as_dict()
 
@@ -976,7 +976,7 @@ class TestAutoMonitoring:
             "columns": ["continuous"],
             "bins": _histogram._bucket_limits,
         }
-        assert feature_data.summary_type_name == "FloatHistogram"
+        assert feature_data.summary_type_name == _histogram._type_string()
         assert feature_data.labels == labels
         assert json.loads(feature_data.content) == _histogram._as_dict()
 
@@ -989,7 +989,7 @@ class TestAutoMonitoring:
         assert feature_data.feature_name == "discrete"
         assert feature_data.profiler_name == "BinaryHistogramProfiler"
         assert json.loads(feature_data.profiler_parameters) == {"columns": ["discrete"]}
-        assert feature_data.summary_type_name == "DiscreteHistogram"
+        assert feature_data.summary_type_name == _histogram._type_string()
         assert feature_data.labels == labels
         assert json.loads(feature_data.content) == _histogram._as_dict()
 
@@ -1048,11 +1048,11 @@ class TestAutoMonitoring:
         # missing value, distribution summary for each supported column +
         # equal number of attributes for visualization
         assert(len(attributes.keys()) == len(supported_col_names) * 2 * 2)
-        assert(discrete_col_distribution_summary.summary_type_name == "DiscreteHistogram")
+        assert(discrete_col_distribution_summary.summary_type_name == "verta.discreteHistogram.v1")
         assert(discrete_col_distribution_summary.profiler_name == "BinaryHistogramProfiler")
         assert(len(json.loads(discrete_col_distribution_summary.content)["discreteHistogram"]["buckets"]) <= 5)
 
-        assert(discrete_col_missing_summary.summary_type_name == "DiscreteHistogram")
+        assert(discrete_col_missing_summary.summary_type_name == "verta.discreteHistogram.v1")
         assert(discrete_col_missing_summary.profiler_name == "MissingValuesProfiler")
         assert(len(json.loads(discrete_col_missing_summary.content)["discreteHistogram"]["buckets"]) == 2)
 
@@ -1105,4 +1105,4 @@ class TestAutoMonitoring:
                         )
                     )
                 point_profile = feature_profiler.profile_point(point, reference)
-                assert point_profile.__class__.__name__ == feature_data["summary_type_name"]
+                assert point_profile._type_string() == feature_data["summary_type_name"]


### PR DESCRIPTION
https://github.com/VertaAI/modeldb/pull/2457 had a bug fix changing
```
summary_type_name = "DiscreteHistogram"
```
to
```
summary_type_name = "verta.discreteHistogram.v1"
```

This PR updates tests accordingly.