### PR TITLE
[VR-12200] Batch request in log_training_data_profile()

### DIFF
--- a/client/verta/tests/monitoring/strategies.py
+++ b/client/verta/tests/monitoring/strategies.py
@@ -1,10 +1,15 @@
 # -*- coding: utf-8 -*-
 
+import string
+
 import hypothesis
 import hypothesis.strategies as st
 import pytest
+
 from verta._protos.public.monitoring.Summary_pb2 import AggregationQuerySummary
 from verta.monitoring.summaries.aggregation import Aggregation
+from verta.registry.entities import RegisteredModelVersion
+
 from ..time_strategies import millis_timedelta_strategy, millis_uint64_strategy
 
 ProtoOperations = AggregationQuerySummary.AggregationOperation
@@ -149,7 +154,7 @@ def dataframes(draw, min_rows=0, max_rows=2 ** 8, min_cols=0, max_cols=2 ** 8):
             st.text(),
             min_size=len(col_types),
             max_size=len(col_types),
-            unique=True,
+            unique_by=RegisteredModelVersion._normalize_attribute_key,
         )
     )
 

--- a/client/verta/tests/monitoring/strategies.py
+++ b/client/verta/tests/monitoring/strategies.py
@@ -88,7 +88,7 @@ def series(draw, num_rows, data_type, name=None, has_missing=True):
 
 
 @st.composite
