### PR TITLE
[VR-12278] Fix bug where repr(endpoint) errors if Kafka features are not available

### DIFF
--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -1110,6 +1110,9 @@ class Client(object):
 
         An accessible endpoint with name `name` will be created and initialized with specified metadata parameters.
 
+        .. versionadded:: 0.19.0
+            The `kafka_settings` parameter.
+
         Parameters
         ----------
         path : str

--- a/client/verta/verta/endpoint/_endpoint.py
+++ b/client/verta/verta/endpoint/_endpoint.py
@@ -419,6 +419,8 @@ class Endpoint(object):
             stage_id,
         )
         response = _utils.make_request("GET", url, self._conn)
+        if response.status_code == 403:  # Kafka not available in platform
+            return None
         _utils.raise_for_http_error(response)
 
         kafka_settings_dict = response.json().get("update_request", {})

--- a/client/verta/verta/endpoint/_endpoint.py
+++ b/client/verta/verta/endpoint/_endpoint.py
@@ -42,6 +42,9 @@ class Endpoint(object):
     :meth:`Client.get_or_create_endpoint()
     <verta.Client.get_or_create_endpoint>`.
 
+    .. versionadded:: 0.19.0
+        The `kafka_settings` attribute.
+
     Attributes
     ----------
     id : int
@@ -237,6 +240,9 @@ class Endpoint(object):
     ):
         """
         Updates the endpoint with a model logged in an Experiment Run or a Model Version.
+
+        .. versionadded:: 0.19.0
+            The `kafka_settings` parameter.
 
         Parameters
         ----------

--- a/client/verta/verta/endpoint/_kafka_settings.py
+++ b/client/verta/verta/endpoint/_kafka_settings.py
@@ -7,6 +7,8 @@ class KafkaSettings(object):
     """
     A set of topics to be used with deployed endpoints.
 
+    .. versionadded:: 0.19.0
+
     Attributes
     ----------
     input_topic : str

--- a/client/verta/verta/endpoint/_kafka_settings.py
+++ b/client/verta/verta/endpoint/_kafka_settings.py
@@ -24,7 +24,15 @@ class KafkaSettings(object):
 
         from verta.endpoint import KafkaSettings
 
-        kafka_settings = KafkaSettings("my_input_data", "my_predictions", "my_endpoint_errors")
+        kafka_settings = KafkaSettings(
+            input_topic="my_input_data",
+            output_topic="my_predictions",
+            error_topic="my_endpoint_errors",
+        )
+
+        endpoint = client.create_endpoint(path="/my-endpoint", kafka_settings=kafka_settings)
+        print(endpoint.kafka_settings)
+
     """
 
     def __init__(self, input_topic, output_topic, error_topic):


### PR DESCRIPTION
Also upgraded docstrings while I was at it.

### Before

```python
> repr(endpoint)
~/Documents/modeldb/client/verta/verta/endpoint/_endpoint.py in __repr__(self)
     78                 "curl: {}".format(curl),
     79                 "status: {}".format(status["status"]),
---> 80                 "Kafka settings: {}".format(self.kafka_settings),
     81                 "date created: {}".format(data["date_created"]),
     82                 "date updated: {}".format(data["date_updated"]),

...

HTTPError: 403 Client Error: Forbidden for url:
https://app.verta.ai/api/v1/deployment/stages/990126/kafka
at 2021-07-28 21:55:08.047000 UTC
```

### After

```python
> repr(endpoint)
path: /ml-test
url: https://app.verta.ai/Michael_Verta/endpoints/390008/summary
id: 390008
curl: <endpoint not deployed>
status: inactive
Kafka settings: None
date created: 2021-07-28T21:51:35.000Z
date updated: 2021-07-28T21:51:36.000Z
stage's date created: 2021-07-28T21:51:36.000Z
stage's date updated: 2021-07-28T21:51:41.000Z
components: []
```