### PR TITLE
Remove stray line from changelog

### DIFF
--- a/client/verta/docs/changelog.rst
+++ b/client/verta/docs/changelog.rst
@@ -73,7 +73,6 @@ Bug Fixes
   <https://github.com/VertaAI/modeldb/pull/2440>`__
 - `allow alerts to properly handle samples of past time windows
   <https://github.com/VertaAI/modeldb/pull/2478>`__
-- `accommodate pandas v1.1.* in
 
 Internal Changes
 ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
I thought I fixed this for https://github.com/VertaAI/modeldb/pull/2489, but it seems I neglected to push the commit 😞 