### PR TITLE
Remove duplicated artifact download tests

### DIFF
--- a/client/verta/tests/deployable_entity/conftest.py
+++ b/client/verta/tests/deployable_entity/conftest.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from verta.tracking.entities._deployable_entity import _DeployableEntity
+from verta.tracking.entities import ExperimentRun
+from verta.registry.entities import RegisteredModelVersion
+
+
+@pytest.fixture(params=_DeployableEntity.__subclasses__())
+def deployable_entity(request, client, created_entities):
+    cls = request.param
+    if cls is ExperimentRun:
+        proj = client.create_project()
+        created_entities.append(proj)
+        entity = client.create_experiment_run()
+    elif cls is RegisteredModelVersion:
+        reg_model = client.create_registered_model()
+        created_entities.append(reg_model)
+        entity = reg_model.create_version()
+    else:
+        raise RuntimeError(
+            "_DeployableEntity appears to have a subclass {} that is not"
+            " accounted for in this fixture".format(cls)
+        )
+
+    return entity

--- a/client/verta/tests/deployable_entity/test_artifacts.py
+++ b/client/verta/tests/deployable_entity/test_artifacts.py
@@ -550,7 +550,7 @@ class TestOverwrite:
         deployable_entity.log_model(model)
         deployable_entity.log_model(new_model, overwrite=True)
 
-        assert deployable_entity.get_artifact(_artifact_utils.MODEL_KEY) == new_model
+        assert deployable_entity.get_model() == new_model
 
     def test_setup_script(self, deployable_entity):
         setup_script = "import verta"

--- a/client/verta/tests/deployable_entity/test_artifacts.py
+++ b/client/verta/tests/deployable_entity/test_artifacts.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import pytest
-
-import six
 
 import filecmp
 import hashlib
@@ -12,14 +9,15 @@ import shutil
 import tempfile
 import zipfile
 
+import pytest
 import requests
+import six
 
 from verta._internal_utils import (
     _artifact_utils,
-    _file_utils,
     _request_utils,
-    _utils,
 )
+
 from .. import utils
 
 

--- a/client/verta/tests/deployable_entity/test_artifacts.py
+++ b/client/verta/tests/deployable_entity/test_artifacts.py
@@ -38,7 +38,7 @@ class TestUtils:
 
             assert piecewise_checksum == whole_checksum
 
-    def test_download_file_no_collision(self, experiment_run, dir_and_files, in_tempdir):
+    def test_download_file_no_collision(self, deployable_entity, dir_and_files, in_tempdir):
         source_dirpath, _ = dir_and_files
         key = "artifact"
 
@@ -48,8 +48,8 @@ class TestUtils:
         os.rename(temp_zip.name, filepath)
 
         # upload and download file
