### PR TITLE
Validate VertaModelBase.__init__() param names

### DIFF
--- a/client/verta/tests/models/standard_models.py
+++ b/client/verta/tests/models/standard_models.py
@@ -61,11 +61,37 @@ def decorated_verta_models():
 def incomplete_verta_models():
     models = []
 
-    models.extend([
-        VertaModelNoImpl,
-        VertaModelOnlyInit,
-        VertaModelOnlyPredict,
-    ])
+    models.extend(
+        [
+            VertaModelNoImpl,
+            VertaModelOnlyInit,
+            VertaModelOnlyPredict,
+        ]
+    )
+
+    return models
+
+
+def bad_init_verta_models():
+    models = []
+
+    class InsufficientInit(VertaModelBase):
+        def __init__(self):  # no `artifacts`
+            pass
+
+        def predict(self, input):
+            pass
+
+    models.append(InsufficientInit)
+
+    class MisnamedInit(VertaModelBase):
+        def __init__(self, relics):  # not `artifacts`
+            pass
+
+        def predict(self, input):
+            pass
+
+    models.append(MisnamedInit)
 
     return models
 

--- a/client/verta/tests/registry/test_standard_model.py
+++ b/client/verta/tests/registry/test_standard_model.py
@@ -21,6 +21,7 @@ from ..strategies import json_strategy
 verta_models = standard_models.verta_models()
 decorated_verta_models = standard_models.decorated_verta_models()
 incomplete_verta_models = standard_models.incomplete_verta_models()
+bad_init_verta_models = standard_models.bad_init_verta_models()
 keras_models = standard_models.keras_models()
 unsupported_keras_models = standard_models.unsupported_keras_models()
 sklearn_models = standard_models.sklearn_models()
@@ -106,6 +107,17 @@ class TestModelValidator:
             r"^model must finish implementing the following methods of VertaModelBase: "
         )
         msg_match += re.escape(str(list(sorted(model.__abstractmethods__))))
+        with pytest.raises(TypeError, match=msg_match):
+            model_validator.must_verta(model)
+
+    @pytest.mark.parametrize(
+        "model",
+        bad_init_verta_models,
+    )
+    def test_bad_init_verta(self, model):
+        msg_match = "^" + re.escape(
+            "model __init__() parameters must be named ('self', 'artifacts'), not "
+        )
         with pytest.raises(TypeError, match=msg_match):
             model_validator.must_verta(model)
 
@@ -242,7 +254,7 @@ class TestStandardModels:
 
     @pytest.mark.parametrize(
         "model",
-        incomplete_verta_models,
+        incomplete_verta_models + bad_init_verta_models,
     )
     def test_incomplete_verta(self, registered_model, model):
         with pytest.raises(TypeError):

--- a/client/verta/verta/_internal_utils/model_validator.py
+++ b/client/verta/verta/_internal_utils/model_validator.py
@@ -73,27 +73,27 @@ def must_xgboost_sklearn(model):
     return True
 
 
-def must_verta(model_cls):
-    if not (isinstance(model_cls, type) and issubclass(model_cls, VertaModelBase)):
+def must_verta(model):
+    if not (isinstance(model, type) and issubclass(model, VertaModelBase)):
         raise TypeError(
             "model must be a subclass of verta.registry.VertaModelBase,"
-            " not {}".format(model_cls)
+            " not {}".format(model)
         )
-    remaining_abstract_methods = list(sorted(getattr(model_cls, "__abstractmethods__", [])))
+    remaining_abstract_methods = list(sorted(getattr(model, "__abstractmethods__", [])))
     if remaining_abstract_methods:
         raise TypeError(
             "model must finish implementing the following methods of"
             " VertaModelBase: {}".format(remaining_abstract_methods)
         )
     expected_init_params = tuple(getargspec(VertaModelBase.__init__).args)
-    init_params = tuple(getargspec(model_cls.__init__).args)
+    init_params = tuple(getargspec(model.__init__).args)
     if init_params != expected_init_params:
         # model service passes __init__(artifacts) by keyword
         raise TypeError(
             "model __init__() parameters must be named {},"
             " not {}".format(expected_init_params, init_params)
         )
