### PR TITLE
Move _get_artifact_msg() to _DeployableEntity interface

### DIFF
--- a/client/verta/verta/tracking/entities/_deployable_entity.py
+++ b/client/verta/verta/tracking/entities/_deployable_entity.py
@@ -54,6 +54,22 @@ class _DeployableEntity(_ModelDBEntity):
         )
 
     @abc.abstractmethod
+    def _get_artifact_msg(self, key):
+        """Get Artifact protobuf with `key`.
+
+        Paramaters
+        ----------
+        key : str
+            Artifact key.
+
+        Returns
+        -------
+        common.CommonService_pb2.Artifact
+
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
     def _get_artifact(self, key):
         raise NotImplementedError
 


### PR DESCRIPTION
## Impact and Context

Testing #2592 end-to-end involves inspecting `Artifact` protobuf objects to make sure the fields are set. This is made much easier with a `_DeployableEntity._get_artifact_msg()`.

(This method [already exists on `RegisteredModelVersion`](https://github.com/VertaAI/modeldb/blob/de66ff2d1080c2a63b9411157245cb3e9f06ea14/client/verta/verta/registry/entities/_modelversion.py#L265-L277), which is why you'll only see it implemented for `ExperimentRun` in this PR.)

## Risks

This is a slight refactor, which always runs the risk of introducing regressions, but that's what tests are for.

## Testing

- [ ] ~Deployed the service to dev env~
  - no new service added
- [ ] ~Used functionality on dev env~
  - no new service added
- [ ] ~Added unit test(s)~
  - covered by existing tests
- [ ] ~Added integration test(s)~
  - covered by existing tests

Test results:

- Python 2.7 `test_experimentrun/test_artifacts.py` **all passed** (job/pytest-2.7/47)
- Python 3.7 `test_experimentrun/test_artifacts.py` **all passed** (job/pytest-3.7/206)
- Python 2.7 `deployable_entity/test_artifacts.py` **passed with expected failures** (job/pytest-2.7/48)
- Python 3.7 `deployable_entity/test_artifacts.py` **passed with expected failures** (job/pytest-3.7/207)

For more info on "expected failures", see #2604 (tl;dr they're captured in tickets)

## How to Revert

Revert this PR.