-def dataframes(draw):
+def simple_dataframes(draw):
     """Generate DataFrames with a "continuous" and "discrete" column.
 
     Returns
@@ -115,4 +115,48 @@ def dataframes(draw):
             continuous_col: continuous_series,
             discrete_col: discrete_series,
         }
+    )
+
+
+@st.composite
+def dataframes(draw, min_rows=0, max_rows=2 ** 8, min_cols=0, max_cols=2 ** 8):
+    """Generate DataFrames containing discrete and continuous columns.
+
+    Parameters
+    ----------
+    min_rows : int, default 0
+    max_rows : int, default 2^8
+    min_cols : int, default 0
+    max_cols : int, default 2^8
+
+    Returns
+    -------
+    pd.DataFrame
+
+    """
+    pd = pytest.importorskip("pandas")
+
+    num_rows = draw(st.integers(min_value=min_rows, max_value=max_rows))
+    col_types = draw(
+        st.lists(
+            st.sampled_from(["continuous", "discrete"]),
+            min_size=min_cols,
+            max_size=max_cols,
+        )
+    )
+    col_names = draw(
+        st.lists(
+            st.text(),
+            min_size=len(col_types),
+            max_size=len(col_types),
+            unique=True,
+        )
+    )
+
+    return pd.concat(
+        [
+            draw(series(num_rows, col_type, col_name))
+            for col_type, col_name in zip(col_types, col_names)
+        ],
+        axis="columns",
     )

--- a/client/verta/tests/monitoring/strategies.py
+++ b/client/verta/tests/monitoring/strategies.py
@@ -154,6 +154,9 @@ def dataframes(draw, min_rows=0, max_rows=2 ** 8, min_cols=0, max_cols=2 ** 8):
             st.text(),
             min_size=len(col_types),
             max_size=len(col_types),
+            # the following line is required otherwise log_training_data_proflie()
+            # tests in TestAutoMonitoring fail with columns that get normalized
+            # to the same attribute key (VR-12274 to resolve)
             unique_by=RegisteredModelVersion._normalize_attribute_key,
         )
     )

--- a/client/verta/tests/monitoring/test_profilers.py
+++ b/client/verta/tests/monitoring/test_profilers.py
@@ -19,7 +19,7 @@ from . import strategies
 class TestProfilers:
     @hypothesis.settings(deadline=None)  # building DataFrames can be slow
     @hypothesis.given(
-        df=strategies.dataframes(),  # pylint: disable=no-value-for-parameter
+        df=strategies.simple_dataframes(),  # pylint: disable=no-value-for-parameter
     )
     def test_continuous(self, df):
         np = pytest.importorskip("numpy")
@@ -42,7 +42,7 @@ class TestProfilers:
 
     @hypothesis.settings(deadline=None)  # building DataFrames can be slow
     @hypothesis.given(
-        df=strategies.dataframes(),  # pylint: disable=no-value-for-parameter
+        df=strategies.simple_dataframes(),  # pylint: disable=no-value-for-parameter
     )
     def test_discrete(self, df):
         cols = ["discrete"]
@@ -63,7 +63,7 @@ class TestProfilers:
 
     @hypothesis.settings(deadline=None)  # building DataFrames can be slow
     @hypothesis.given(
-        df=strategies.dataframes(),  # pylint: disable=no-value-for-parameter
+        df=strategies.simple_dataframes(),  # pylint: disable=no-value-for-parameter
     )
     def test_missing(self, df):
         cols = ["continuous", "discrete"]

--- a/client/verta/tests/test_model_registry/test_model_version.py
+++ b/client/verta/tests/test_model_registry/test_model_version.py
@@ -944,11 +944,11 @@ class TestAutoMonitoring:
 
     @hypothesis.settings(deadline=None)  # building DataFrames can be slow
     @hypothesis.given(
-        df=strategies.dataframes(),  # pylint: disable=no-value-for-parameter
+        df=strategies.simple_dataframes(),  # pylint: disable=no-value-for-parameter
         labels=st.dictionaries(st.text(), st.text()),
     )
     def test_create_summaries(self, df, labels):
-        """Unit test for the profiling helper functions."""
+        """Unit test for the exact expected output of discrete & continuous columns."""
         pytest.importorskip("numpy")
 
         # missing

--- a/client/verta/tests/test_model_registry/test_model_version.py
+++ b/client/verta/tests/test_model_registry/test_model_version.py
@@ -1054,7 +1054,10 @@ class TestAutoMonitoring:
                     sample_key = feature_data.feature_name + "MissingValues"
                 else:
                     sample_key = feature_data.feature_name + "Distribution"
-                sample_key = RegisteredModelVersion._normalize_attribute_key(sample_key)
+                sample_key = (
+                    _deployable_entity._TRAINING_DATA_ATTR_PREFIX
+                    + RegisteredModelVersion._normalize_attribute_key(sample_key)
+                )
                 assert feature_data_attrs[sample_key] == json.loads(feature_data.content)
 
     def test_profile_training_data(self, model_version):
@@ -1122,7 +1125,11 @@ class TestAutoMonitoring:
 
         # reference distribution attributes can be fetched back as histograms
         for col in supported_col_names:
-            key = col + "Distribution"
+            key = (
+                _deployable_entity._TRAINING_DATA_ATTR_PREFIX
+                + col
+                + "Distribution"
+            )
             histogram = model_version.get_attribute(key)
             assert isinstance(histogram, _verta_data_type._VertaDataType)
 

--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -1414,6 +1414,10 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
                     "`in_df` and `out_df` must be of type pd.DataFrame,"
                     " not {}".format(type(df))
                 )
+            if not (len(in_df) and len(out_df)):
+                raise ValueError(
+                    "`in_df` and `out_df` must both have at least one row"
+                )
             if not all(isinstance(col, six.string_types) for col in df.columns):
                 # helper fns run into type errors handling non-str column names
                 # TODO: try to resolve this restriction

--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -1365,7 +1365,10 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
             logger.info("collecting feature %s", feature_data.feature_name)
             feature_data_key = _deployable_entity._FEATURE_DATA_ATTR_PREFIX + str(i)
             feature_data_val = _utils.proto_to_json(feature_data, False)
-            sample_key = cls._normalize_attribute_key(feature_data.summary_name)
+            sample_key = (
+                _deployable_entity._TRAINING_DATA_ATTR_PREFIX
+                + cls._normalize_attribute_key(feature_data.summary_name)
+            )
             sample_val = json.loads(feature_data.content)
 
             attributes.update(

--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -1301,7 +1301,7 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
 
         Returns
         -------
-        list of DeploymentIntegration_pb2.FeatureDataInModelVersion
+        feature_data_list : list of DeploymentIntegration_pb2.FeatureDataInModelVersion
             DataFrame feature data.
 
         """
