### PR TITLE
Move remaining generalizable artifact tests

### DIFF
--- a/client/verta/tests/deployable_entity/test_artifacts.py
+++ b/client/verta/tests/deployable_entity/test_artifacts.py
@@ -20,7 +20,7 @@ from verta._internal_utils import (
     _request_utils,
     _utils,
 )
-from . import utils
+from .. import utils
 
 
 class TestUtils:


### PR DESCRIPTION
## Impact and Context

After the preceding #2614, all that's left in the root `test_artifacts.py` are tests that conceptually apply to both `ExperimentRun` and `RegisteredModelVersion`. Since they are common to deployable entities, this PR moves those remaining tests to the new `deployable_entity/` test subdirectory.

## Risks

Since tests are effectively being renamed, some test executions histories on Jenkins will lose their continuity.

## Testing

See #2603 and #2604.

## How to Revert

Revert this PR.
