### PR TITLE
[VR-11805] fix _promote_naive_to_utc() to handle naive datetimes in Python 2

### DIFF
--- a/client/verta/verta/_internal_utils/time_utils/__init__.py
+++ b/client/verta/verta/_internal_utils/time_utils/__init__.py
@@ -39,7 +39,7 @@ def epoch_millis(dt):
 def _promote_naive_to_utc(dt):
     if dt.tzinfo is None:
         warnings.warn("Time zone naive datetime found, assuming UTC time zone")
-        return dt.astimezone(utc)
+        return dt.replace(tzinfo=utc)
     else:
         return dt
 


### PR DESCRIPTION
### Description

- Replaces `astimezone` with `replace` for correct conversion of naive datetime objects.

From the [docs](https://docs.python.org/2.7/library/datetime.html)
> If you merely want to attach a time zone object tz to a datetime dt without adjustment of date and time data, use dt.replace(tzinfo=tz). If you merely want to remove the time zone object from an aware datetime dt without conversion of date and time data, use dt.replace(tzinfo=None).

### Testing
````
(verta-py2) daniel@Daniels-MacBook-Pro verta % pytest tests/test_utils/test_time_utils.py
============================================================================== test session starts ===============================================================================
platform darwin -- Python 2.7.18, pytest-4.6.11, py-1.10.0, pluggy-0.13.1
rootdir: /Users/daniel/workspace/modeldb/client/verta/tests, inifile: pytest.ini
plugins: hypothesis-4.57.1
collected 14 items

tests/test_utils/test_time_utils.py ..............                                                                                                                         [100%]

=========================================================================== 14 passed in 1.56 seconds ============================================================================
```