### PR TITLE
Fix internal server error while recreating session factory due to JMX Management Beans creation internally by hibernate

### DIFF
--- a/backend/src/main/java/ai/verta/modeldb/utils/ModelDBUtils.java
+++ b/backend/src/main/java/ai/verta/modeldb/utils/ModelDBUtils.java
@@ -377,15 +377,6 @@ public class ModelDBUtils {
       LOGGER.warn(
           "Detected communication exception of type {}",
           communicationsException.getCause().getClass());
-      ModelDBHibernateUtil modelDBHibernateUtil = ModelDBHibernateUtil.getInstance();
-      if (modelDBHibernateUtil.checkDBConnection()) {
-        LOGGER.info("Resetting session Factory");
-
-        modelDBHibernateUtil.resetSessionFactory();
-        LOGGER.info("Resetted session Factory");
-      } else {
-        LOGGER.warn("DB could not be reached");
-      }
       return true;
     } else if ((communicationsException.getCause() instanceof LockAcquisitionException)) {
       LOGGER.warn(communicationsException.getMessage());


### PR DESCRIPTION
**Jira Ticket:** https://vertaai.atlassian.net/browse/VR-12137

**Issue:** We have added `hibernate.hikari.registerMbeans=true` when we are creating session factory, but when we are recreating session factory it will complaining for already created beans randomly.

**Errors:**
```
Jul 19, 2021 @ 23:01:13.416 | ERROR | hibernate - JMX name (hibernate) is already registered.
```
and 
```
{"thread":"pool-3-thread-2","level":"ERROR","loggerName":"ai.verta.modeldb.common.CommonUtils","message":"Stacktrace with 48 elements for class org.hibernate.HibernateException Unable to register MBean [ON=org.hibernate.core:sessionFactory=null,serviceRole=org.hibernate.stat.spi.StatisticsImplementor,serviceType=org.hibernate.stat.internal.StatisticsImpl]","endOfBatch":false,"loggerFqcn":"org.apache.logging.log4j.spi.AbstractLogger","instant":{"epochSecond":1626715873,"nanoOfSecond":690839902},"threadId":143,"threadPriority":5,"source":{"class":"ai.verta.modeldb.common.CommonUtils","method":"logError","file":"CommonUtils.java","line":111},"hostName":"registry--backend-54f8f98789-2zz7p","kubernetes.podIP":""}
```

**Solution:** Modify logic to stop recreating session factory and used existing one with checking DB connection status so no need to re-initialize session factory so it will fix all problem related to re-create session factory.