### PR TITLE
Move PaginatedIterable tests to bases/

### DIFF
--- a/client/verta/tests/bases/test_paginated_iterable.py
+++ b/client/verta/tests/bases/test_paginated_iterable.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+
+from verta._protos.public.modeldb import ExperimentRunService_pb2 as _ExperimentRunService
+from verta._bases import _PaginatedIterable
+
+
+class TestPaginatedIterable:
+    class LL(_PaginatedIterable):
+        def __init__(self, size):
+            super(TestPaginatedIterable.LL, self).__init__(None, None, _ExperimentRunService.FindExperimentRuns())
+            self._size = size
+            self._calls = 0
+
+        def _call_back_end(self, msg):
+            self._calls += 1
+
+            start = (self._page_number(msg)-1)*self._page_limit(msg)
+            end = self._page_number(msg)*self._page_limit(msg)
+            end = min(self._size, end)
+            ids = list(range(start, end))
+            objs = [_ExperimentRunService.ExperimentRun(id=str(i)) for i in ids]
+            assert max(ids) <= self._size
+            return objs, self._size
+
+        def _create_element(self, el):
+            return el
+
+    def test_ll(self):
+        size = 1000
+        ll = TestPaginatedIterable.LL(size)
+
+        for i, obj in enumerate(ll):
+            assert str(i) == obj.id
+
+    def test_limit(self):
+        size = 1000
+        limit = 10
+        ll = TestPaginatedIterable.LL(size)
+        ll.set_page_limit(limit)
+
+        for i, obj in enumerate(ll):
+            assert str(i) == obj.id
+
+        assert ll._calls == size/limit

--- a/client/verta/tests/test_entities.py
+++ b/client/verta/tests/test_entities.py
@@ -15,13 +15,10 @@ from verta.tracking.entities._deployable_entity import _CACHE_DIR
 from . import utils
 
 import verta
-from verta._bases import _PaginatedIterable
 from verta._internal_utils import _utils
 import json
 
 from verta.external.six.moves.urllib.parse import urlparse  # pylint: disable=import-error, no-name-in-module
-
-from verta._protos.public.modeldb import ExperimentRunService_pb2 as _ExperimentRunService
 
 
 KWARGS = {
@@ -36,46 +33,6 @@ KWARGS_COMBOS = [dict(zip(KWARGS.keys(), values))
 
 # for `tags` typecheck tests
 TAG = "my-tag"
-
-
-class TestPaginatedIterable:
-    class LL(_PaginatedIterable):
-        def __init__(self, size):
-            super(TestPaginatedIterable.LL, self).__init__(None, None, _ExperimentRunService.FindExperimentRuns())
-            self._size = size
-            self._calls = 0
-
-        def _call_back_end(self, msg):
-            self._calls += 1
-
-            start = (self._page_number(msg)-1)*self._page_limit(msg)
-            end = self._page_number(msg)*self._page_limit(msg)
-            end = min(self._size, end)
-            ids = list(range(start, end))
-            objs = [_ExperimentRunService.ExperimentRun(id=str(i)) for i in ids]
-            assert max(ids) <= self._size
-            return objs, self._size
-
-        def _create_element(self, el):
-            return el
-
-    def test_ll(self):
-        size = 1000
-        ll = TestPaginatedIterable.LL(size)
-
-        for i, obj in enumerate(ll):
-            assert str(i) == obj.id
-
-    def test_limit(self):
-        size = 1000
-        limit = 10
-        ll = TestPaginatedIterable.LL(size)
-        ll.set_page_limit(limit)
-
-        for i, obj in enumerate(ll):
-            assert str(i) == obj.id
-
-        assert ll._calls == size/limit
 
 
 class TestClient:


### PR DESCRIPTION
## Impact and Context

#2592 adds a `bases/` testing subdirectory, which is a good location for the `_PaginatedIterable` tests to reside in.

## Risks

Because tests are effectively being renamed, we may lose continuity in Jenkins history.

## Testing

- [ ] ~Deployed the service to dev env~
  - no new service added
- [ ] ~Used functionality on dev env~
  - no new service added
- [ ] ~Added unit test(s)~
  - covered by existing tests
- [ ] ~Added integration test(s)~
  - covered by existing tests

Test results:

- Python 2.7 `bases/test_paginated_iterable.py` **all passed** (job/pytest-2.7/50)
- Python 3.7 `bases/test_paginated_iterable.py` **all passed** (job/pytest-3.7/210)

## How to Revert

Revert this PR.