-        experiment_run.log_artifact(key, filepath)
-        download_url = experiment_run._get_url_for_artifact(key, "GET").url
+        deployable_entity.log_artifact(key, filepath)
+        download_url = deployable_entity._get_url_for_artifact(key, "GET").url
         response = requests.get(download_url)
         downloaded_filepath = _request_utils.download_file(
             response, filepath, overwrite_ok=False,
@@ -61,7 +61,7 @@ class TestUtils:
         # contents match
         assert filecmp.cmp(filepath, downloaded_filepath)
 
-    def test_download_zipped_dir_no_collision(self, experiment_run, dir_and_files, in_tempdir):
+    def test_download_zipped_dir_no_collision(self, deployable_entity, dir_and_files, in_tempdir):
         source_dirpath, _ = dir_and_files
         key = "artifact"
 
@@ -70,8 +70,8 @@ class TestUtils:
         os.rename(source_dirpath, dirpath)
 
         # upload and download directory
-        experiment_run.log_artifact(key, dirpath)
-        download_url = experiment_run._get_url_for_artifact(key, "GET").url
+        deployable_entity.log_artifact(key, dirpath)
+        download_url = deployable_entity._get_url_for_artifact(key, "GET").url
         response = requests.get(download_url)
         downloaded_dirpath = _request_utils.download_zipped_dir(
             response, dirpath, overwrite_ok=False,
@@ -85,21 +85,21 @@ class TestUtils:
 
 
 class TestArtifacts:
-    def test_upload_object(self, experiment_run, strs, all_values):
+    def test_upload_object(self, deployable_entity, strs, all_values):
         strs, holdout = strs[:-1], strs[-1]  # reserve last key
         all_values = (value  # log_artifact treats str value as filepath to open
                       for value in all_values if not isinstance(value, str))
 
         for key, artifact in zip(strs, all_values):
-            experiment_run.log_artifact(key, artifact)
+            deployable_entity.log_artifact(key, artifact)
 
         for key, artifact in zip(strs, all_values):
-            assert experiment_run.get_artifact(key) == artifact
+            assert deployable_entity.get_artifact(key) == artifact
 
         with pytest.raises(KeyError):
-            experiment_run.get_artifact(holdout)
+            deployable_entity.get_artifact(holdout)
 
-    def test_upload_file(self, experiment_run, strs):
+    def test_upload_file(self, deployable_entity, strs):
         filepaths = (
             filepath for filepath in os.listdir('.')
             if filepath.endswith('.py')
@@ -110,28 +110,28 @@ class TestArtifacts:
         # log using file handle
         for key, artifact_filepath in artifacts[:len(artifacts)//2]:
             with open(artifact_filepath, 'r') as artifact_file:  # does not need to be 'rb'
-                experiment_run.log_artifact(key, artifact_file)
+                deployable_entity.log_artifact(key, artifact_file)
 
         # log using filepath
         for key, artifact_filepath in artifacts[len(artifacts)//2:]:
-            experiment_run.log_artifact(key, artifact_filepath)
+            deployable_entity.log_artifact(key, artifact_filepath)
 
         # get
         for key, artifact_filepath in artifacts:
             with open(artifact_filepath, 'rb') as artifact_file:
-                assert experiment_run.get_artifact(key).read() == artifact_file.read()
+                assert deployable_entity.get_artifact(key).read() == artifact_file.read()
 
-    def test_upload_dir(self, experiment_run, strs, dir_and_files):
+    def test_upload_dir(self, deployable_entity, strs, dir_and_files):
         dirpath, filepaths = dir_and_files
         key = strs[0]
 
-        experiment_run.log_artifact(key, dirpath)
+        deployable_entity.log_artifact(key, dirpath)
 
-        with zipfile.ZipFile(experiment_run.get_artifact(key), 'r') as zipf:
+        with zipfile.ZipFile(deployable_entity.get_artifact(key), 'r') as zipf:
             assert filepaths == set(zipf.namelist())
 
     @pytest.mark.not_oss
-    def test_upload_multipart(self, experiment_run, in_tempdir):
+    def test_upload_multipart(self, deployable_entity, in_tempdir):
         key = "large"
 
         # create artifact
@@ -145,12 +145,12 @@ class TestArtifacts:
         PART_SIZE = int(5.4*(10**6))  # 5.4 MB; S3 parts must be > 5 MB
         os.environ['VERTA_ARTIFACT_PART_SIZE'] = str(PART_SIZE)
         try:
-            experiment_run.log_artifact(key, tempf.name)
+            deployable_entity.log_artifact(key, tempf.name)
         finally:
             del os.environ['VERTA_ARTIFACT_PART_SIZE']
 
         # get artifact parts
-        committed_parts = experiment_run.get_artifact_parts(key)
+        committed_parts = deployable_entity.get_artifact_parts(key)
         assert committed_parts
 
         # part checksums match actual file contents
@@ -161,33 +161,33 @@ class TestArtifacts:
                 assert part_hash == committed_part['etag'].strip('"')
 
         # retrieved artifact matches original file
-        filepath = experiment_run.download_artifact(key, download_to_path=key)
+        filepath = deployable_entity.download_artifact(key, download_to_path=key)
         with open(filepath, 'rb') as f:
             file_parts = iter(lambda: f.read(PART_SIZE), b'')
             for file_part, committed_part in zip(file_parts, committed_parts):
                 part_hash = hashlib.md5(file_part).hexdigest()
                 assert part_hash == committed_part['etag'].strip('"')
 
-    def test_empty(self, experiment_run, strs):
+    def test_empty(self, deployable_entity, strs):
         """uploading empty data, e.g. an empty file, raises an error"""
 
         with pytest.raises(ValueError):
-            experiment_run.log_artifact(strs[0], six.BytesIO())
+            deployable_entity.log_artifact(strs[0], six.BytesIO())
 
-    def test_conflict(self, experiment_run, strs, all_values):
+    def test_conflict(self, deployable_entity, strs, all_values):
         all_values = (value  # log_artifact treats str value as filepath to open
                       for value in all_values if not isinstance(value, str))
 
         for key, artifact in zip(strs, all_values):
-            experiment_run.log_artifact(key, artifact)
+            deployable_entity.log_artifact(key, artifact)
             with pytest.raises(ValueError):
-                experiment_run.log_artifact(key, artifact)
+                deployable_entity.log_artifact(key, artifact)
 
         for key, artifact in reversed(list(zip(strs, all_values))):
             with pytest.raises(ValueError):
-                experiment_run.log_artifact(key, artifact)
+                deployable_entity.log_artifact(key, artifact)
 
-    def test_download(self, experiment_run, strs, in_tempdir, random_data):
+    def test_download(self, deployable_entity, strs, in_tempdir, random_data):
         key = strs[0]
         filename = strs[1]
         new_filename = strs[2]
@@ -196,35 +196,35 @@ class TestArtifacts:
         # create file and upload as artifact
         with open(filename, 'wb') as f:
             f.write(FILE_CONTENTS)
-        experiment_run.log_artifact(key, filename)
+        deployable_entity.log_artifact(key, filename)
         os.remove(filename)
 
         # download artifact and verify contents
-        new_filepath = experiment_run.download_artifact(key, new_filename)
+        new_filepath = deployable_entity.download_artifact(key, new_filename)
         assert new_filepath == os.path.abspath(new_filename)
         with open(new_filepath, 'rb') as f:
             assert f.read() == FILE_CONTENTS
 
         # object as well
         obj = {'some': ["arbitrary", "object"]}
-        experiment_run.log_artifact(key, obj, overwrite=True)
-        new_filepath = experiment_run.download_artifact(key, new_filename)
+        deployable_entity.log_artifact(key, obj, overwrite=True)
+        new_filepath = deployable_entity.download_artifact(key, new_filename)
         with open(new_filepath, 'rb') as f:
             assert pickle.load(f) == obj
 
-    def test_download_directory(self, experiment_run, strs, dir_and_files, in_tempdir):
+    def test_download_directory(self, deployable_entity, strs, dir_and_files, in_tempdir):
         key, download_path = strs[:2]
         dirpath, _ = dir_and_files
 
-        experiment_run.log_artifact(key, dirpath)
-        retrieved_path = experiment_run.download_artifact(key, download_path)
+        deployable_entity.log_artifact(key, dirpath)
+        retrieved_path = deployable_entity.download_artifact(key, download_path)
 
         # contents match
         utils.assert_dirs_match(dirpath, retrieved_path)
 
 
 class TestModels:
-    def test_sklearn(self, seed, experiment_run, strs):
+    def test_sklearn(self, seed, deployable_entity, strs):
         np = pytest.importorskip("numpy")
         sklearn = pytest.importorskip("sklearn")
         from sklearn import cluster, naive_bayes, pipeline, preprocessing
@@ -242,8 +242,8 @@ class TestModels:
         )
         pipeline.fit(X, y)
 
-        experiment_run.log_model(pipeline)
-        retrieved_pipeline = experiment_run.get_model()
+        deployable_entity.log_model(pipeline)
+        retrieved_pipeline = deployable_entity.get_model()
 
         assert np.allclose(pipeline.predict(X), retrieved_pipeline.predict(X))
 
@@ -252,7 +252,7 @@ class TestModels:
             assert step[0] == retrieved_step[0]  # step name
             assert step[1].get_params() == retrieved_step[1].get_params()  # step model
 
-    def test_torch(self, seed, experiment_run, strs):
+    def test_torch(self, seed, deployable_entity, strs):
         np = pytest.importorskip("numpy")
         torch = pytest.importorskip("torch")
         import torch.nn as nn
@@ -293,8 +293,8 @@ class TestModels:
             loss.backward()
             optimizer.step()
 
-        experiment_run.log_model(net)
-        retrieved_net = experiment_run.get_model()
+        deployable_entity.log_model(net)
+        retrieved_net = deployable_entity.get_model()
 
         assert torch.allclose(net(X), retrieved_net(X))
 
@@ -302,7 +302,7 @@ class TestModels:
         for key, weight in net.state_dict().items():
             assert torch.allclose(weight, retrieved_net.state_dict()[key])
 
-    def test_torch_state_dict(self, experiment_run, in_tempdir):
+    def test_torch_state_dict(self, deployable_entity, in_tempdir):
         torch = pytest.importorskip("torch")
         import torch.nn as nn
         import torch.nn.functional as F
@@ -332,10 +332,10 @@ class TestModels:
         # save state dict as artifact
         with open("buffer", 'wb') as buffer:
             torch.save(net.state_dict(), buffer)
-        experiment_run.log_artifact("net_state", buffer.name)
+        deployable_entity.log_artifact("net_state", buffer.name)
 
         # retrieve and load state dict
-        state_dict = experiment_run.get_artifact("net_state")
+        state_dict = deployable_entity.get_artifact("net_state")
         new_net = Model()
         new_net.load_state_dict(state_dict)
 
@@ -345,7 +345,7 @@ class TestModels:
             assert torch.allclose(weight, state_dict[key])
 
     @pytest.mark.tensorflow
-    def test_keras(self, seed, experiment_run, strs):
+    def test_keras(self, seed, deployable_entity, strs):
         np = pytest.importorskip("numpy")
         tf = pytest.importorskip("tensorflow")
         from tensorflow import keras
@@ -369,8 +369,8 @@ class TestModels:
         )
         net.fit(X, y, epochs=5)
 
-        experiment_run.log_model(net)
-        retrieved_net = experiment_run.get_model()
+        deployable_entity.log_model(net)
+        retrieved_net = deployable_entity.get_model()
 
         assert np.allclose(net.predict(X), retrieved_net.predict(X))
         # NOTE: history is purged when model is saved
@@ -382,7 +382,7 @@ class TestModels:
 
         tf.compat.v1.reset_default_graph()
 
-    def test_function(self, experiment_run, strs, flat_lists, flat_dicts):
+    def test_function(self, deployable_entity, strs, flat_lists, flat_dicts):
         key = strs[0]
         func_args = flat_lists[0]
         func_kwargs = flat_dicts[0]
@@ -390,11 +390,11 @@ class TestModels:
         def func(is_func=True, _cache=set([1, 2, 3]), *args, **kwargs):
             return (args, kwargs)
 
-        experiment_run.log_model(func)
-        assert experiment_run.get_model().__defaults__ == func.__defaults__
-        assert experiment_run.get_model()(*func_args, **func_kwargs) == func(*func_args, **func_kwargs)
+        deployable_entity.log_model(func)
+        assert deployable_entity.get_model().__defaults__ == func.__defaults__
+        assert deployable_entity.get_model()(*func_args, **func_kwargs) == func(*func_args, **func_kwargs)
 
-    def test_custom_class(self, experiment_run, strs, flat_lists, flat_dicts):
+    def test_custom_class(self, deployable_entity, strs, flat_lists, flat_dicts):
         key = strs[0]
         init_args = flat_lists[0]
         init_kwargs = flat_dicts[0]
@@ -409,11 +409,11 @@ class TestModels:
 
         custom = Custom(*init_args, **init_kwargs)
 
-        experiment_run.log_model(custom)
-        assert experiment_run.get_model().__dict__ == custom.__dict__
-        assert experiment_run.get_model().predict(strs) == custom.predict(strs)
+        deployable_entity.log_model(custom)
+        assert deployable_entity.get_model().__dict__ == custom.__dict__
+        assert deployable_entity.get_model().predict(strs) == custom.predict(strs)
 
-    def test_pyspark(self, experiment_run, in_tempdir):
+    def test_pyspark(self, deployable_entity, in_tempdir):
         data_filename = "census-train.csv"
         spark_model_dir = "spark-model"
 
@@ -437,14 +437,14 @@ class TestModels:
 
         # log model
         model = LogisticRegression().fit(df)
-        experiment_run.log_model(model, custom_modules=[])
+        deployable_entity.log_model(model, custom_modules=[])
 
         # get model
-        with zipfile.ZipFile(experiment_run.get_model()) as zipf:
+        with zipfile.ZipFile(deployable_entity.get_model()) as zipf:
             zipf.extractall(spark_model_dir)
         assert LogisticRegressionModel.load(spark_model_dir).params == model.params
 
-    def test_download_sklearn(self, experiment_run, in_tempdir):
+    def test_download_sklearn(self, deployable_entity, in_tempdir):
         LogisticRegression = pytest.importorskip("sklearn.linear_model").LogisticRegression
 
         upload_path = "model.pkl"
@@ -454,8 +454,8 @@ class TestModels:
         with open(upload_path, 'wb') as f:
             pickle.dump(model, f)
 
-        experiment_run.log_model(model, custom_modules=[])
-        returned_path = experiment_run.download_model(download_path)
+        deployable_entity.log_model(model, custom_modules=[])
+        returned_path = deployable_entity.download_model(download_path)
         assert returned_path == os.path.abspath(download_path)
 
         with open(download_path, 'rb') as f:
@@ -466,54 +466,54 @@ class TestModels:
 
 class TestArbitraryModels:
     @staticmethod
-    def _assert_no_deployment_artifacts(experiment_run):
-        artifact_keys = experiment_run.get_artifact_keys()
+    def _assert_no_deployment_artifacts(deployable_entity):
+        artifact_keys = deployable_entity.get_artifact_keys()
         assert _artifact_utils.CUSTOM_MODULES_KEY not in artifact_keys
         assert _artifact_utils.MODEL_API_KEY not in artifact_keys
 
-    def test_arbitrary_file(self, experiment_run, random_data):
+    def test_arbitrary_file(self, deployable_entity, random_data):
         with tempfile.NamedTemporaryFile() as f:
             f.write(random_data)
             f.seek(0)
 
-            experiment_run.log_model(f)
+            deployable_entity.log_model(f)
 
-        assert experiment_run.get_model().read() == random_data
+        assert deployable_entity.get_model().read() == random_data
 
-        self._assert_no_deployment_artifacts(experiment_run)
+        self._assert_no_deployment_artifacts(deployable_entity)
 
-    def test_arbitrary_directory(self, experiment_run, dir_and_files):
+    def test_arbitrary_directory(self, deployable_entity, dir_and_files):
         dirpath, filepaths = dir_and_files
 
-        experiment_run.log_model(dirpath)
+        deployable_entity.log_model(dirpath)
 
-        with zipfile.ZipFile(experiment_run.get_model(), 'r') as zipf:
+        with zipfile.ZipFile(deployable_entity.get_model(), 'r') as zipf:
             assert set(zipf.namelist()) == filepaths
 
-        self._assert_no_deployment_artifacts(experiment_run)
+        self._assert_no_deployment_artifacts(deployable_entity)
 
-    def test_arbitrary_object(self, experiment_run):
+    def test_arbitrary_object(self, deployable_entity):
         model = {'a': 1}
 
-        experiment_run.log_model(model)
+        deployable_entity.log_model(model)
 
-        assert experiment_run.get_model() == model
+        assert deployable_entity.get_model() == model
 
-        self._assert_no_deployment_artifacts(experiment_run)
+        self._assert_no_deployment_artifacts(deployable_entity)
 
-    def test_download_arbitrary_directory(self, experiment_run, dir_and_files, strs, in_tempdir):
+    def test_download_arbitrary_directory(self, deployable_entity, dir_and_files, strs, in_tempdir):
         """Model that was originally a dir is unpacked on download."""
         dirpath, _ = dir_and_files
         download_path = strs[0]
 
-        experiment_run.log_model(dirpath)
-        returned_path = experiment_run.download_model(download_path)
+        deployable_entity.log_model(dirpath)
+        returned_path = deployable_entity.download_model(download_path)
         assert returned_path == os.path.abspath(download_path)
 
         # contents match
         utils.assert_dirs_match(dirpath, download_path)
 
-    def test_download_arbitrary_zip(self, experiment_run, dir_and_files, strs, in_tempdir):
+    def test_download_arbitrary_zip(self, deployable_entity, dir_and_files, strs, in_tempdir):
         """Model that was originally a ZIP is not unpacked on download."""
         model_dir, _ = dir_and_files
         upload_path, download_path = strs[:2]
@@ -525,8 +525,8 @@ class TestArbitraryModels:
                 f,
             )
 
-        experiment_run.log_model(upload_path)
-        returned_path = experiment_run.download_model(download_path)
+        deployable_entity.log_model(upload_path)
+        returned_path = deployable_entity.download_model(download_path)
         assert returned_path == os.path.abspath(download_path)
 
         assert zipfile.is_zipfile(download_path)
@@ -534,29 +534,29 @@ class TestArbitraryModels:
 
 
 class TestOverwrite:
-    def test_artifact(self, experiment_run):
+    def test_artifact(self, deployable_entity):
         artifact = ['banana']
         new_artifact = ["coconut"]
 
-        experiment_run.log_artifact("date", artifact)
-        experiment_run.log_artifact("date", new_artifact, overwrite=True)
+        deployable_entity.log_artifact("date", artifact)
+        deployable_entity.log_artifact("date", new_artifact, overwrite=True)
 
-        assert experiment_run.get_artifact("date") == new_artifact
+        assert deployable_entity.get_artifact("date") == new_artifact
 
-    def test_model(self, experiment_run):
+    def test_model(self, deployable_entity):
         model = TestArtifacts
         new_model = TestOverwrite
 
-        experiment_run.log_model(model)
-        experiment_run.log_model(new_model, overwrite=True)
+        deployable_entity.log_model(model)
+        deployable_entity.log_model(new_model, overwrite=True)
 
-        assert experiment_run.get_artifact(_artifact_utils.MODEL_KEY) == new_model
+        assert deployable_entity.get_artifact(_artifact_utils.MODEL_KEY) == new_model
 
-    def test_setup_script(self, experiment_run):
+    def test_setup_script(self, deployable_entity):
         setup_script = "import verta"
         new_setup_script = "import cloudpickle"
 
-        experiment_run.log_setup_script(setup_script)
-        experiment_run.log_setup_script(new_setup_script, overwrite=True)
+        deployable_entity.log_setup_script(setup_script)
+        deployable_entity.log_setup_script(new_setup_script, overwrite=True)
 
-        assert experiment_run.get_artifact("setup_script").read() == six.ensure_binary(new_setup_script)
+        assert deployable_entity.get_artifact("setup_script").read() == six.ensure_binary(new_setup_script)

--- a/client/verta/tests/deployable_entity/test_deployment.py
+++ b/client/verta/tests/deployable_entity/test_deployment.py
@@ -1,6 +1,4 @@
-import pytest
-
-import six
+# -*- coding: utf-8 -*-
 
 import glob
 import json
@@ -13,19 +11,18 @@ import time
 import zipfile
 import cloudpickle
 
-import requests
-
-import yaml
+import pytest
+import six
 
 import verta
 from verta.tracking.entities._deployable_entity import _CACHE_DIR
 from verta._internal_utils import (
     _artifact_utils,
-    _histogram_utils,
     _utils,
 )
 from verta.endpoint.update import DirectUpdateStrategy
 from verta.environment import Python
+
 
 pytestmark = pytest.mark.not_oss
 

--- a/client/verta/tests/deployable_entity/test_deployment.py
+++ b/client/verta/tests/deployable_entity/test_deployment.py
@@ -224,7 +224,12 @@ class TestFetchArtifacts:
                        for filepath in six.viewvalues(artifacts))
 
             for key, filepath in six.viewitems(artifacts):
-                artifact_contents, _ = deployable_entity._get_artifact(key)
+                artifact_contents = deployable_entity._get_artifact(key)
+                if type(artifact_contents) is tuple:
+                    # ER returns (contents, path_only)
+                    # TODO: ER & RMV _get_artifact() should return the same thing
+                    artifact_contents, _ = artifact_contents
+
                 with open(filepath, 'rb') as f:
                     file_contents = f.read()
 

--- a/client/verta/tests/deployable_entity/test_deployment.py
+++ b/client/verta/tests/deployable_entity/test_deployment.py
@@ -220,8 +220,10 @@ class TestFetchArtifacts:
             artifacts = deployable_entity.fetch_artifacts(strs)
 
             assert set(six.viewkeys(artifacts)) == set(strs)
-            assert all(filepath.startswith(_CACHE_DIR)
-                       for filepath in six.viewvalues(artifacts))
+            assert all(
+                filepath.startswith(_CACHE_DIR)
+                for filepath in six.viewvalues(artifacts)
+            )
 
             for key, filepath in six.viewitems(artifacts):
                 artifact_contents = deployable_entity._get_artifact(key)
@@ -567,29 +569,6 @@ class TestDeployability:
             filepaths = set(f.getnames())
 
         assert "Dockerfile" in filepaths
-
-    def test_fetch_artifacts(self, deployable_entity, strs, flat_dicts):
-        strs, flat_dicts = strs[:3], flat_dicts[:3]  # all 12 is excessive for a test
-        for key, artifact in zip(strs, flat_dicts):
-            deployable_entity.log_artifact(key, artifact)
-
-        try:
-            artifacts = deployable_entity.fetch_artifacts(strs)
-
-            assert set(six.viewkeys(artifacts)) == set(strs)
-            assert all(
-                filepath.startswith(_deployable_entity._CACHE_DIR)
-                for filepath in six.viewvalues(artifacts)
-            )
-
-            for key, filepath in six.viewitems(artifacts):
-                artifact_contents = deployable_entity._get_artifact(key)
-                with open(filepath, "rb") as f:
-                    file_contents = f.read()
-
-                assert file_contents == artifact_contents
-        finally:
-            shutil.rmtree(_deployable_entity._CACHE_DIR, ignore_errors=True)
 
     def test_model_artifacts(self, deployable_entity, endpoint, in_tempdir):
         key = "foo"

--- a/client/verta/tests/deployable_entity/test_deployment.py
+++ b/client/verta/tests/deployable_entity/test_deployment.py
@@ -38,15 +38,15 @@ def model_packaging():
 
 
 class TestLogModel:
-    def test_model(self, experiment_run, model_for_deployment):
-        experiment_run.log_model(model_for_deployment['model'])
+    def test_model(self, deployable_entity, model_for_deployment):
+        deployable_entity.log_model(model_for_deployment['model'])
 
-        assert model_for_deployment['model'].get_params() == experiment_run.get_model().get_params()
+        assert model_for_deployment['model'].get_params() == deployable_entity.get_model().get_params()
 
-    def test_custom_modules(self, experiment_run, model_for_deployment):
+    def test_custom_modules(self, deployable_entity, model_for_deployment):
         custom_modules_dir = "."
 
-        experiment_run.log_model(
+        deployable_entity.log_model(
             model_for_deployment['model'],
             custom_modules=["."],
         )
@@ -60,12 +60,12 @@ class TestLogModel:
 
             custom_module_filenames.update(map(os.path.basename, filenames))
 
-        custom_modules = experiment_run.get_artifact(_artifact_utils.CUSTOM_MODULES_KEY)
+        custom_modules = deployable_entity.get_artifact(_artifact_utils.CUSTOM_MODULES_KEY)
         with zipfile.ZipFile(custom_modules, 'r') as zipf:
             assert custom_module_filenames == set(map(os.path.basename, zipf.namelist()))
 
-    def test_no_custom_modules(self, experiment_run, model_for_deployment):
-        experiment_run.log_model(model_for_deployment['model'])
+    def test_no_custom_modules(self, deployable_entity, model_for_deployment):
+        deployable_entity.log_model(model_for_deployment['model'])
 
         custom_module_filenames = {"__init__.py", "_verta_config.py"}
         for path in sys.path:
@@ -84,12 +84,12 @@ class TestLogModel:
                     continue
                 custom_module_filenames.update(map(os.path.basename, filenames))
 
-        custom_modules = experiment_run.get_artifact(_artifact_utils.CUSTOM_MODULES_KEY)
+        custom_modules = deployable_entity.get_artifact(_artifact_utils.CUSTOM_MODULES_KEY)
         with zipfile.ZipFile(custom_modules, 'r') as zipf:
             assert custom_module_filenames == set(map(os.path.basename, zipf.namelist()))
 
-    def test_model_api(self, experiment_run, model_for_deployment, model_packaging):
-        experiment_run.log_model(
+    def test_model_api(self, deployable_entity, model_for_deployment, model_packaging):
+        deployable_entity.log_model(
             model_for_deployment['model'],
             model_api=model_for_deployment['model_api'],
         )
@@ -99,45 +99,45 @@ class TestLogModel:
             'model_packaging': model_packaging,
         })
         assert model_api == json.loads(six.ensure_str(
-            experiment_run.get_artifact(_artifact_utils.MODEL_API_KEY).read()))
+            deployable_entity.get_artifact(_artifact_utils.MODEL_API_KEY).read()))
 
