### PR TITLE
Accommodate differing _get_artifact() returns

### DIFF
--- a/client/verta/tests/deployable_entity/test_deployment.py
+++ b/client/verta/tests/deployable_entity/test_deployment.py
@@ -224,7 +224,12 @@ class TestFetchArtifacts:
                        for filepath in six.viewvalues(artifacts))
 
             for key, filepath in six.viewitems(artifacts):
-                artifact_contents, _ = deployable_entity._get_artifact(key)
+                artifact_contents = deployable_entity._get_artifact(key)
+                if type(artifact_contents) is tuple:
+                    # ER returns (contents, path_only)
+                    # TODO: ER & RMV _get_artifact() should return the same thing
+                    artifact_contents, _ = artifact_contents
+
                 with open(filepath, 'rb') as f:
                     file_contents = f.read()
 

--- a/client/verta/tests/deployable_entity/test_deployment.py
+++ b/client/verta/tests/deployable_entity/test_deployment.py
@@ -220,8 +220,10 @@ class TestFetchArtifacts:
             artifacts = deployable_entity.fetch_artifacts(strs)
 
             assert set(six.viewkeys(artifacts)) == set(strs)
-            assert all(filepath.startswith(_CACHE_DIR)
-                       for filepath in six.viewvalues(artifacts))
+            assert all(
+                filepath.startswith(_CACHE_DIR)
+                for filepath in six.viewvalues(artifacts)
+            )
 
             for key, filepath in six.viewitems(artifacts):
                 artifact_contents = deployable_entity._get_artifact(key)
@@ -567,29 +569,6 @@ class TestDeployability:
             filepaths = set(f.getnames())
 
         assert "Dockerfile" in filepaths
-
-    def test_fetch_artifacts(self, deployable_entity, strs, flat_dicts):
-        strs, flat_dicts = strs[:3], flat_dicts[:3]  # all 12 is excessive for a test
-        for key, artifact in zip(strs, flat_dicts):
-            deployable_entity.log_artifact(key, artifact)
-
-        try:
-            artifacts = deployable_entity.fetch_artifacts(strs)
-
-            assert set(six.viewkeys(artifacts)) == set(strs)
-            assert all(
-                filepath.startswith(_deployable_entity._CACHE_DIR)
-                for filepath in six.viewvalues(artifacts)
-            )
-
-            for key, filepath in six.viewitems(artifacts):
-                artifact_contents = deployable_entity._get_artifact(key)
-                with open(filepath, "rb") as f:
-                    file_contents = f.read()
-
-                assert file_contents == artifact_contents
-        finally:
-            shutil.rmtree(_deployable_entity._CACHE_DIR, ignore_errors=True)
 
     def test_model_artifacts(self, deployable_entity, endpoint, in_tempdir):
         key = "foo"


### PR DESCRIPTION
## Impact and Context

`ExperimentRun._get_artifact()` and `DeployedModelVersion._get_artifact()` unfortunately have different return formats (the former returns a 2-tuple, the latter returns only one value). This changes the test to accommodate that until the client's artifact handling can be consolidated.

## Risks

Having a test do conditional manipulation during runtime can mask bugs, but I'd consider that to be a low risk because there are no other conditions for `_get_artifact()` to return a `tuple`.

## Testing

```bash
$ pytest deployable_entity/test_deployment.py::TestFetchArtifacts::test_fetch_artifacts
===================================================== test session starts ======================================================
platform darwin -- Python 3.7.10, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /Users/miliu/Documents/modeldb/client/verta/tests, configfile: pytest.ini
plugins: hypothesis-6.14.0
collected 2 items                                                                                                              

deployable_entity/test_deployment.py ..                                                                                  [100%]

================================================ 2 passed, 4 warnings in 37.10s ================================================
```

## How to Revert

Revert this PR.
