### PR TITLE
Split create_version_from_run to RMV test

### DIFF
--- a/client/verta/tests/deployable_entity/test_deployment.py
+++ b/client/verta/tests/deployable_entity/test_deployment.py
@@ -549,10 +549,6 @@ class TestDeployability:
 
         deployable_entity.log_model(model_for_deployment["model"], custom_modules=[])
         deployable_entity.log_environment(Python(["scikit-learn"]))
-        deployable_entity = registered_model.create_version_from_run(
-            run_id=deployable_entity.id,
-            name="From Run {}".format(deployable_entity.id),
-        )
 
         filepath = deployable_entity.download_docker_context(download_to_path)
         assert filepath == os.path.abspath(download_to_path)

--- a/client/verta/tests/test_experimentrun/test_deployment.py
+++ b/client/verta/tests/test_experimentrun/test_deployment.py
@@ -316,18 +316,3 @@ class TestGitOps:
 
         assert model_deployment['kind'] == "ModelDeployment"
         assert model_deployment['metadata']['name'] == experiment_run.id
-
-    def test_download_docker_context(self, experiment_run, model_for_deployment, in_tempdir):
-        download_to_path = "context.tgz"
-
-        experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
-        experiment_run.log_environment(Python(['scikit-learn']))
-
-        filepath = experiment_run.download_docker_context(download_to_path)
-        assert filepath == os.path.abspath(download_to_path)
-
-        # can be loaded as tgz
-        with tarfile.open(filepath, 'r:gz') as f:
-            filepaths = set(f.getnames())
-
-        assert "Dockerfile" in filepaths


### PR DESCRIPTION
## Impact and Context

The test in `deployable_entity/` was failing because it has the registry-specific `create_version_from_run()`. But testing that function in particular is important, so I duplicated the test into `registry/model_version/` to keep that coverage.

I also removed the duplicated test in `test_experimentrun/`.

## Risks

This test's code is now 80% duplicated between `deployable_entity/` and `registry/model_version/` which _could_ be harder to maintain in the future.

## Testing

```bash
$ pytest deployable_entity/test_deployment.py::TestDeployability::test_download_docker_context \
> registry/model_version/test_deployment.py::TestDeployability::test_from_run_download_docker_context
===================================================== test session starts ======================================================
platform darwin -- Python 3.7.10, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /Users/miliu/Documents/modeldb/client/verta/tests, configfile: pytest.ini
plugins: hypothesis-6.14.0
collected 3 items                                                                                                              

deployable_entity/test_deployment.py ..                                                                                  [ 66%]
registry/model_version/test_deployment.py .                                                                              [100%]

================================================ 3 passed, 5 warnings in 51.24s ================================================
```

## How to Revert
Revert this PR.