@@ -1345,28 +1345,37 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
 
         return feature_data_list
 
-    def _log_feature_data_and_vis_attributes(self, feature_data_list):
-        """Log DataFrame feature data as attributes.
+    @classmethod
+    def _collect_feature_data_and_vis_attributes(cls, feature_data_list):
+        """Convert DataFrame feature data into serialized representations.
 
         Parameters
         ----------
         feature_data_list : list of DeploymentIntegration_pb2.FeatureDataInModelVersion
 
+        Returns
+        -------
+        feature_data_attrs : dict
+            Feature data, ready to add as attributes.
+
         """
-        def log_attribute(i, feature_data):
-            logger.info("logging feature %s", feature_data.feature_name)
-            self.add_attribute(
-                _deployable_entity._FEATURE_DATA_ATTR_PREFIX + str(i),
-                _utils.proto_to_json(feature_data, False),
-            )
-            self.add_attribute(
-                self._normalize_attribute_key(feature_data.summary_name),
-                json.loads(feature_data.content),
+        attributes = dict()
+
+        for i, feature_data in enumerate(feature_data_list):
+            logger.info("collecting feature %s", feature_data.feature_name)
+            feature_data_key = _deployable_entity._FEATURE_DATA_ATTR_PREFIX + str(i)
+            feature_data_val = _utils.proto_to_json(feature_data, False)
+            sample_key = cls._normalize_attribute_key(feature_data.summary_name)
+            sample_val = json.loads(feature_data.content)
+
+            attributes.update(
+                {
+                    feature_data_key: feature_data_val,
+                    sample_key: sample_val,
+                }
             )
 
-        p = ThreadPool(1)
-        p.map(lambda args: log_attribute(*args), enumerate(feature_data_list))
-        p.close()
+        return attributes
 
     def log_training_data_profile(self, in_df, out_df):
         """Capture the profiles of training input and output data.
@@ -1416,4 +1425,5 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
         feature_data_list = self._compute_training_data_profile(
             in_df, out_df,
         )
-        self._log_feature_data_and_vis_attributes(feature_data_list)
+        attrs = self._collect_feature_data_and_vis_attributes(feature_data_list)
+        self.add_attributes(attrs)

--- a/client/verta/verta/tracking/entities/_deployable_entity.py
+++ b/client/verta/verta/tracking/entities/_deployable_entity.py
@@ -40,6 +40,7 @@ _CACHE_DIR = os.path.join(
 
 _INTERNAL_ATTR_PREFIX = "__verta_"
 _FEATURE_DATA_ATTR_PREFIX = _INTERNAL_ATTR_PREFIX + "feature_data_"
+_TRAINING_DATA_ATTR_PREFIX = _INTERNAL_ATTR_PREFIX + "training_data_"
 
 
 @six.add_metaclass(abc.ABCMeta)


### PR DESCRIPTION
> I am pleased to report that batching log_training_data_profile() for a dataframe with 100 columns brings the runtime from 10 minutes down to 5 seconds

—me

## Changes

- change `_log_feature_data_and_vis_attributes()` to `_collect_feature_data_and_vis_attributes()`, which locally batches attributes to be sent in a single request
- rename `dataframes` fixture to `simple_dataframes`
- create new, more general `dataframes` fixture
- add two property tests for `log_training_data_profile()` helper functions

## Tests
```sh
$ pytest test_model_registry/test_model_version.py::TestAutoMonitoring::test_compute_training_data_profile \
> test_model_registry/test_model_version.py::TestAutoMonitoring::test_collect_feature_data_and_vis_attributes
==================================================== test session starts ====================================================
platform darwin -- Python 3.7.10, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /Users/miliu/Documents/modeldb/client/verta/tests, configfile: pytest.ini
plugins: hypothesis-6.14.0
collected 2 items                                                                                                           

test_model_registry/test_model_version.py ..                                                                          [100%]

============================================== 2 passed, 5 warnings in 38.65s ===============================================
```