### PR TITLE
Rename misnamed internal utility function

### DIFF
--- a/client/verta/tests/test_utils/test_pip_requirements.py
+++ b/client/verta/tests/test_utils/test_pip_requirements.py
@@ -71,7 +71,7 @@ class TestPipRequirementsUtils:
         requirement = "+".join([clean_requirement, metadata])
 
         requirements = [requirement]
-        _pip_requirements_utils.remove_public_version_identifier(requirements)
+        _pip_requirements_utils.remove_local_version_identifier(requirements)
         assert requirements != [requirement]
         assert requirements == [clean_requirement]
 

--- a/client/verta/verta/_internal_utils/_pip_requirements_utils.py
+++ b/client/verta/verta/_internal_utils/_pip_requirements_utils.py
@@ -372,7 +372,7 @@ def preserve_req_suffixes(requirement, pinned_library_req):
         return delimiter.join(split_req)
     return pinned_library_req
 
-def remove_public_version_identifier(requirements):
+def remove_local_version_identifier(requirements):
     """Removes local version identifiers from version pins if present.
 
     PyTorch in particular adds local build information to its pip environment
@@ -392,7 +392,7 @@ def remove_public_version_identifier(requirements):
         before = ["torch==1.8.1+cu102"]
         after = ["torch==1.8.1"]
 
-        remove_public_version_identifier(before)
+        remove_local_version_identifier(before)
         assert before == after
 
     References

--- a/client/verta/verta/environment/_python.py
+++ b/client/verta/verta/environment/_python.py
@@ -231,7 +231,7 @@ class Python(_environment._Environment):
             _pip_requirements_utils.must_all_valid_package_names(requirements_copy)
             _pip_requirements_utils.strip_inexact_specifiers(requirements_copy)
             _pip_requirements_utils.set_version_pins(requirements_copy)
-            _pip_requirements_utils.remove_public_version_identifier(requirements_copy)
+            _pip_requirements_utils.remove_local_version_identifier(requirements_copy)
 
             self._msg.python.requirements.extend(
                 map(


### PR DESCRIPTION
## Impact and Context

There's a function that removes a **local** version identifier from a Python library version number. However, when I implemented it, I misnamed it as "remove **public** version identifier", which is [something different](https://www.python.org/dev/peps/pep-0440/#public-version-identifiers).

## Risks

None—this is not a part of the client's public API, and it was a straightforward find-and-replace.

## Testing

```bash
$ pytest test_versioning/test_environment.py test_utils/test_pip_requirements.py 
===================================================== test session starts ======================================================
platform darwin -- Python 3.7.10, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /Users/miliu/Documents/modeldb/client/verta/tests, configfile: pytest.ini
plugins: hypothesis-6.14.0
collected 17 items                                                                                                             

test_versioning/test_environment.py .............s..                                                                     [ 94%]
test_utils/test_pip_requirements.py .                                                                                    [100%]

========================================== 16 passed, 1 skipped, 3 warnings in 23.50s ==========================================
```

## How to Revert

Revert this PR
