### PR TITLE
Clean up JDBI tracing

### DIFF
--- a/backend/common/src/main/java/ai/verta/modeldb/common/config/Config.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/config/Config.java
@@ -14,6 +14,7 @@ import io.opentracing.contrib.grpc.ActiveSpanSource;
 import io.opentracing.contrib.grpc.TracingClientInterceptor;
 import io.opentracing.contrib.grpc.TracingServerInterceptor;
 import io.opentracing.contrib.jdbc.TracingDriver;
+import io.opentracing.contrib.jdbi3.OpentracingJdbi3Plugin;
 import io.opentracing.util.GlobalTracer;
 import java.io.FileInputStream;
 import java.io.InputStream;
@@ -134,7 +135,7 @@ public abstract class Config {
     hikariDataSource.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory());
     hikariDataSource.setPoolName(poolName);
 
-    final Jdbi jdbi = Jdbi.create(hikariDataSource).installPlugins();
+    final Jdbi jdbi = Jdbi.create(hikariDataSource).installPlugin(new OpentracingJdbi3Plugin(GlobalTracer.get()));
     return jdbi;
   }
 

--- a/backend/common/src/main/java/ai/verta/modeldb/common/config/Config.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/config/Config.java
@@ -134,10 +134,6 @@ public abstract class Config {
     hikariDataSource.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory());
     hikariDataSource.setPoolName(poolName);
 
-    if (enableTrace) {
-      final var tracer = Configuration.fromEnv().getTracer();
-      GlobalTracer.registerIfAbsent(tracer);
-    }
     final Jdbi jdbi = Jdbi.create(hikariDataSource).installPlugins();
     return jdbi;
   }

--- a/backend/common/src/main/java/ai/verta/modeldb/common/config/Config.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/config/Config.java
@@ -136,7 +136,7 @@ public abstract class Config {
     hikariDataSource.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory());
     hikariDataSource.setPoolName(poolName);
 
-    final Jdbi jdbi = Jdbi.create(hikariDataSource).installPlugin(new OpentracingJdbi3Plugin(GlobalTracer.get()));
+    final Jdbi jdbi = Jdbi.create(hikariDataSource).installPlugins();
     return jdbi;
   }
 

--- a/backend/common/src/main/java/ai/verta/modeldb/common/config/Config.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/config/Config.java
@@ -92,7 +92,7 @@ public abstract class Config {
     if (tracingServerInterceptor == null) {
       Tracer tracer = Configuration.fromEnv().getTracer();
       tracingServerInterceptor = TracingServerInterceptor.newBuilder().withTracer(tracer).build();
-      GlobalTracer.register(tracer);
+      GlobalTracer.registerIfAbsent(tracer);
       TracingDriver.load();
       TracingDriver.setInterceptorMode(true);
       TracingDriver.setInterceptorProperty(true);
@@ -124,6 +124,7 @@ public abstract class Config {
   }
 
   public Jdbi initializeJdbi(DatabaseConfig databaseConfig, String poolName) {
+    initializeTracing();
     final var hikariDataSource = new HikariDataSource();
     final var dbUrl = RdbConfig.buildDatabaseConnectionString(databaseConfig.RdbConfiguration);
     hikariDataSource.setJdbcUrl(dbUrl);


### PR DESCRIPTION
- Remove JDBI creation of trace context
- Call `initializeTracing` at the top of `initializeJdbi`
- Replace deprecated call to `GlobalTracer.register` with `GlobalTracer.registerIfAbsent`