### PR TITLE
[VR-12149] Skip XGBoost integration test in Python 2

### DIFF
--- a/client/verta/tests/test_integrations.py
+++ b/client/verta/tests/test_integrations.py
@@ -323,6 +323,9 @@ class TestTensorFlow:
 
 
 class TestXGBoost:
+
+    # TODO: re-enable with VR-11963
+    @pytest.mark.skip(six.PY2, reason="XGBoost causes a segfault in Python 2")
     def test_callback(self, experiment_run):
         verta_integrations_xgboost = pytest.importorskip("verta.integrations.xgboost")
         verta_callback = verta_integrations_xgboost.verta_callback


### PR DESCRIPTION
XGBoost causes a segfault in our automated test environment.

Until it's resolved in VR-11963, I'm skipping the test so that the suite can run unimpeded.