### PR TITLE
Don't install protobuf incompatible with Python 2

### DIFF
--- a/client/verta/setup.py
+++ b/client/verta/setup.py
@@ -29,7 +29,7 @@ setup(
         "cloudpickle~=1.0",
         "googleapis-common-protos>=1.5, <2.0",
         "pathlib2>=2.2, <3.0",
-        "protobuf>=3.8, <4.0",
+        "protobuf>=3.8, <3.18",
         "pytimeparse>=1.1.8, <2.0",
         "pyyaml>=5.1, <5.4",
         "requests>=2.21, <3.0",


### PR DESCRIPTION
## Impact and Context

https://github.com/protocolbuffers/protobuf/issues/8984

Enjoy the freedom from Python 2, Protobuf maintainers :salute:.

## Risks

We might not get further updates to `protobuf`.

## Testing

Witness passage of the linting checks.

## How to Revert

Revert this PR.
