### PR TITLE
Mention that std lib should not be included in custom_modules

### DIFF
--- a/client/verta/verta/tracking/entities/_deployable_entity.py
+++ b/client/verta/verta/tracking/entities/_deployable_entity.py
@@ -88,9 +88,7 @@ class _DeployableEntity(_ModelDBEntity):
                 - ``str`` path to a file or directory
                 - arbitrary ``pickle``\ able object
         custom_modules : list of str, optional
-            Paths to local Python modules and other files that the deployed
-            model depends on. Modules from the standard library should not be
-            included here.
+            Paths to local Python modules and other files that the deployed model depends on.
                 - If directories are provided, all files within—excluding virtual environments—will
                   be included.
                 - If module names are provided, all files within the corresponding module inside a

--- a/client/verta/verta/tracking/entities/_deployable_entity.py
+++ b/client/verta/verta/tracking/entities/_deployable_entity.py
@@ -88,7 +88,9 @@ class _DeployableEntity(_ModelDBEntity):
                 - ``str`` path to a file or directory
                 - arbitrary ``pickle``\ able object
         custom_modules : list of str, optional
-            Paths to local Python modules and other files that the deployed model depends on.
+            Paths to local Python modules and other files that the deployed
+            model depends on. Modules from the standard library should not be
+            included here.
                 - If directories are provided, all files within—excluding virtual environments—will
                   be included.
                 - If module names are provided, all files within the corresponding module inside a


### PR DESCRIPTION
Python can determine when an object is coming from the standard library (assuming there was an `import` statement either in the original script or within the model itself) without needing to include it in `custom_modules`.