### PR TITLE
Use get_model() directly for model test

### DIFF
--- a/client/verta/tests/deployable_entity/test_artifacts.py
+++ b/client/verta/tests/deployable_entity/test_artifacts.py
@@ -550,7 +550,7 @@ class TestOverwrite:
         deployable_entity.log_model(model)
         deployable_entity.log_model(new_model, overwrite=True)
 
-        assert deployable_entity.get_artifact(_artifact_utils.MODEL_KEY) == new_model
+        assert deployable_entity.get_model() == new_model
 
     def test_setup_script(self, deployable_entity):
         setup_script = "import verta"


### PR DESCRIPTION
## Impact and Context

`ExperimentRun` and `RegisteredModelVersion` use different keys for their model artifact (the former uses `"model.pkl"`, the latter uses `"model"`). There's fortunately no need for this test to manually call `get_artifact()` using that key since it's testing overwrite, so `get_model()` suffices.

## Risks

This sort of sidesteps the fact that `ExperimentRun` and `RegisteredModelVersion` have diverging deployment artifact keys, but that is a task best handled by future client refactors.

## Testing

```bash
$ pytest deployable_entity/test_artifacts.py::TestOverwrite::test_model
===================================================== test session starts ======================================================
platform darwin -- Python 3.7.10, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /Users/miliu/Documents/modeldb/client/verta/tests, configfile: pytest.ini
plugins: hypothesis-6.14.0
collected 2 items                                                                                                              

deployable_entity/test_artifacts.py ..                                                                                   [100%]

========================================== 2 passed, 5 warnings in 213.16s (0:03:33) ===========================================
```

## How to Revert

Revert this PR.
