### PR TITLE
Add instrumentation to JDBI to allow query capture

### DIFF
--- a/backend/common/src/main/java/ai/verta/modeldb/common/config/Config.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/config/Config.java
@@ -15,6 +15,7 @@ import io.opentracing.contrib.grpc.TracingClientInterceptor;
 import io.opentracing.contrib.grpc.TracingServerInterceptor;
 import io.opentracing.contrib.jdbc.TracingDriver;
 import io.opentracing.contrib.jdbi3.OpentracingJdbi3Plugin;
+import io.opentracing.contrib.jdbi3.OpentracingSqlLogger;
 import io.opentracing.util.GlobalTracer;
 import java.io.FileInputStream;
 import java.io.InputStream;
@@ -136,7 +137,8 @@ public abstract class Config {
     hikariDataSource.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory());
     hikariDataSource.setPoolName(poolName);
 
-    final Jdbi jdbi = Jdbi.create(hikariDataSource).installPlugins();
+    final Jdbi jdbi = Jdbi.create(hikariDataSource).setSqlLogger(new OpentracingSqlLogger(GlobalTracer.get()));
+
     return jdbi;
   }
 

--- a/backend/common/src/main/java/ai/verta/modeldb/common/futures/InternalFuture.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/futures/InternalFuture.java
@@ -27,45 +27,14 @@ public class InternalFuture<T> {
     private InternalFuture() {
     }
 
-    static private SpanContext getActiveSpanContext(Tracer tracer) {
-        Span activeSpan = ActiveSpanSource.GRPC_CONTEXT.getActiveSpan();
-        if (activeSpan != null) {
-            return activeSpan.context();
-        }
-
-        SpanContext spanContext = ActiveSpanContextSource.GRPC_CONTEXT.getActiveSpanContext();
-        if (spanContext != null) {
-            return spanContext;
-        }
-
-        return tracer.activeSpan() != null ? tracer.activeSpan().context() : null;
-    }
-
-    static private Span createSpanFromParent(Tracer tracer, SpanContext parentSpanContext, String operationName, Map<String,String> tags) {
-        Tracer.SpanBuilder spanBuilder;
-        if (parentSpanContext == null) {
-            spanBuilder = tracer.buildSpan(operationName);
-        } else {
-            spanBuilder = tracer.buildSpan(operationName).asChildOf(parentSpanContext);
-        }
-
-    if (tags != null) {
-      for (var entry : tags.entrySet()) {
-        spanBuilder = spanBuilder.withTag(entry.getKey(), entry.getValue());
-      }
-        }
-
-        return spanBuilder.start();
-    }
-
     public static <T> InternalFuture<T> trace(Supplier<InternalFuture<T>> supplier, String operationName, Map<String,String> tags, Executor executor) {
         if (!GlobalTracer.isRegistered())
             return supplier.get();
 
         final var tracer = GlobalTracer.get();
 
-        final var spanContext = getActiveSpanContext(tracer);
-        final var span = createSpanFromParent(tracer, spanContext, operationName, tags);
+        final var spanContext = TraceSupport.getActiveSpanContext(tracer);
+        final var span = TraceSupport.createSpanFromParent(tracer, spanContext, operationName, tags);
 
         final var promise = new CompletableFuture<T>();
         supplier.get().stage.whenCompleteAsync((v, t) -> {


### PR DESCRIPTION
Passing the parent span into the executor allows the JDBI native instrumentation to insert the query as a child span.