-    if not getattr(model_cls.predict, _DECORATED_FLAG, False):
+    if not getattr(model.predict, _DECORATED_FLAG, False):
         warnings.warn(
             "model predict() is not decorated with verta.registry.verify_io;"
             " argument and return types may change unintuitively when deployed"

--- a/client/verta/verta/_internal_utils/model_validator.py
+++ b/client/verta/verta/_internal_utils/model_validator.py
@@ -79,20 +79,23 @@ def must_verta(model):
             "model must be a subclass of verta.registry.VertaModelBase,"
             " not {}".format(model)
         )
+
     remaining_abstract_methods = list(sorted(getattr(model, "__abstractmethods__", [])))
     if remaining_abstract_methods:
         raise TypeError(
             "model must finish implementing the following methods of"
             " VertaModelBase: {}".format(remaining_abstract_methods)
         )
+
+    # model service passes __init__(artifacts) by keyword, so params must match
     expected_init_params = tuple(getargspec(VertaModelBase.__init__).args)
     init_params = tuple(getargspec(model.__init__).args)
     if init_params != expected_init_params:
-        # model service passes __init__(artifacts) by keyword
         raise TypeError(
             "model __init__() parameters must be named {},"
             " not {}".format(expected_init_params, init_params)
         )
+
     if not getattr(model.predict, _DECORATED_FLAG, False):
         warnings.warn(
             "model predict() is not decorated with verta.registry.verify_io;"


### PR DESCRIPTION
## Problem

`VertaModelBase` has the following interface [defined for `__init__()`](https://github.com/VertaAI/modeldb/blob/160dbb3/client/verta/verta/registry/_verta_model_base.py#L54):

```python
class VertaModelBase(object):
    @abc.abstractmethod
    def __init__(self, artifacts):
        raise NotImplementedError
```

Our model service [passes the `artifacts` argument by keyword](https://github.com/VertaAI/services/blob/2dc4d7403b9750642fda96efd7314eb9898c0665/deployment/python-model-service/app/wrappers/model/class_model.py#L23), meaning that a subclass _must_ have `artifacts` as a parameter on its `__init__()` method to work with our deployment system today.

However, oftentimes out of forgetfulness ~or laziness~, I personally accidentally omit the `artifacts` parameter when quickly defining a model for testing purposes:

```python
class Model(VertaModelBase):
    def __init__(self):
        pass
```

only to find out about 10 minutes later that the deployment failed, and have to start all over again.

## Changes

To facilitate catching the problem sooner (and not require waiting for artifacts to upload + the endpoint to deploy before realizing it):

- validate at logging-time that a model subclassing VertaModelBase has the correct parameters on `__init__()`

## Tests

### Python 3

```bash
$ pytest registry/test_standard_model.py                                                                   
==================================================== test session starts ====================================================
platform darwin -- Python 3.7.10, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /Users/miliu/Documents/modeldb/client/verta/tests, configfile: pytest.ini
plugins: hypothesis-6.14.0
collected 72 items                                                                                                          

registry/test_standard_model.py ..............s................s................s.................s.....              [100%]

================================== 68 passed, 4 skipped, 38 warnings in 1213.41s (0:20:13) ==================================
```

### Python 2

```bash
$ pytest registry/test_standard_model.py                                                                   
==================================================== test session starts ====================================================
platform darwin -- Python 2.7.18, pytest-4.6.11, py-1.10.0, pluggy-0.13.1                                                    
rootdir: /Users/miliu/Documents/modeldb/client/verta/tests, inifile: pytest.ini                                              
plugins: hypothesis-4.57.1                                                                                                   
collected 72 items                                                                                                           
                                                                                                                             
registry/test_standard_model.py ..............s................s................s.................s.....              [100%] 
                                                                                                                             
=================================== 68 passed, 4 skipped, 38 warnings in 1304.61 seconds ====================================
```

## Alternatives Considered

Aside from linting on the user's end, I'm not aware of any Python mechanisms for validating that a subclass matches the interfaces of its superclass's methods at definition-time.

There is `__init_subclass__()` in Python 3.6+ which could let us bundle the code for this check into the `VertaModelBase` abstract class, but we still need to support 2.7 and 3.5, and the check wouldn't run until the class is instantiated which isn't something we can necessarily do when we log the model.