### PR TITLE
Update test for model version stage find

### DIFF
--- a/client/verta/tests/test_model_registry/test_model_version.py
+++ b/client/verta/tests/test_model_registry/test_model_version.py
@@ -354,7 +354,6 @@ class TestFind:
         registered_model.create_version()
         assert len(registered_model.versions.find("stage == unassigned")) == 1
         assert len(registered_model.versions.find("stage == development")) == 0
-        assert len(registered_model.versions.find("stage == staging")) == 0
 
 
 class TestArtifacts:

--- a/client/verta/tests/test_model_registry/test_model_version.py
+++ b/client/verta/tests/test_model_registry/test_model_version.py
@@ -349,10 +349,11 @@ class TestFind:
 
     def test_find_stage(self, registered_model):
         # TODO: expand with other stages once client impls version transition
-        assert len(registered_model.versions.find("stage == development")) == 0
+        assert len(registered_model.versions.find("stage == unassigned")) == 0
 
         registered_model.create_version()
-        assert len(registered_model.versions.find("stage == development")) == 1
+        assert len(registered_model.versions.find("stage == unassigned")) == 1
+        assert len(registered_model.versions.find("stage == development")) == 0
         assert len(registered_model.versions.find("stage == staging")) == 0
 
 


### PR DESCRIPTION
As of https://github.com/VertaAI/registry/pull/696, `UNASSIGNED` is now the default stage for newly-created model versions rather than `DEVELOPMENT`. This PR updates a client test accordingly.