-    def test_no_model_api(self, experiment_run, model_for_deployment, model_packaging):
-        experiment_run.log_model(model_for_deployment['model'])
+    def test_no_model_api(self, deployable_entity, model_for_deployment, model_packaging):
+        deployable_entity.log_model(model_for_deployment['model'])
 
         model_api = {
             'version': "v1",
             'model_packaging': model_packaging,
         }
         assert model_api == json.loads(six.ensure_str(
-            experiment_run.get_artifact(_artifact_utils.MODEL_API_KEY).read()))
+            deployable_entity.get_artifact(_artifact_utils.MODEL_API_KEY).read()))
 
-    def test_model_class(self, experiment_run, model_for_deployment):
-        experiment_run.log_model(model_for_deployment['model'].__class__)
+    def test_model_class(self, deployable_entity, model_for_deployment):
+        deployable_entity.log_model(model_for_deployment['model'].__class__)
 
-        assert model_for_deployment['model'].__class__ == experiment_run.get_model()
+        assert model_for_deployment['model'].__class__ == deployable_entity.get_model()
 
         retrieved_model_api = verta.utils.ModelAPI.from_file(
-            experiment_run.get_artifact(_artifact_utils.MODEL_API_KEY))
+            deployable_entity.get_artifact(_artifact_utils.MODEL_API_KEY))
         assert retrieved_model_api.to_dict()['model_packaging']['type'] == "class"
 
