### PR TITLE
Generalize expected error message

### DIFF
--- a/client/verta/tests/deployable_entity/test_deployment.py
+++ b/client/verta/tests/deployable_entity/test_deployment.py
@@ -464,7 +464,7 @@ class TestDeployability:
         with pytest.raises(ValueError) as excinfo:
             deployable_entity.log_model(new_classifier)
 
-        assert "model already exists" in str(excinfo.value)
+        assert "already exists" in str(excinfo.value)
 
         # Check custom modules:
         custom_module_filenames = {"__init__.py", "_verta_config.py"}


### PR DESCRIPTION
## Impact and Context

`ExperimentRun.log_model()` attempts to log the model API first, rather than the model, so the error message is slightly different.

## Risks

This sort of sidesteps the fact that `ExperimentRun.log_model()` and `RegisteredModelVersion.log_model()` log the artifacts in different orders, but that is a task best handled by future client refactors.

## Testing

```bash
$ pytest deployable_entity/test_deployment.py::TestDeployability::test_log_model                              
===================================================== test session starts ======================================================
platform darwin -- Python 3.7.10, pytest-6.2.4, py-1.10.0, pluggy-0.13.1                                                        
rootdir: /Users/miliu/Documents/modeldb/client/verta/tests, configfile: pytest.ini
plugins: hypothesis-6.14.0
collected 2 items                                                                                                              

deployable_entity/test_deployment.py ..                                                                                  [100%]

========================================== 2 passed, 9 warnings in 218.50s (0:03:38) ===========================================
```

## How to Revert

Revert this PR.
