### PR TITLE
Move pylint directive

### DIFF
--- a/client/verta/tests/registry/model_version/test_deployment.py
+++ b/client/verta/tests/registry/model_version/test_deployment.py
@@ -457,9 +457,10 @@ class TestAutoMonitoring:
 
     @hypothesis.settings(deadline=None)  # building DataFrames can be slow
     @hypothesis.given(
-        df=strategies.dataframes(
-            min_rows=1, min_cols=2
-        ),  # pylint: disable=no-value-for-parameter
+        df=strategies.dataframes(  # pylint: disable=no-value-for-parameter
+            min_rows=1,
+            min_cols=2,
+        ),
     )
     def test_compute_training_data_profile(self, df):
         """Unit test for helper functions handling DFs of various sizes."""
@@ -474,9 +475,10 @@ class TestAutoMonitoring:
 
     @hypothesis.settings(deadline=None)  # building DataFrames can be slow
     @hypothesis.given(
-        df=strategies.dataframes(
-            min_rows=1, min_cols=2
-        ),  # pylint: disable=no-value-for-parameter
+        df=strategies.dataframes(  # pylint: disable=no-value-for-parameter
+            min_rows=1,
+            min_cols=2,
+        ),
     )
     def test_collect_feature_data_and_vis_attributes(self, df):
         """Unit test that attributes pre-logging are the correct format."""


### PR DESCRIPTION
## Impact and Context

Our code formatter `black` moved this `pylint: disable` directive to a line where it no longer has an effect. This PR moves it so it works again.

## Risks

None—this is just a localized change to linting behavior

## Testing

I watched the `no-value-for-parameter` linting error disappear from the `strategies.dataframes()` call.

## How to Revert

Revert this PR.
