### PR TITLE
Update logging output to align with other backend services

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <hibernate.version>5.4.17.Final</hibernate.version>
-        <log4j.version>2.13.2</log4j.version>
+        <log4j.version>2.14.1</log4j.version>
         <grpc.version>1.28.1</grpc.version>
         <postgres.version>42.2.6</postgres.version>
         <liquibase.version>3.8.0</liquibase.version>
@@ -177,7 +177,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.12.1</version>
+            <version>${log4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-layout-template-json</artifactId>
+            <version>${log4j.version}</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.liquibase/liquibase-core -->
         <dependency>

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.main.banner-mode=off

--- a/backend/src/main/resources/log-template.json
+++ b/backend/src/main/resources/log-template.json
@@ -11,8 +11,8 @@
     }
   },
   "location": {
-    "$resolver": "logger",
-    "field": "fqcn"
+    "$resolver": "source",
+    "field": "className"
   },
   "method": {
     "$resolver": "source",

--- a/backend/src/main/resources/log-template.json
+++ b/backend/src/main/resources/log-template.json
@@ -1,0 +1,29 @@
+{
+  "level": {
+    "$resolver": "level",
+    "field": "name"
+  },
+  "@timestamp": {
+    "$resolver": "timestamp",
+    "pattern": {
+      "format": "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
+      "timeZone": "UTC"
+    }
+  },
+  "location": {
+    "$resolver": "logger",
+    "field": "fqcn"
+  },
+  "method": {
+    "$resolver": "source",
+    "field": "methodName"
+  },
+  "line": {
+    "$resolver": "source",
+    "field": "lineNumber"
+  },
+  "message": {
+    "$resolver": "message",
+    "stringified": true
+  }
+}

--- a/backend/src/main/resources/log4j2.xml
+++ b/backend/src/main/resources/log4j2.xml
@@ -4,7 +4,6 @@
         <Console name="ConsoleJSONAppender" target="SYSTEM_OUT">
             <JsonTemplateLayout eventTemplateUri="classpath:log-template.json" locationInfoEnabled="true">
                 <EventTemplateAdditionalField key="hostName" value="${env:hostName:-}"/>
-                <EventTemplateAdditionalField key="kubernetes.podIP" value="${k8s:podIp:-}"/>
             </JsonTemplateLayout>
         </Console>
     </Appenders>

--- a/backend/src/main/resources/log4j2.xml
+++ b/backend/src/main/resources/log4j2.xml
@@ -2,11 +2,10 @@
 <Configuration status="INFO">
     <Appenders>
         <Console name="ConsoleJSONAppender" target="SYSTEM_OUT">
-              <!--  Doc link for key value pair: https://logging.apache.org/log4j/2.x/manual/lookups.html -->
-              <JsonLayout complete="false" compact="true" eventEol="true" stacktraceAsString="true" locationInfo="true">
-                <KeyValuePair key="hostName" value="${env:hostName:-}"/>
-                <KeyValuePair key="kubernetes.podIP" value="${k8s:podIp:-}"/>
-            </JsonLayout>
+            <JsonTemplateLayout eventTemplateUri="classpath:log-template.json" locationInfoEnabled="true">
+                <EventTemplateAdditionalField key="hostName" value="${env:hostName:-}"/>
+                <EventTemplateAdditionalField key="kubernetes.podIP" value="${k8s:podIp:-}"/>
+            </JsonTemplateLayout>
         </Console>
     </Appenders>
     <Loggers>


### PR DESCRIPTION
Implements logging output in line with go service: 
`{"level":"INFO","@timestamp":"2021-08-12T03:43:45.752Z","location":"org.springframework.scheduling.concurrent.ExecutorConfigurationSupport","method":"shutdown","line":208,"message":"Shutting down ExecutorService 'applicationTaskExecutor'","hostName":"Corys-MacBook-Pro.local"}
`