### PR TITLE
Remove non-generalizable, duplicated test

### DIFF
--- a/client/verta/tests/deployable_entity/test_artifacts.py
+++ b/client/verta/tests/deployable_entity/test_artifacts.py
@@ -189,16 +189,6 @@ class TestArtifacts:
             with pytest.raises(ValueError):
                 experiment_run.log_artifact(key, artifact)
 
-    def test_blocklisted_key_error(self, experiment_run, all_values):
-        all_values = (value  # log_artifact treats str value as filepath to open
-                      for value in all_values if not isinstance(value, str))
-
-        for key, artifact in zip(_artifact_utils.BLOCKLISTED_KEYS, all_values):
-            with pytest.raises(ValueError, match="please use a different key$"):
-                experiment_run.log_artifact(key, artifact)
-            with pytest.raises(ValueError, match="please use a different key$"):
-                experiment_run.log_artifact_path(key, artifact)
-
     def test_download(self, experiment_run, strs, in_tempdir, random_data):
         key = strs[0]
         filename = strs[1]


### PR DESCRIPTION
## Impact and Context

This test from the preceding #2615 actually isn't generalizable, because `RegisteredModelVersion` today doesn't enforce a blocklist in `log_artifact()`. So this PR removes it from `deployable_entity/`.

This test does still exist (verbatim) in [`test_experimentrun/test_artifacts.py`](https://github.com/VertaAI/modeldb/blob/311dffa2e6733061a2edb2dff06e7a55f232013e/client/verta/tests/test_experimentrun/test_artifacts.py#L73-L81), and an equivalent is present—though skipped—in [`registry/model_version/test_artifacts.py`](https://github.com/VertaAI/modeldb/blob/311dffa2e6733061a2edb2dff06e7a55f232013e/client/verta/tests/registry/model_version/test_artifacts.py#L163-L169).

## Risks

None.

## Testing

See #2603 and #2604.

## How to Revert

Revert this PR.