-    def test_artifacts(self, experiment_run, model_for_deployment, strs, flat_dicts):
+    def test_artifacts(self, deployable_entity, model_for_deployment, strs, flat_dicts):
         for key, artifact in zip(strs, flat_dicts):
-            experiment_run.log_artifact(key, artifact)
+            deployable_entity.log_artifact(key, artifact)
 
-        experiment_run.log_model(
+        deployable_entity.log_model(
             model_for_deployment['model'].__class__,
             artifacts=strs,
         )
 
-        assert experiment_run.get_attribute("verta_model_artifacts") == strs
+        assert deployable_entity.get_attribute("verta_model_artifacts") == strs
 
-    def test_no_artifacts(self, experiment_run, model_for_deployment):
-        experiment_run.log_model(model_for_deployment['model'].__class__)
+    def test_no_artifacts(self, deployable_entity, model_for_deployment):
+        deployable_entity.log_model(model_for_deployment['model'].__class__)
 
         with pytest.raises(KeyError):
-            experiment_run.get_attribute("verta_model_artifacts")
+            deployable_entity.get_attribute("verta_model_artifacts")
 
-    def test_wrong_type_artifacts_error(self, experiment_run, model_for_deployment, all_values):
+    def test_wrong_type_artifacts_error(self, deployable_entity, model_for_deployment, all_values):
         # remove Nones, because they're equivalent to unprovided
         all_values = [val for val in all_values
                       if val is not None]
@@ -147,43 +147,43 @@ class TestLogModel:
 
         for val in all_values:
             with pytest.raises(TypeError):
-                experiment_run.log_model(
+                deployable_entity.log_model(
                     model_for_deployment['model'].__class__,
                     artifacts=val,
                 )
 
-    def test_not_class_model_artifacts_error(self, experiment_run, model_for_deployment, strs, flat_dicts):
+    def test_not_class_model_artifacts_error(self, deployable_entity, model_for_deployment, strs, flat_dicts):
         for key, artifact in zip(strs, flat_dicts):
-            experiment_run.log_artifact(key, artifact)
+            deployable_entity.log_artifact(key, artifact)
 
         with pytest.raises(ValueError):
-            experiment_run.log_model(
+            deployable_entity.log_model(
                 model_for_deployment['model'],
                 artifacts=strs,
             )
 
-    def test_unlogged_keys_artifacts_error(self, experiment_run, model_for_deployment, strs, flat_dicts):
+    def test_unlogged_keys_artifacts_error(self, deployable_entity, model_for_deployment, strs, flat_dicts):
         with pytest.raises(ValueError):
-            experiment_run.log_model(
+            deployable_entity.log_model(
                 model_for_deployment['model'],
                 artifacts=[strs[0]],
             )
 
-        experiment_run.log_artifact(strs[0], flat_dicts[0])
+        deployable_entity.log_artifact(strs[0], flat_dicts[0])
 
         with pytest.raises(ValueError):
-            experiment_run.log_model(
+            deployable_entity.log_model(
                 model_for_deployment['model'],
                 artifacts=[strs[1]],
             )
 
         with pytest.raises(ValueError):
-            experiment_run.log_model(
+            deployable_entity.log_model(
                 model_for_deployment['model'],
                 artifacts=strs[1:],
             )
 
-    def test_overwrite_artifacts(self, experiment_run, endpoint, in_tempdir):
+    def test_overwrite_artifacts(self, deployable_entity, endpoint, in_tempdir):
         key = "foo"
         val = {'a': 1}
 
@@ -199,32 +199,32 @@ class TestLogModel:
         # first log junk artifact, to test `overwrite`
         bad_key = "bar"
         bad_val = {'b': 2}
-        experiment_run.log_artifact(bad_key, bad_val)
-        experiment_run.log_model(ModelWithDependency, custom_modules=[], artifacts=[bad_key])
+        deployable_entity.log_artifact(bad_key, bad_val)
+        deployable_entity.log_model(ModelWithDependency, custom_modules=[], artifacts=[bad_key])
 
         # log real artifact using `overwrite`
-        experiment_run.log_artifact(key, val)
-        experiment_run.log_model(ModelWithDependency, custom_modules=[], artifacts=[key], overwrite=True)
-        experiment_run.log_environment(Python([]))
+        deployable_entity.log_artifact(key, val)
+        deployable_entity.log_model(ModelWithDependency, custom_modules=[], artifacts=[key], overwrite=True)
+        deployable_entity.log_environment(Python([]))
 
-        endpoint.update(experiment_run, DirectUpdateStrategy(), wait=True)
+        endpoint.update(deployable_entity, DirectUpdateStrategy(), wait=True)
         assert val == endpoint.get_deployed_model().predict(val)
 
 class TestFetchArtifacts:
-    def test_fetch_artifacts(self, experiment_run, strs, flat_dicts):
+    def test_fetch_artifacts(self, deployable_entity, strs, flat_dicts):
         strs, flat_dicts = strs[:3], flat_dicts[:3]  # all 12 is excessive for a test
         for key, artifact in zip(strs, flat_dicts):
-            experiment_run.log_artifact(key, artifact)
+            deployable_entity.log_artifact(key, artifact)
 
         try:
-            artifacts = experiment_run.fetch_artifacts(strs)
+            artifacts = deployable_entity.fetch_artifacts(strs)
 
             assert set(six.viewkeys(artifacts)) == set(strs)
             assert all(filepath.startswith(_CACHE_DIR)
                        for filepath in six.viewvalues(artifacts))
 
             for key, filepath in six.viewitems(artifacts):
-                artifact_contents, _ = experiment_run._get_artifact(key)
+                artifact_contents, _ = deployable_entity._get_artifact(key)
                 with open(filepath, 'rb') as f:
                     file_contents = f.read()
 
@@ -232,30 +232,30 @@ class TestFetchArtifacts:
         finally:
             shutil.rmtree(_CACHE_DIR, ignore_errors=True)
 
-    def test_cached_fetch_artifacts(self, experiment_run, strs, flat_dicts):
+    def test_cached_fetch_artifacts(self, deployable_entity, strs, flat_dicts):
         key = strs[0]
 
-        experiment_run.log_artifact(key, flat_dicts[0])
+        deployable_entity.log_artifact(key, flat_dicts[0])
 
         try:
-            filepath = experiment_run.fetch_artifacts([key])[key]
+            filepath = deployable_entity.fetch_artifacts([key])[key]
             last_modified = os.path.getmtime(filepath)
 
             time.sleep(3)
-            assert experiment_run.fetch_artifacts([key])[key] == filepath
+            assert deployable_entity.fetch_artifacts([key])[key] == filepath
 
             assert os.path.getmtime(filepath) == last_modified
         finally:
             shutil.rmtree(_CACHE_DIR, ignore_errors=True)
 
-    def test_fetch_zip(self, experiment_run, strs, dir_and_files):
+    def test_fetch_zip(self, deployable_entity, strs, dir_and_files):
         dirpath, filepaths = dir_and_files
         key = strs[0]
 
-        experiment_run.log_artifact(key, dirpath)
+        deployable_entity.log_artifact(key, dirpath)
 
         try:
-            dirpath = experiment_run.fetch_artifacts([key])[key]
+            dirpath = deployable_entity.fetch_artifacts([key])[key]
 
             assert dirpath.startswith(_CACHE_DIR)
 
@@ -270,24 +270,24 @@ class TestFetchArtifacts:
         finally:
             shutil.rmtree(_CACHE_DIR, ignore_errors=True)
 
-    def test_cached_fetch_zip(self, experiment_run, strs, dir_and_files):
+    def test_cached_fetch_zip(self, deployable_entity, strs, dir_and_files):
         dirpath, _ = dir_and_files
         key = strs[0]
 
-        experiment_run.log_artifact(key, dirpath)
+        deployable_entity.log_artifact(key, dirpath)
 
         try:
-            dirpath = experiment_run.fetch_artifacts([key])[key]
+            dirpath = deployable_entity.fetch_artifacts([key])[key]
             last_modified = os.path.getmtime(dirpath)
 
             time.sleep(3)
-            assert experiment_run.fetch_artifacts([key])[key] == dirpath
+            assert deployable_entity.fetch_artifacts([key])[key] == dirpath
 
             assert os.path.getmtime(dirpath) == last_modified
         finally:
             shutil.rmtree(_CACHE_DIR, ignore_errors=True)
 
-    def test_fetch_tgz(self, experiment_run, strs, dir_and_files):
+    def test_fetch_tgz(self, deployable_entity, strs, dir_and_files):
         dirpath, filepaths = dir_and_files
         key = strs[0]
 
@@ -299,10 +299,10 @@ class TestFetchArtifacts:
             os.fsync(tempf.fileno())  # flush OS buffer
             tempf.seek(0)
 
-            experiment_run.log_artifact(key, tempf.name)
+            deployable_entity.log_artifact(key, tempf.name)
 
         try:
-            dirpath = experiment_run.fetch_artifacts([key])[key]
+            dirpath = deployable_entity.fetch_artifacts([key])[key]
 
             assert dirpath.startswith(_CACHE_DIR)
 
@@ -317,7 +317,7 @@ class TestFetchArtifacts:
         finally:
             shutil.rmtree(_CACHE_DIR, ignore_errors=True)
 
-    def test_fetch_tar(self, experiment_run, strs, dir_and_files):
+    def test_fetch_tar(self, deployable_entity, strs, dir_and_files):
         dirpath, filepaths = dir_and_files
         key = strs[0]
 
@@ -329,10 +329,10 @@ class TestFetchArtifacts:
             os.fsync(tempf.fileno())  # flush OS buffer
             tempf.seek(0)
 
-            experiment_run.log_artifact(key, tempf.name)
+            deployable_entity.log_artifact(key, tempf.name)
 
         try:
-            dirpath = experiment_run.fetch_artifacts([key])[key]
+            dirpath = deployable_entity.fetch_artifacts([key])[key]
 
             assert dirpath.startswith(_CACHE_DIR)
 
@@ -347,7 +347,7 @@ class TestFetchArtifacts:
         finally:
             shutil.rmtree(_CACHE_DIR, ignore_errors=True)
 
-    def test_fetch_tar_gz(self, experiment_run, strs, dir_and_files):
+    def test_fetch_tar_gz(self, deployable_entity, strs, dir_and_files):
         dirpath, filepaths = dir_and_files
         key = strs[0]
 
@@ -359,10 +359,10 @@ class TestFetchArtifacts:
             os.fsync(tempf.fileno())  # flush OS buffer
             tempf.seek(0)
 
-            experiment_run.log_artifact(key, tempf.name)
+            deployable_entity.log_artifact(key, tempf.name)
 
         try:
-            dirpath = experiment_run.fetch_artifacts([key])[key]
+            dirpath = deployable_entity.fetch_artifacts([key])[key]
 
             assert dirpath.startswith(_CACHE_DIR)
 
@@ -377,63 +377,63 @@ class TestFetchArtifacts:
         finally:
             shutil.rmtree(_CACHE_DIR, ignore_errors=True)
 
-    def test_wrong_type_artifacts_error(self, experiment_run, all_values):
+    def test_wrong_type_artifacts_error(self, deployable_entity, all_values):
         # remove lists of strings and empty lists, because they're valid arguments
         all_values = [val for val in all_values
                       if not (isinstance(val, list) and all(isinstance(el, six.string_types) for el in val))]
 
         for val in all_values:
             with pytest.raises(TypeError):
-                experiment_run.fetch_artifacts(val)
+                deployable_entity.fetch_artifacts(val)
 
-    def test_unlogged_keys_artifacts_error(self, experiment_run, strs, flat_dicts):
+    def test_unlogged_keys_artifacts_error(self, deployable_entity, strs, flat_dicts):
         with pytest.raises(ValueError):
-            experiment_run.fetch_artifacts([strs[0]])
+            deployable_entity.fetch_artifacts([strs[0]])
 
-        experiment_run.log_artifact(strs[0], flat_dicts[0])
-
-        with pytest.raises(ValueError):
-            experiment_run.fetch_artifacts([strs[1]])
+        deployable_entity.log_artifact(strs[0], flat_dicts[0])
 
         with pytest.raises(ValueError):
-            experiment_run.fetch_artifacts(strs[1:])
+            deployable_entity.fetch_artifacts([strs[1]])
+
+        with pytest.raises(ValueError):
+            deployable_entity.fetch_artifacts(strs[1:])
 
 
 class TestDeployability:
     """Deployment-related functionality"""
 
     def test_log_environment(self, registered_model):
-        model_version = registered_model.get_or_create_version(name="my version")
+        deployable_entity = registered_model.get_or_create_version(name="my version")
 
         reqs = Python.read_pip_environment()
         env = Python(requirements=reqs)
-        model_version.log_environment(env)
+        deployable_entity.log_environment(env)
 
-        model_version = registered_model.get_version(id=model_version.id)
-        assert str(env) == str(model_version.get_environment())
+        deployable_entity = registered_model.get_version(id=deployable_entity.id)
+        assert str(env) == str(deployable_entity.get_environment())
 
         with pytest.raises(ValueError):
-            model_version.log_environment(env)
-        model_version.log_environment(env, overwrite=True)
-        assert str(env) == str(model_version.get_environment())
+            deployable_entity.log_environment(env)
+        deployable_entity.log_environment(env, overwrite=True)
+        assert str(env) == str(deployable_entity.get_environment())
 
     def test_del_environment(self, registered_model):
-        model_version = registered_model.get_or_create_version(name="my version")
+        deployable_entity = registered_model.get_or_create_version(name="my version")
 
         reqs = Python.read_pip_environment()
         env = Python(requirements=reqs)
-        model_version.log_environment(env)
-        model_version.del_environment()
+        deployable_entity.log_environment(env)
+        deployable_entity.del_environment()
 
-        model_version = registered_model.get_version(id=model_version.id)
-        assert not model_version.has_environment
+        deployable_entity = registered_model.get_version(id=deployable_entity.id)
+        assert not deployable_entity.has_environment
 
         with pytest.raises(RuntimeError) as excinfo:
-            model_version.get_environment()
+            deployable_entity.get_environment()
 
         assert "environment was not previously set" in str(excinfo.value)
 
-    def test_log_model(self, model_version):
+    def test_log_model(self, deployable_entity):
         np = pytest.importorskip("numpy")
         sklearn = pytest.importorskip("sklearn")
         from sklearn.linear_model import LogisticRegression
@@ -441,28 +441,28 @@ class TestDeployability:
         classifier = LogisticRegression()
         classifier.fit(np.random.random((36, 12)), np.random.random(36).round())
         original_coef = classifier.coef_
-        model_version.log_model(classifier)
+        deployable_entity.log_model(classifier)
 
         # retrieve the classifier:
-        retrieved_classfier = model_version.get_model()
+        retrieved_classfier = deployable_entity.get_model()
         assert np.array_equal(retrieved_classfier.coef_, original_coef)
 
         # check model api:
-        assert _artifact_utils.MODEL_API_KEY in model_version.get_artifact_keys()
-        for artifact in model_version._msg.artifacts:
+        assert _artifact_utils.MODEL_API_KEY in deployable_entity.get_artifact_keys()
+        for artifact in deployable_entity._msg.artifacts:
             if artifact.key == _artifact_utils.MODEL_API_KEY:
                 assert artifact.filename_extension == "json"
 
         # overwrite should work:
         new_classifier = LogisticRegression()
         new_classifier.fit(np.random.random((36, 12)), np.random.random(36).round())
-        model_version.log_model(new_classifier, overwrite=True)
-        retrieved_classfier = model_version.get_model()
+        deployable_entity.log_model(new_classifier, overwrite=True)
+        retrieved_classfier = deployable_entity.get_model()
         assert np.array_equal(retrieved_classfier.coef_, new_classifier.coef_)
 
         # when overwrite = false, overwriting should fail
         with pytest.raises(ValueError) as excinfo:
-            model_version.log_model(new_classifier)
+            deployable_entity.log_model(new_classifier)
 
         assert "model already exists" in str(excinfo.value)
 
@@ -488,13 +488,13 @@ class TestDeployability:
                     continue
                 custom_module_filenames.update(map(os.path.basename, filenames))
 
-        custom_modules = model_version.get_artifact(_artifact_utils.CUSTOM_MODULES_KEY)
+        custom_modules = deployable_entity.get_artifact(_artifact_utils.CUSTOM_MODULES_KEY)
         with zipfile.ZipFile(custom_modules, "r") as zipf:
             assert custom_module_filenames == set(
                 map(os.path.basename, zipf.namelist())
             )
 
-    def test_download_sklearn(self, model_version, in_tempdir):
+    def test_download_sklearn(self, deployable_entity, in_tempdir):
         LogisticRegression = pytest.importorskip(
             "sklearn.linear_model"
         ).LogisticRegression
@@ -506,8 +506,8 @@ class TestDeployability:
         with open(upload_path, "wb") as f:
             pickle.dump(model, f)
 
-        model_version.log_model(model, custom_modules=[])
-        returned_path = model_version.download_model(download_path)
+        deployable_entity.log_model(model, custom_modules=[])
+        returned_path = deployable_entity.download_model(download_path)
         assert returned_path == os.path.abspath(download_path)
 
         with open(download_path, "rb") as f:
@@ -515,10 +515,10 @@ class TestDeployability:
 
         assert downloaded_model.get_params() == model.get_params()
 
-    def test_log_model_with_custom_modules(self, model_version, model_for_deployment):
+    def test_log_model_with_custom_modules(self, deployable_entity, model_for_deployment):
         custom_modules_dir = "."
 
-        model_version.log_model(
+        deployable_entity.log_model(
             model_for_deployment["model"],
             custom_modules=["."],
         )
@@ -536,25 +536,25 @@ class TestDeployability:
 
             custom_module_filenames.update(map(os.path.basename, filenames))
 
-        custom_modules = model_version.get_artifact(_artifact_utils.CUSTOM_MODULES_KEY)
+        custom_modules = deployable_entity.get_artifact(_artifact_utils.CUSTOM_MODULES_KEY)
         with zipfile.ZipFile(custom_modules, "r") as zipf:
             assert custom_module_filenames == set(
                 map(os.path.basename, zipf.namelist())
             )
 
     def test_download_docker_context(
-        self, experiment_run, model_for_deployment, in_tempdir, registered_model
+        self, deployable_entity, model_for_deployment, in_tempdir, registered_model
     ):
         download_to_path = "context.tgz"
 
-        experiment_run.log_model(model_for_deployment["model"], custom_modules=[])
-        experiment_run.log_environment(Python(["scikit-learn"]))
-        model_version = registered_model.create_version_from_run(
-            run_id=experiment_run.id,
-            name="From Run {}".format(experiment_run.id),
+        deployable_entity.log_model(model_for_deployment["model"], custom_modules=[])
+        deployable_entity.log_environment(Python(["scikit-learn"]))
+        deployable_entity = registered_model.create_version_from_run(
+            run_id=deployable_entity.id,
+            name="From Run {}".format(deployable_entity.id),
         )
 
-        filepath = model_version.download_docker_context(download_to_path)
+        filepath = deployable_entity.download_docker_context(download_to_path)
         assert filepath == os.path.abspath(download_to_path)
 
         # can be loaded as tgz
@@ -563,13 +563,13 @@ class TestDeployability:
 
         assert "Dockerfile" in filepaths
 
-    def test_fetch_artifacts(self, model_version, strs, flat_dicts):
+    def test_fetch_artifacts(self, deployable_entity, strs, flat_dicts):
         strs, flat_dicts = strs[:3], flat_dicts[:3]  # all 12 is excessive for a test
         for key, artifact in zip(strs, flat_dicts):
-            model_version.log_artifact(key, artifact)
+            deployable_entity.log_artifact(key, artifact)
 
         try:
-            artifacts = model_version.fetch_artifacts(strs)
+            artifacts = deployable_entity.fetch_artifacts(strs)
 
             assert set(six.viewkeys(artifacts)) == set(strs)
             assert all(
@@ -578,7 +578,7 @@ class TestDeployability:
             )
 
             for key, filepath in six.viewitems(artifacts):
-                artifact_contents = model_version._get_artifact(key)
+                artifact_contents = deployable_entity._get_artifact(key)
                 with open(filepath, "rb") as f:
                     file_contents = f.read()
 
@@ -586,7 +586,7 @@ class TestDeployability:
         finally:
             shutil.rmtree(_deployable_entity._CACHE_DIR, ignore_errors=True)
 
-    def test_model_artifacts(self, model_version, endpoint, in_tempdir):
+    def test_model_artifacts(self, deployable_entity, endpoint, in_tempdir):
         key = "foo"
         val = {"a": 1}
 
@@ -602,17 +602,17 @@ class TestDeployability:
         # first log junk artifact, to test `overwrite`
         bad_key = "bar"
         bad_val = {"b": 2}
-        model_version.log_artifact(bad_key, bad_val)
-        model_version.log_model(
+        deployable_entity.log_artifact(bad_key, bad_val)
+        deployable_entity.log_model(
             ModelWithDependency, custom_modules=[], artifacts=[bad_key]
         )
 
         # log real artifact using `overwrite`
-        model_version.log_artifact(key, val)
-        model_version.log_model(
+        deployable_entity.log_artifact(key, val)
+        deployable_entity.log_model(
             ModelWithDependency, custom_modules=[], artifacts=[key], overwrite=True
         )
-        model_version.log_environment(Python([]))
+        deployable_entity.log_environment(Python([]))
 
-        endpoint.update(model_version, DirectUpdateStrategy(), wait=True)
+        endpoint.update(deployable_entity, DirectUpdateStrategy(), wait=True)
         assert val == endpoint.get_deployed_model().predict(val)

--- a/client/verta/tests/deployable_entity/test_deployment.py
+++ b/client/verta/tests/deployable_entity/test_deployment.py
@@ -464,7 +464,7 @@ class TestDeployability:
         with pytest.raises(ValueError) as excinfo:
             deployable_entity.log_model(new_classifier)
 
-        assert "model already exists" in str(excinfo.value)
+        assert "already exists" in str(excinfo.value)
 
         # Check custom modules:
         custom_module_filenames = {"__init__.py", "_verta_config.py"}

--- a/client/verta/tests/deployable_entity/test_deployment.py
+++ b/client/verta/tests/deployable_entity/test_deployment.py
@@ -549,10 +549,6 @@ class TestDeployability:
 
         deployable_entity.log_model(model_for_deployment["model"], custom_modules=[])
         deployable_entity.log_environment(Python(["scikit-learn"]))
-        deployable_entity = registered_model.create_version_from_run(
-            run_id=deployable_entity.id,
-            name="From Run {}".format(deployable_entity.id),
-        )
 
         filepath = deployable_entity.download_docker_context(download_to_path)
         assert filepath == os.path.abspath(download_to_path)

--- a/client/verta/tests/registry/model_version/test_artifacts.py
+++ b/client/verta/tests/registry/model_version/test_artifacts.py
@@ -1,13 +1,8 @@
 # -*- coding: utf-8 -*-
 
-import os
-import pickle
-
 import pytest
 
 from verta._internal_utils import _artifact_utils
-
-from ... import utils
 
 
 pytestmark = pytest.mark.not_oss  # skip if run in oss setup. Applied to entire module

--- a/client/verta/tests/registry/model_version/test_artifacts.py
+++ b/client/verta/tests/registry/model_version/test_artifacts.py
@@ -57,41 +57,6 @@ class TestArtifacts:
         retrieved_file = model_version.get_artifact("file")
         assert retrieved_file.getvalue() == FILE_CONTENTS
 
-    def test_download(self, model_version, strs, in_tempdir, random_data):
-        key = strs[0]
-        filename = strs[1]
-        new_filename = strs[2]
-        FILE_CONTENTS = random_data
-
-        # create file and upload as artifact
-        with open(filename, "wb") as f:
-            f.write(FILE_CONTENTS)
-        model_version.log_artifact(key, filename)
-        os.remove(filename)
-
-        # download artifact and verify contents
-        new_filepath = model_version.download_artifact(key, new_filename)
-        assert new_filepath == os.path.abspath(new_filename)
-        with open(new_filepath, "rb") as f:
-            assert f.read() == FILE_CONTENTS
-
-        # object as well
-        obj = {"some": ["arbitrary", "object"]}
-        model_version.log_artifact(key, obj, overwrite=True)
-        new_filepath = model_version.download_artifact(key, new_filename)
-        with open(new_filepath, "rb") as f:
-            assert pickle.load(f) == obj
-
-    def test_download_directory(self, model_version, strs, dir_and_files, in_tempdir):
-        key, download_path = strs[:2]
-        dirpath, _ = dir_and_files
-
-        model_version.log_artifact(key, dirpath)
-        retrieved_path = model_version.download_artifact(key, download_path)
-
-        # contents match
-        utils.assert_dirs_match(dirpath, retrieved_path)
-
     def test_wrong_key(self, model_version):
         with pytest.raises(KeyError) as excinfo:
             model_version.get_model()

--- a/client/verta/tests/registry/model_version/test_deployment.py
+++ b/client/verta/tests/registry/model_version/test_deployment.py
@@ -1,31 +1,19 @@
 # -*- coding: utf-8 -*-
 
 import datetime
-import filecmp
-import glob
 import json
-import pickle
 import os
-import shutil
-import sys
-import tarfile
-import tempfile
 import uuid
-import zipfile
 
-import cloudpickle
 import hypothesis
 import hypothesis.strategies as st
 import pytest
-import six
 
 from verta._protos.public.monitoring.DeploymentIntegration_pb2 import (
     FeatureDataInModelVersion,
 )
-from verta._internal_utils import _artifact_utils, _utils
+from verta._internal_utils import _utils
 from verta.data_types import _verta_data_type
-from verta.endpoint.update import DirectUpdateStrategy
-from verta.environment import Python
 from verta.monitoring import profiler
 from verta.registry.entities import RegisteredModelVersion
 from verta.tracking.entities import _deployable_entity

--- a/client/verta/tests/test_experimentrun/test_deployment.py
+++ b/client/verta/tests/test_experimentrun/test_deployment.py
@@ -4,14 +4,9 @@ import os
 import tarfile
 
 import pytest
-
-import six
-
 import requests
-
 import yaml
 
-import verta
 from verta._internal_utils import (
     _artifact_utils,
     _utils,

--- a/client/verta/tests/test_experimentrun/test_deployment.py
+++ b/client/verta/tests/test_experimentrun/test_deployment.py
@@ -316,18 +316,3 @@ class TestGitOps:
 
         assert model_deployment['kind'] == "ModelDeployment"
         assert model_deployment['metadata']['name'] == experiment_run.id
-
-    def test_download_docker_context(self, experiment_run, model_for_deployment, in_tempdir):
-        download_to_path = "context.tgz"
-
-        experiment_run.log_model(model_for_deployment['model'], custom_modules=[])
-        experiment_run.log_environment(Python(['scikit-learn']))
-
-        filepath = experiment_run.download_docker_context(download_to_path)
-        assert filepath == os.path.abspath(download_to_path)
-
-        # can be loaded as tgz
-        with tarfile.open(filepath, 'r:gz') as f:
-            filepaths = set(f.getnames())
-
-        assert "Dockerfile" in filepaths


### PR DESCRIPTION
## Impact and Context

These tests for artifact download are already covered (basically verbatim) in [`deployable_entity/test_artifacts.py`](https://github.com/VertaAI/modeldb/blob/cf5cce87a51972027550a469317f1a3e0f05219c/client/verta/tests/deployable_entity/test_artifacts.py#L192-L225)

## Risks

None.

## Testing

See #2603 and #2604.

## How to Revert

Revert this PR.
