### PR TITLE
Log training data distributions with a special attribute prefix

### DIFF
--- a/client/verta/tests/test_model_registry/test_model_version.py
+++ b/client/verta/tests/test_model_registry/test_model_version.py
@@ -1054,7 +1054,10 @@ class TestAutoMonitoring:
                     sample_key = feature_data.feature_name + "MissingValues"
                 else:
                     sample_key = feature_data.feature_name + "Distribution"
-                sample_key = RegisteredModelVersion._normalize_attribute_key(sample_key)
+                sample_key = (
+                    _deployable_entity._TRAINING_DATA_ATTR_PREFIX
+                    + RegisteredModelVersion._normalize_attribute_key(sample_key)
+                )
                 assert feature_data_attrs[sample_key] == json.loads(feature_data.content)
 
     def test_profile_training_data(self, model_version):
@@ -1122,7 +1125,11 @@ class TestAutoMonitoring:
 
         # reference distribution attributes can be fetched back as histograms
         for col in supported_col_names:
-            key = col + "Distribution"
+            key = (
+                _deployable_entity._TRAINING_DATA_ATTR_PREFIX
+                + col
+                + "Distribution"
+            )
             histogram = model_version.get_attribute(key)
             assert isinstance(histogram, _verta_data_type._VertaDataType)
 

--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -1365,7 +1365,10 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
             logger.info("collecting feature %s", feature_data.feature_name)
             feature_data_key = _deployable_entity._FEATURE_DATA_ATTR_PREFIX + str(i)
             feature_data_val = _utils.proto_to_json(feature_data, False)
-            sample_key = cls._normalize_attribute_key(feature_data.summary_name)
+            sample_key = (
+                _deployable_entity._TRAINING_DATA_ATTR_PREFIX
+                + cls._normalize_attribute_key(feature_data.summary_name)
+            )
             sample_val = json.loads(feature_data.content)
 
             attributes.update(

--- a/client/verta/verta/tracking/entities/_deployable_entity.py
+++ b/client/verta/verta/tracking/entities/_deployable_entity.py
@@ -40,6 +40,7 @@ _CACHE_DIR = os.path.join(
 
 _INTERNAL_ATTR_PREFIX = "__verta_"
 _FEATURE_DATA_ATTR_PREFIX = _INTERNAL_ATTR_PREFIX + "feature_data_"
+_TRAINING_DATA_ATTR_PREFIX = _INTERNAL_ATTR_PREFIX + "training_data_"
 
 
 @six.add_metaclass(abc.ABCMeta)


### PR DESCRIPTION
As of https://github.com/VertaAI/VertaWebApp/pull/2042, the webapp will be expecting training data distributions to be logged with the prefix [`__verta_training_data_`](https://github.com/VertaAI/VertaWebApp/pull/2042/files#diff-40dcc1aec8e6a538768145197f35ab7916c2143ec2c2d5367c28ef3b95b04820R19) to render them in their own dedicated section of the RMV page.

## Tests

```bash
$ pytest test_model_registry/test_model_version.py::TestAutoMonitoring
==================================================== test session starts ====================================================
platform darwin -- Python 3.7.10, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /Users/miliu/Documents/modeldb/client/verta/tests, configfile: pytest.ini
plugins: hypothesis-6.14.0
collected 6 items                                                                                                           

test_model_registry/test_model_version.py ......                                                                      [100%]

============================================== 6 passed, 8 warnings in 52.94s ===============================================
```