### PR TITLE
[VR-12610] Make KafkaSettings more discoverable in API docs

### DIFF
--- a/client/verta/verta/endpoint/_kafka_settings.py
+++ b/client/verta/verta/endpoint/_kafka_settings.py
@@ -5,7 +5,10 @@ from verta.external import six
 
 class KafkaSettings(object):
     """
-    A set of topics to be used with deployed endpoints.
+    A set of Kafka topics to be used with deployed endpoints.
+
+    For use during :class:`~verta.endpoint.Endpoint` creation or with
+    :meth:`Endpoint.update() <verta.endpoint.Endpoint.update>`.
 
     .. versionadded:: 0.19.0
 


### PR DESCRIPTION
Admittedly, despite a lot of reading in the last year, RTD's search mechanisms remain a mystery to me. But at least the word "Kafka" is now in `KafkaSettings`'s docstring.

### Before

![Screen Shot 2021-08-18 at 12 56 11 PM](https://user-images.githubusercontent.com/7754936/129963669-d47580b1-2238-4d62-930c-a1f2f8f6c338.png)

### After

![Screen Shot 2021-08-18 at 12 56 17 PM](https://user-images.githubusercontent.com/7754936/129963687-bd2a10d1-729f-49c2-a8f3-1eaf2e6e2459.png)

I have no idea why `endpoint` now appears in the results despite me not changing anything about it whatsoever.