### PR TITLE
Fix stale data related test cases

### DIFF
--- a/backend/src/test/java/ai/verta/modeldb/CommitTest.java
+++ b/backend/src/test/java/ai/verta/modeldb/CommitTest.java
@@ -81,6 +81,7 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.After;
@@ -1891,9 +1892,11 @@ public class CommitTest extends TestsInit {
   public void FindRepositoryBlobsTest() throws ModelDBException, NoSuchAlgorithmException {
     LOGGER.info("Find repository blobs test start................................");
 
+    List<BlobExpanded> blobsList = new ArrayList<>();
     List<IdentificationType> labelIds = new ArrayList<>();
     CreateCommitRequest createCommitRequest =
         getCreateCommitRequest(repository.getId(), 111, initialCommit, Blob.ContentCase.CONFIG);
+    blobsList.add(createCommitRequest.getBlobs(0));
     CreateCommitRequest.Response commitResponse =
         versioningServiceBlockingStub.createCommit(createCommitRequest);
     Commit configCommit = commitResponse.getCommit();
@@ -1938,6 +1941,7 @@ public class CommitTest extends TestsInit {
                       .addAllLocation(location.getLocationList())
                       .build())
               .build();
+      blobsList.add(createCommitRequest.getBlobs(0));
 
       commitResponse = versioningServiceBlockingStub.createCommit(createCommitRequest);
       Commit datasetCommit = commitResponse.getCommit();
@@ -2045,12 +2049,16 @@ public class CommitTest extends TestsInit {
 
         listCommitBlobsResponse =
             versioningServiceBlockingStub.findRepositoriesBlobs(findRepositoriesBlobs);
-        Assert.assertEquals(
-            "blob count not match with expected blob count",
-            2,
-            listCommitBlobsResponse.getBlobsCount());
-        boolean match = false;
+        Set<BlobExpanded> blobSet = new HashSet<>();
         for (BlobExpanded blobExpanded : listCommitBlobsResponse.getBlobsList()) {
+          if (blobsList.contains(blobExpanded)) {
+            blobSet.add(blobExpanded);
+          }
+        }
+        Assert.assertEquals(
+            "blob count not match with expected blob count", blobsList.size(), blobSet.size());
+        boolean match = false;
+        for (BlobExpanded blobExpanded : blobSet) {
           if (datasetBlob.equals(blobExpanded.getBlob())) {
             match = true;
           }

--- a/backend/src/test/java/ai/verta/modeldb/FindDatasetEntitiesTest.java
+++ b/backend/src/test/java/ai/verta/modeldb/FindDatasetEntitiesTest.java
@@ -422,8 +422,6 @@ public class FindDatasetEntitiesTest extends TestsInit {
   public void findDatasetsByAttributesTest() {
     LOGGER.info("FindDatasets by attribute test start................................");
 
-    DatasetTest datasetTest = new DatasetTest();
-
     // get dataset with value of attributes.attribute_1 <= 0.6543210
     Value numValue = Value.newBuilder().setNumberValue(0.6543210).build();
     KeyValueQuery keyValueQuery =
@@ -436,18 +434,16 @@ public class FindDatasetEntitiesTest extends TestsInit {
     FindDatasets findDatasets = FindDatasets.newBuilder().addPredicates(keyValueQuery).build();
 
     FindDatasets.Response response = datasetServiceStub.findDatasets(findDatasets);
-    LOGGER.info("FindDatasets Response : " + response.getDatasetsList());
-    assertEquals(
-        "Dataset count not match with expected dataset count",
-        3,
-        response.getDatasetsList().size());
+    List<Dataset> expectedDatasets = new ArrayList<>();
+    for (Dataset dataset : response.getDatasetsList()) {
+      if (datasetMap.containsKey(dataset.getId())) {
+        expectedDatasets.add(dataset);
+      }
+    }
+    LOGGER.info("FindDatasets Response : " + expectedDatasets.size());
+    assertEquals("Dataset count not match with expected dataset count", 3, expectedDatasets.size());
 
-    assertEquals(
-        "Total records count not matched with expected records count",
-        3,
-        response.getTotalRecords());
-
-    for (Dataset fetchedDataset : response.getDatasetsList()) {
+    for (Dataset fetchedDataset : expectedDatasets) {
       boolean doesAttributeExist = false;
       for (KeyValue fetchedAttribute : fetchedDataset.getAttributesList()) {
         if (fetchedAttribute.getKey().equals("attribute_1")) {
@@ -997,11 +993,6 @@ public class FindDatasetEntitiesTest extends TestsInit {
         3,
         expectedDatasetVersions.size());
 
-    assertEquals(
-        "Total records count not matched with expected records count",
-        3,
-        response.getTotalRecords());
-
     numValue = Value.newBuilder().setStringValue("0.6543210").build();
     keyValueQuery =
         KeyValueQuery.newBuilder()
@@ -1018,15 +1009,16 @@ public class FindDatasetEntitiesTest extends TestsInit {
 
     response = datasetVersionServiceStub.findDatasetVersions(findDatasetVersions);
     LOGGER.info("FindDatasetVersions Response : " + response.getDatasetVersionsList());
+    expectedDatasetVersions = new ArrayList<>();
+    for (DatasetVersion datasetVersion : response.getDatasetVersionsList()) {
+      if (datasetVersionMap.containsKey(datasetVersion.getId())) {
+        expectedDatasetVersions.add(datasetVersion);
+      }
+    }
     assertEquals(
         "DatasetVersion count not match with expected datasetVersion count",
         3,
-        response.getDatasetVersionsList().size());
-
-    assertEquals(
-        "Total records count not matched with expected records count",
-        3,
-        response.getTotalRecords());
+        expectedDatasetVersions.size());
 
     LOGGER.info("FindDatasetVersions by attribute test stop................................");
   }
@@ -1408,20 +1400,25 @@ public class FindDatasetEntitiesTest extends TestsInit {
     FindDatasets findDatasets = FindDatasets.newBuilder().build();
 
     FindDatasets.Response response = datasetServiceStub.findDatasets(findDatasets);
-    LOGGER.info("FindDatasets Response : " + response.getDatasetsCount());
+    List<Dataset> expectedDatasets = new ArrayList<>();
+    for (Dataset dataset : response.getDatasetsList()) {
+      if (datasetMap.containsKey(dataset.getId())) {
+        expectedDatasets.add(dataset);
+      }
+    }
+    LOGGER.info("FindDatasets Response : " + expectedDatasets.size());
+
     assertEquals(
         "Total records count not matched with expected records count",
         datasetMap.size(),
-        response.getTotalRecords());
+        expectedDatasets.size());
 
-    response
-        .getDatasetsList()
-        .forEach(
-            dataset -> {
-              if (dataset.getId().equals(String.valueOf(id))) {
-                fail("Regular repository should not visible in protected repository list");
-              }
-            });
+    expectedDatasets.forEach(
+        dataset -> {
+          if (dataset.getId().equals(String.valueOf(id))) {
+            fail("Regular repository should not visible in protected repository list");
+          }
+        });
 
     DeleteRepositoryRequest deleteRepository =
         DeleteRepositoryRequest.newBuilder()

--- a/backend/src/test/java/ai/verta/modeldb/FindProjectEntitiesTest.java
+++ b/backend/src/test/java/ai/verta/modeldb/FindProjectEntitiesTest.java
@@ -2517,16 +2517,14 @@ public class FindProjectEntitiesTest extends TestsInit {
     FindProjects findProjects = FindProjects.newBuilder().addPredicates(keyValueQuery).build();
 
     FindProjects.Response response = projectServiceStub.findProjects(findProjects);
-    LOGGER.info("FindProjects Response : " + response.getProjectsList());
-    assertEquals(
-        "Project count not match with expected project count",
-        4,
-        response.getProjectsList().size());
-
-    assertEquals(
-        "Total records count not matched with expected records count",
-        4,
-        response.getTotalRecords());
+    List<Project> projectList = new ArrayList<>();
+    for (Project project : response.getProjectsList()) {
+      if (projectMap.containsKey(project.getId())) {
+        projectList.add(project);
+      }
+    }
+    LOGGER.info("FindProjects Response : " + projectList.size());
+    assertEquals("Project count not match with expected project count", 4, projectList.size());
 
     keyValueQuery =
         KeyValueQuery.newBuilder()
@@ -2537,12 +2535,14 @@ public class FindProjectEntitiesTest extends TestsInit {
     findProjects = FindProjects.newBuilder().addPredicates(keyValueQuery).build();
 
     response = projectServiceStub.findProjects(findProjects);
+    projectList = new ArrayList<>();
+    for (Project project : response.getProjectsList()) {
+      if (projectMap.containsKey(project.getId())) {
+        projectList.add(project);
+      }
+    }
     assertEquals(
-        "Total records count not matched with expected records count",
-        0,
-        response.getTotalRecords());
-    assertEquals(
-        "Project count not match with expected project count", 0, response.getProjectsCount());
+        "Total records count not matched with expected records count", 0, projectList.size());
 
     stringValue = Value.newBuilder().setStringValue("asdasdasd").build();
     keyValueQuery =
@@ -2555,11 +2555,14 @@ public class FindProjectEntitiesTest extends TestsInit {
     findProjects = FindProjects.newBuilder().addPredicates(keyValueQuery).build();
 
     response = projectServiceStub.findProjects(findProjects);
-    LOGGER.info("FindProjects Response : " + response.getProjectsList());
-    assertEquals(
-        "Project count not match with expected project count",
-        0,
-        response.getProjectsList().size());
+    projectList = new ArrayList<>();
+    for (Project project : response.getProjectsList()) {
+      if (projectMap.containsKey(project.getId())) {
+        projectList.add(project);
+      }
+    }
+    LOGGER.info("FindProjects Response : " + projectList.size());
+    assertEquals("Project count not match with expected project count", 0, projectList.size());
 
     LOGGER.info("FindProjects by owner fuzzy search test stop ................................");
   }

--- a/backend/src/test/java/ai/verta/modeldb/HydratedServiceTest.java
+++ b/backend/src/test/java/ai/verta/modeldb/HydratedServiceTest.java
@@ -2196,16 +2196,14 @@ public class HydratedServiceTest extends TestsInit {
     LOGGER.info("GetHydratedProjects Count : " + response.getTotalRecords());
     List<Project> projectList = new ArrayList<>();
     for (HydratedProject hydratedProject : response.getHydratedProjectsList()) {
-      projectList.add(hydratedProject.getProject());
+      if (projectsMap.containsKey(hydratedProject.getProject().getId())) {
+        projectList.add(hydratedProject.getProject());
+      }
     }
     assertEquals(
         "HydratedProjects count not match with expected HydratedProjects count",
         projectsMap.size(),
         projectList.size());
-    assertEquals(
-        "Projects count not match with expected projects count",
-        projectsMap.size(),
-        response.getTotalRecords());
 
     for (Project project : projectList) {
       if (projectsMap.get(project.getId()) == null) {
@@ -2227,14 +2225,11 @@ public class HydratedServiceTest extends TestsInit {
       GetHydratedProjects.Response hydratedProjectsResponse =
           hydratedServiceBlockingStub.getHydratedProjects(getHydratedProjects);
 
-      assertEquals(
-          "Total records count not matched with expected records count",
-          experimentMap.size(),
-          hydratedProjectsResponse.getTotalRecords());
-
       projectList = new ArrayList<>();
       for (HydratedProject hydratedProject : hydratedProjectsResponse.getHydratedProjectsList()) {
-        projectList.add(hydratedProject.getProject());
+        if (projectsMap.containsKey(hydratedProject.getProject().getId())) {
+          projectList.add(hydratedProject.getProject());
+        }
       }
 
       if (!projectList.isEmpty()) {

--- a/backend/src/test/java/ai/verta/modeldb/ProjectTest.java
+++ b/backend/src/test/java/ai/verta/modeldb/ProjectTest.java
@@ -27,6 +27,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.After;
@@ -1883,7 +1884,7 @@ public class ProjectTest extends TestsInit {
         assertEquals(Status.INTERNAL.getCode(), status.getCode());
       }
 
-      String shortName = "project-sprt_app";
+      String shortName = ModelDBUtils.convertToProjectShortName(UUID.randomUUID().toString());
       SetProjectShortName setProjectShortName =
           SetProjectShortName.newBuilder().setShortName(shortName).setId(project.getId()).build();
       SetProjectShortName.Response response =
@@ -1915,8 +1916,8 @@ public class ProjectTest extends TestsInit {
       }
     } catch (StatusRuntimeException e) {
       Status status2 = Status.fromThrowable(e);
-      fail();
       LOGGER.error("Error Code : " + status2.getCode() + " Error : " + status2.getDescription());
+      fail(e.getMessage());
     }
 
     LOGGER.info("Set Project short name test stop................................");

--- a/backend/src/test/java/ai/verta/modeldb/RepositoryTest.java
+++ b/backend/src/test/java/ai/verta/modeldb/RepositoryTest.java
@@ -841,16 +841,17 @@ public class RepositoryTest extends TestsInit {
         FindRepositories.newBuilder().addPredicates(keyValueQuery).build();
     FindRepositories.Response findRepositoriesResponse =
         versioningServiceBlockingStub.findRepositories(findRepositoriesRequest);
-    LOGGER.info("FindProjects Response : " + findRepositoriesResponse.getRepositoriesList());
+    List<Repository> repositoryList = new ArrayList<>();
+    for (Repository repository : findRepositoriesResponse.getRepositoriesList()) {
+      if (repositoryMap.containsKey(repository.getId())) {
+        repositoryList.add(repository);
+      }
+    }
+    LOGGER.info("FindProjects Response : " + repositoryList.size());
     assertEquals(
         "Project count not match with expected project count",
         repositoryMap.size(),
-        findRepositoriesResponse.getRepositoriesCount());
-
-    assertEquals(
-        "Total records count not matched with expected records count",
-        repositoryMap.size(),
-        findRepositoriesResponse.getTotalRecords());
+        repositoryList.size());
 
     keyValueQuery =
         KeyValueQuery.newBuilder()
@@ -861,15 +862,14 @@ public class RepositoryTest extends TestsInit {
     findRepositoriesRequest = FindRepositories.newBuilder().addPredicates(keyValueQuery).build();
     findRepositoriesResponse =
         versioningServiceBlockingStub.findRepositories(findRepositoriesRequest);
-    LOGGER.info("FindProjects Response : " + findRepositoriesResponse.getRepositoriesList());
-    assertEquals(
-        "Project count not match with expected project count",
-        0,
-        findRepositoriesResponse.getRepositoriesCount());
-    assertEquals(
-        "Total records count not matched with expected records count",
-        0,
-        findRepositoriesResponse.getTotalRecords());
+    repositoryList = new ArrayList<>();
+    for (Repository repository : findRepositoriesResponse.getRepositoriesList()) {
+      if (repositoryMap.containsKey(repository.getId())) {
+        repositoryList.add(repository);
+      }
+    }
+    LOGGER.info("FindProjects Response : " + repositoryList.size());
+    assertEquals("Project count not match with expected project count", 0, repositoryList.size());
 
     stringValue = Value.newBuilder().setStringValue("asdasdasd").build();
     keyValueQuery =
@@ -882,15 +882,14 @@ public class RepositoryTest extends TestsInit {
     findRepositoriesRequest = FindRepositories.newBuilder().addPredicates(keyValueQuery).build();
     findRepositoriesResponse =
         versioningServiceBlockingStub.findRepositories(findRepositoriesRequest);
-    LOGGER.info("FindProjects Response : " + findRepositoriesResponse.getRepositoriesList());
-    assertEquals(
-        "Project count not match with expected project count",
-        0,
-        findRepositoriesResponse.getRepositoriesCount());
-    assertEquals(
-        "Total records count not matched with expected records count",
-        0,
-        findRepositoriesResponse.getTotalRecords());
+    repositoryList = new ArrayList<>();
+    for (Repository repository : findRepositoriesResponse.getRepositoriesList()) {
+      if (repositoryMap.containsKey(repository.getId())) {
+        repositoryList.add(repository);
+      }
+    }
+    LOGGER.info("FindProjects Response : " + repositoryList.size());
+    assertEquals("Project count not match with expected project count", 0, repositoryList.size());
 
     LOGGER.info("FindRepositories by owner fuzzy search test stop ...");
   }
@@ -926,16 +925,15 @@ public class RepositoryTest extends TestsInit {
         FindRepositories.newBuilder().addPredicates(keyValueQuery).build();
     FindRepositories.Response findRepositoriesResponse =
         versioningServiceBlockingStub.findRepositories(findRepositoriesRequest);
-    LOGGER.info("FindRepositories Response : " + findRepositoriesResponse.getRepositoriesList());
+    List<Repository> repositoryList = new ArrayList<>();
+    for (Repository repository : findRepositoriesResponse.getRepositoriesList()) {
+      if (repositoryMap.containsKey(repository.getId())) {
+        repositoryList.add(repository);
+      }
+    }
+    LOGGER.info("FindRepositories Response : " + repositoryList.size());
     assertEquals(
-        "Repositories count not match with expected Repositories count",
-        3,
-        findRepositoriesResponse.getRepositoriesCount());
-
-    assertEquals(
-        "Total records count not matched with expected records count",
-        3,
-        findRepositoriesResponse.getTotalRecords());
+        "Repositories count not match with expected Repositories count", 3, repositoryList.size());
 
     LOGGER.info("FindRepositories by owner fuzzy search test stop ...");
   }


### PR DESCRIPTION
1. https://jenkins.dev.verta.ai/job/test/job/integration-mdb/544/testReport/junit/ai.verta.modeldb/ProjectTest/q_setProjectShortNameTest/
2. https://jenkins.dev.verta.ai/job/test/job/integration-mdb/544/testReport/junit/ai.verta.modeldb/HydratedServiceTest/getHydratedProjectsByPagination/
3. https://jenkins.dev.verta.ai/job/test/job/integration-mdb/544/testReport/junit/ai.verta.modeldb/FindProjectEntitiesTest/findProjectsByFuzzyOwnerTest/
4. https://jenkins.dev.verta.ai/job/test/job/integration-mdb/544/testReport/junit/ai.verta.modeldb/FindDatasetEntitiesTest/findDatasetVersionsByAttributeTest/
5. https://jenkins.dev.verta.ai/job/test/job/integration-mdb/544/testReport/junit/ai.verta.modeldb/FindDatasetEntitiesTest/findDatasetsByAttributesTest/
6. https://jenkins.dev.verta.ai/job/test/job/integration-mdb/544/testReport/junit/ai.verta.modeldb/FindDatasetEntitiesTest/findDatasetsWithMarkedAsProtectedRepositoryTest/
7. https://jenkins.dev.verta.ai/job/test/job/integration-mdb/544/testReport/junit/ai.verta.modeldb/RepositoryTest/findRepositoriesByFuzzyOwnerTest/
8. https://jenkins.dev.verta.ai/job/test/job/integration-mdb/544/testReport/junit/ai.verta.modeldb/RepositoryTest/findRepositoriesByOwnerArrWithInOperatorTest/
9. https://jenkins.dev.verta.ai/job/test/job/integration-mdb/544/testReport/junit/ai.verta.modeldb/CommitTest/FindRepositoryBlobsTest/