### PR TITLE
Allow create_version_from_run() to take a run obj

### DIFF
--- a/client/verta/tests/test_model_registry/test_model_version.py
+++ b/client/verta/tests/test_model_registry/test_model_version.py
@@ -55,17 +55,18 @@ class TestMDBIntegration:
         artifact = np.random.random((36, 12))
         experiment_run.log_artifact("some-artifact", artifact)
 
-        model_version = registered_model.create_version_from_run(
-            run_id=experiment_run.id,
-            name="From Run {}".format(experiment_run.id),
-        )
+        for i, run_id_arg in enumerate([experiment_run.id, experiment_run]):  # also accept run obj
+            model_version = registered_model.create_version_from_run(
+                run_id=run_id_arg,
+                name="From Run {} {}".format(experiment_run.id, i),
+            )
 
-        env_str = str(model_version.get_environment())
-        assert 'scikit-learn' in env_str
-        assert 'Python' in env_str
+            env_str = str(model_version.get_environment())
+            assert 'scikit-learn' in env_str
+            assert 'Python' in env_str
 
-        assert model_for_deployment['model'].get_params() == model_version.get_model().get_params()
-        assert np.array_equal(model_version.get_artifact("some-artifact"), artifact)
+            assert model_for_deployment['model'].get_params() == model_version.get_model().get_params()
+            assert np.array_equal(model_version.get_artifact("some-artifact"), artifact)
 
     def test_from_run_diff_workspaces(self, client, experiment_run, organization, created_entities):
         registered_model = client.create_registered_model(workspace=organization.name)

--- a/client/verta/verta/registry/entities/_model.py
+++ b/client/verta/verta/registry/entities/_model.py
@@ -623,8 +623,8 @@ class RegisteredModel(_entity._ModelDBEntity):
 
         Parameters
         ----------
-        run_id : str
-            ID of the run from which to create the model version.
+        run_id : str or :class:`~verta.tracking.entities.ExperimentRun`
+            Run from which to create the model version.
         name : str, optional
             Name of the model version. If no name is provided, one will be generated.
         lock_level : :mod:`~verta.registry.lock`, default :class:`~verta.registry.lock.Open`

--- a/client/verta/verta/registry/entities/_model.py
+++ b/client/verta/verta/registry/entities/_model.py
@@ -6,7 +6,7 @@ import requests
 from verta._internal_utils._utils import check_unnecessary_params_warning
 from verta.tracking import _Context
 from verta.tracking.entities import _entity
-from verta._internal_utils import _artifact_utils, _utils, model_validator
+from verta._internal_utils import _artifact_utils, _utils, arg_handler, model_validator
 
 from verta._protos.public.common import CommonService_pb2 as _CommonCommonService
 from verta._protos.public.registry import RegistryService_pb2 as _RegistryService
@@ -635,6 +635,8 @@ class RegisteredModel(_entity._ModelDBEntity):
         :class:`~verta.registry.entities.RegisteredModelVersion`
 
         """
+        run_id = arg_handler.extract_id(run_id)
+
         ctx = _Context(self._conn, self._conf)
         ctx.registered_model = self
         return RegisteredModelVersion._create(


### PR DESCRIPTION
Because a method that says `from_run()` ought to be able to take a run.

## Tests
```bash
$ pytest test_model_registry/test_model_version.py::TestMDBIntegration::test_from_run
==================================================== test session starts ====================================================
platform darwin -- Python 2.7.18, pytest-4.6.11, py-1.10.0, pluggy-0.13.1
rootdir: /Users/miliu/Documents/modeldb/client/verta/tests, inifile: pytest.ini
plugins: hypothesis-4.57.1
collected 1 item                                                                                                            

test_model_registry/test_model_version.py .                                                                           [100%]

=========================================== 1 passed, 4 warnings in 31.85 seconds ===========================================
```