### PR TITLE
[VR-12540] Fix bugs in profile_point()

### DIFF
--- a/client/verta/tests/monitoring/test_profilers.py
+++ b/client/verta/tests/monitoring/test_profilers.py
@@ -63,10 +63,12 @@ class TestContinuousHistogramProfiler:
             assert sum(profile._data) == 1
 
             # check value is in correct bucket
-            lower_bucket_limit = max(filter(
-                lambda bucket: bucket <= value,
-                profile._bucket_limits,
-            ))
+            lower_bucket_limit = max(
+                filter(
+                    lambda bucket: bucket <= value,
+                    profile._bucket_limits,
+                )
+            )
             data_index = min(
                 profile._bucket_limits.index(lower_bucket_limit),
                 len(profile._data) - 1,  # right-most bucket

--- a/client/verta/tests/monitoring/test_profilers.py
+++ b/client/verta/tests/monitoring/test_profilers.py
@@ -16,12 +16,12 @@ from verta.monitoring._profilers import ProfilerReference
 from . import strategies
 
 
-class TestProfilers:
+class TestContinuousHistogramProfiler:
     @hypothesis.settings(deadline=None)  # building DataFrames can be slow
     @hypothesis.given(
         df=strategies.simple_dataframes(),  # pylint: disable=no-value-for-parameter
     )
-    def test_continuous(self, df):
+    def test_profile(self, df):
         np = pytest.importorskip("numpy")
 
         cols = ["continuous"]
@@ -40,16 +40,63 @@ class TestProfilers:
             # missing values omitted
             assert sum(data._data) == sum(~series.isna())
 
+    def test_profile_point(self):
+        np = pytest.importorskip("numpy")
+        pd = pytest.importorskip("pandas")
+        colname = "data"
+        df = pd.DataFrame(
+            {
+                colname: np.r_[
+                    0,
+                    np.abs(np.random.normal(loc=10, scale=5, size=50)),
+                    None,
+                ],
+            }
+        )
+
+        profiler = ContinuousHistogramProfiler([colname])
+        reference = profiler.profile(df)[colname + "_histogram"]
+
+        for value in df[colname].dropna():
+            profile = profiler.profile_point(value, reference)
+            assert profile._bucket_limits == reference._bucket_limits
+            assert sum(profile._data) == 1
+
+            # check value is in correct bucket
+            lower_bucket_limit = max(filter(
+                lambda bucket: bucket <= value,
+                profile._bucket_limits,
+            ))
+            data_index = min(
+                profile._bucket_limits.index(lower_bucket_limit),
+                len(profile._data) - 1,  # right-most bucket
+            )
+            assert profile._data[data_index] == 1
+
+        # value not in reference
+        value = -5
+        profile = profiler.profile_point(value, reference)
+        assert profile._bucket_limits == reference._bucket_limits
+        assert sum(profile._data) == 0
+
+        # missing value
+        value = None
+        profile = profiler.profile_point(value, reference)
+        assert profile._bucket_limits == reference._bucket_limits
+        assert sum(profile._data) == 0
+
+
+class TestBinaryHistogramProfiler:
     @hypothesis.settings(deadline=None)  # building DataFrames can be slow
     @hypothesis.given(
         df=strategies.simple_dataframes(),  # pylint: disable=no-value-for-parameter
     )
-    def test_discrete(self, df):
+    def test_profile(self, df):
         cols = ["discrete"]
 
         profiler = BinaryHistogramProfiler(cols)
-        profile = profiler.profile(df)
 
+        profile = profiler.profile(df)
         assert len(profile) == len(cols)
         for name, data in profile.items():
             assert isinstance(data, data_types.DiscreteHistogram)
@@ -61,16 +108,44 @@ class TestProfilers:
             # missing values omitted
             assert sum(data._data) == sum(~series.isna())
 
+    def test_profile_point(self):
+        pd = pytest.importorskip("pandas")
+        colname = "data"
+        df = pd.DataFrame({colname: [0, 1, None]})
+
+        profiler = BinaryHistogramProfiler([colname])
+        reference = profiler.profile(df)[colname + "_histogram"]
+
+        for value in [0, 1]:  # 0 (when in reference) should not be discarded
+            profile = profiler.profile_point(value, reference)
+            assert profile._buckets == reference._buckets
+            assert sum(profile._data) == 1
+            assert profile._data[profile._buckets.index(value)] == 1
+
+        # value not in reference
+        value = 2
+        profile = profiler.profile_point(value, reference)
+        assert profile._buckets == reference._buckets
+        assert sum(profile._data) == 0
+
+        # missing value
+        value = None
+        profile = profiler.profile_point(value, reference)
+        assert profile._buckets == reference._buckets
+        assert sum(profile._data) == 0
+
+
+class TestMissingValuesProfiler:
     @hypothesis.settings(deadline=None)  # building DataFrames can be slow
     @hypothesis.given(
         df=strategies.simple_dataframes(),  # pylint: disable=no-value-for-parameter
     )
-    def test_missing(self, df):
+    def test_profile(self, df):
         cols = ["continuous", "discrete"]
 
         profiler = MissingValuesProfiler(cols)
-        profile = profiler.profile(df)
 
+        profile = profiler.profile(df)
         assert len(profile) == len(cols)
         for name, data in profile.items():
             assert isinstance(data, data_types.DiscreteHistogram)
@@ -78,6 +153,27 @@ class TestProfilers:
             series = df[name.split("_missing")[0]]
             assert data._data[data._buckets.index("present")] == sum(~series.isna())
             assert data._data[data._buckets.index("missing")] == sum(series.isna())
+
+    def test_profile_point(self):
+        pd = pytest.importorskip("pandas")
+        colname = "data"
+        df = pd.DataFrame({colname: [0, 1, None]})
+
+        profiler = MissingValuesProfiler([colname])
+        reference = profiler.profile(df)[colname + "_missing"]
+
+        for value in [0, 1, 2]:
+            profile = profiler.profile_point(value, reference)
+            assert profile._buckets == reference._buckets
+            assert profile._data[profile._buckets.index("present")] == 1
+            assert profile._data[profile._buckets.index("missing")] == 0
+
+        # missing value
+        value = None
+        profile = profiler.profile_point(value, reference)
+        assert profile._buckets == reference._buckets
+        assert profile._data[profile._buckets.index("present")] == 0
+        assert profile._data[profile._buckets.index("missing")] == 1
 
 
 class TestLiveProfilers(object):

--- a/client/verta/verta/monitoring/profiler.py
+++ b/client/verta/verta/monitoring/profiler.py
@@ -176,7 +176,7 @@ class BinaryHistogramProfiler(Profiler):
         buckets = reference._buckets
         data = [0]*len(buckets)
 
-        if sample:
+        if sample is not None:
             data[buckets.index(sample)] = 1
         return DiscreteHistogram(buckets, data)
 

--- a/client/verta/verta/monitoring/profiler.py
+++ b/client/verta/verta/monitoring/profiler.py
@@ -76,6 +76,28 @@ class Profiler(object):
         """
         raise NotImplementedError("")
 
+    # TODO: this conceptually could be a static method
+    @abc.abstractmethod
+    def profile_point(self, sample, reference):
+        """Profile a single value against a reference distribution.
+
+        Parameters
+        ----------
+        sample : any
+            Value to be profiled.
+        reference : :mod:`VertaDataType <verta.data_types>`
+            Reference distribution for `sample` to be profiled against. An
+            instance of this profiler's data type.
+
+        Returns
+        -------
+        profile : :mod:`VertaDataType <verta.data_types>`
+            Profile of `sample` against `reference`. An instance of this
+            profiler's data type.
+
+        """
+        raise NotImplementedError
+
 
 class MissingValuesProfiler(Profiler):
     """Produces discrete histograms for present and missing values.

--- a/client/verta/verta/monitoring/profiler.py
+++ b/client/verta/verta/monitoring/profiler.py
@@ -233,5 +233,9 @@ class ContinuousHistogramProfiler(Profiler):
 
     # TODO: consider the case where the data is outside of the bucket list
     def profile_point(self, sample, reference):
-        values, _ = self._np.histogram([sample], bins=reference._bucket_limits)
+        if sample is not None:
+            values, _ = self._np.histogram([sample], bins=reference._bucket_limits)
+        else:
+            values = [0]*len(reference._data)
+
         return FloatHistogram(reference._bucket_limits, values)

--- a/client/verta/verta/monitoring/profiler.py
+++ b/client/verta/verta/monitoring/profiler.py
@@ -198,7 +198,7 @@ class BinaryHistogramProfiler(Profiler):
         buckets = reference._buckets
         data = [0]*len(buckets)
 
-        if sample is not None:
+        if (sample is not None) and (sample in buckets):
             data[buckets.index(sample)] = 1
         return DiscreteHistogram(buckets, data)
 

--- a/client/verta/verta/monitoring/profiler.py
+++ b/client/verta/verta/monitoring/profiler.py
@@ -76,7 +76,6 @@ class Profiler(object):
         """
         raise NotImplementedError("")
 
-    # TODO: this conceptually could be a static method
     @abc.abstractmethod
     def profile_point(self, sample, reference):
         """Profile a single value against a reference distribution.


### PR DESCRIPTION
## Changes

- `BinaryHistogramProfiler.profile_point(0, reference)` when `0` is in `reference` now returns an accurate sample instead of discarding the value (**which resulted in `[0, 0]` for binary data**).
- `BinaryHistogramProfiler.profile_point(value_not_in_reference, reference)` now returns a zero-valued sample instead of raising
  ```python
      if sample is not None:
  >       data[buckets.index(sample)] = 1
  E       ValueError: "foo" is not in list
  ```
- `ContinuousHistogramProfiler.profile_point(None, reference)` now returns a zero-valued sample instead of raising
  ```python
  >   values, _ = self._np.histogram([sample], bins=reference._bucket_limits)
  E   TypeError: '<' not supported between instances of 'NoneType' and 'float'
  ```

## Tests

### Python 3

```bash
$ pytest monitoring/test_profilers.py 
==================================================== test session starts ====================================================
platform darwin -- Python 3.7.10, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /Users/miliu/Documents/modeldb/client/verta/tests, configfile: pytest.ini
plugins: hypothesis-6.14.0
collected 8 items                                                                                                           

monitoring/test_profilers.py .......s                                                                                 [100%]

=================================== 7 passed, 1 skipped, 6 warnings in 119.93s (0:01:59) ====================================
```

### Python 2

```bash
$ pytest monitoring/test_profilers.py 
==================================================== test session starts ====================================================
platform darwin -- Python 2.7.18, pytest-4.6.11, py-1.10.0, pluggy-0.13.1
rootdir: /Users/miliu/Documents/modeldb/client/verta/tests, inifile: pytest.ini
plugins: hypothesis-4.57.1
collected 8 items                                                                                                           

monitoring/test_profilers.py .......s                                                                                 [100%]

===================================== 7 passed, 1 skipped, 4 warnings in 151.42 seconds =====================================
```