### PR TITLE
[VR-9364] Support setting custom environment variables

### DIFF
--- a/client/verta/tests/strategies.py
+++ b/client/verta/tests/strategies.py
@@ -44,3 +44,40 @@ def filepath(draw):
 
     segments = [draw(st.text(legal_chars, min_size=1)) for _ in range(num_segments)]
     return os.path.join(*segments)
+
+
+@st.composite
+def env_vars(draw):
+    """For use as Environment versioning's `env_var` parameter.
+
+    The parameter can be either a list of variable names that exist in the
+    environment or a mapping of names to specific values.
+
+    Returns
+    -------
+    env_vars : list of str, or dict of str to str
+        Environment variables.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        env = Environment(env_vars=env_vars)
+
+        if isinstance(env_vars, list):
+            env_vars = {name: os.environ[name] for name in env_vars}
+
+        assert env.env_vars == (env_vars or None)
+
+    """
+    return draw(
+        st.one_of(
+            st.lists(
+                st.sampled_from(sorted(os.environ.keys())),
+            ),
+            st.dictionaries(
+                keys=st.text(min_size=1),
+                values=st.text(min_size=1),
+            ),
+        )
+    )

--- a/client/verta/tests/versioning/environment/test_environment.py
+++ b/client/verta/tests/versioning/environment/test_environment.py
@@ -4,6 +4,7 @@ import os
 
 import hypothesis
 import hypothesis.strategies as st
+import pytest
 
 from verta.environment import _Environment
 
@@ -21,6 +22,20 @@ class Environment(_Environment):
 
 class TestEnvironmentVariables:
     @hypothesis.given(
+        env_vars=st.dictionaries(
+            keys=st.text(min_size=1),
+            values=st.text(min_size=1),
+        ),
+    )
+    def test_provided_values(self, env_vars):
+        env = Environment(
+            env_vars=env_vars,
+            autocapture=False,
+        )
+
+        assert env.env_vars == env_vars
+
+    @hypothesis.given(
         names=st.lists(st.sampled_from(sorted(os.environ.keys()))),
     )
     def test_capture_values(self, names):
@@ -33,3 +48,44 @@ class TestEnvironmentVariables:
             name: os.environ[name]
             for name in names
         }
+
+    @hypothesis.given(
+        env_vars=st.dictionaries(
+            keys=st.text(min_size=1),
+            values=st.text(min_size=1),
+        ),
+        names=st.lists(st.sampled_from(sorted(os.environ.keys()))),
+    )
+    def test_add(self, env_vars, names):
+        env = Environment(
+            env_vars=env_vars,
+            autocapture=False,
+        )
+        env.add_env_vars(names)
+
+        expected_env_vars = {
+            name: os.environ[name]
+            for name in names
+        }
+        expected_env_vars.update(env_vars)
+        assert env.env_vars == expected_env_vars
+
+    @hypothesis.given(name=st.text(min_size=1))
+    def test_not_found_error(self, name):
+        hypothesis.assume(name not in os.environ)
+
+        with pytest.raises(KeyError, match="not found in environment"):
+            Environment(
+                env_vars=[name],
+                autocapture=False,
+            )
+
+        env = Environment(
+            env_vars={"foo": "bar"},
+            autocapture=False,
+        )
+
+        with pytest.raises(KeyError, match="not found in environment"):
+            env.add_env_vars(
+                [name],
+            )

--- a/client/verta/tests/versioning/environment/test_environment.py
+++ b/client/verta/tests/versioning/environment/test_environment.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+
+import os
+
+import hypothesis
+import hypothesis.strategies as st
+
+from verta.environment import _Environment
+
+
+class Environment(_Environment):
+    """A minimal concrete class."""
+
+    @classmethod
+    def _from_proto(cls, blob_msg):
+        pass
+
+    def _as_proto(self):
+        pass
+
+
+class TestEnvironmentVariables:
+    @hypothesis.given(
+        names=st.lists(st.sampled_from(sorted(os.environ.keys()))),
+    )
+    def test_capture_values(self, names):
+        env = Environment(
+            env_vars=names,
+            autocapture=False,
+        )
+
+        assert env.env_vars == {
+            name: os.environ[name]
+            for name in names
+        }

--- a/client/verta/tests/versioning/environment/test_environment.py
+++ b/client/verta/tests/versioning/environment/test_environment.py
@@ -21,6 +21,17 @@ class Environment(_Environment):
 
 
 class TestEnvironmentVariables:
+    @pytest.mark.parametrize(
+        "env_vars", [None, [], {}],
+    )
+    def test_empty(self, env_vars):
+        env = Environment(
+            env_vars=env_vars,
+            autocapture=False,
+        )
+
+        assert env.env_vars is None
+
     @hypothesis.given(
         env_vars=st.dictionaries(
             keys=st.text(min_size=1),

--- a/client/verta/tests/versioning/environment/test_python.py
+++ b/client/verta/tests/versioning/environment/test_python.py
@@ -107,14 +107,6 @@ class TestPythonVersion:
         assert env._msg.python.version.patch == sys.version_info.micro
 
 
-class TestEnvironmentVariables:
-    def test_env_vars(self):
-        env_vars = os.environ.keys()
-        env = Python(requirements=[], env_vars=env_vars)
-
-        assert env._msg.environment_variables
-
-
 class TestAptPackages:
     def test_apt_packages(self):
         env = Python([])

--- a/client/verta/verta/environment/_environment.py
+++ b/client/verta/verta/environment/_environment.py
@@ -17,6 +17,11 @@ class _Environment(_blob.Blob):
 
     Handles environment variables and command line arguments.
 
+    Attributes
+    ----------
+    env_vars : dict of str to str
+        Environment variables.
+
     """
 
     def __init__(self, env_vars, autocapture, apt_packages=None):
@@ -43,6 +48,10 @@ class _Environment(_blob.Blob):
             self._msg.apt.CopyFrom(apt_blob)
         else:
             self._msg.apt.Clear()
+
+    @property
+    def env_vars(self):
+        return {var.name: var.value for var in self._msg.environment_variables}
 
     def _as_env_proto(self):
         """Returns this environment blob as an environment protobuf message.

--- a/client/verta/verta/environment/_environment.py
+++ b/client/verta/verta/environment/_environment.py
@@ -79,9 +79,6 @@ class _Environment(_blob.Blob):
         --------
         .. code-block:: python
 
-            from verta.environment import Python
-
-            env = Python(requirements=["verta"])
             print(env.env_vars)
             # {}
 

--- a/client/verta/verta/environment/_environment.py
+++ b/client/verta/verta/environment/_environment.py
@@ -22,7 +22,7 @@ class _Environment(_blob.Blob):
 
     Attributes
     ----------
-    env_vars : dict of str to str
+    env_vars : dict of str to str, or None
         Environment variables.
 
     """
@@ -54,7 +54,9 @@ class _Environment(_blob.Blob):
 
     @property
     def env_vars(self):
-        return {var.name: var.value for var in self._msg.environment_variables}
+        return {
+            var.name: var.value for var in self._msg.environment_variables
+        } or None
 
     def _as_env_proto(self):
         """Returns this environment blob as an environment protobuf message.

--- a/client/verta/verta/environment/_environment.py
+++ b/client/verta/verta/environment/_environment.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 import os
 import sys
 
+import six
 from six.moves import collections_abc
 
 from verta.external import six
@@ -101,7 +102,9 @@ class _Environment(_blob.Blob):
             try:
                 env_vars_dict = {name: os.environ[name] for name in env_vars}
             except KeyError as e:
-                new_e = KeyError("'{}' not found in environment".format(e.args[0]))
+                new_e = KeyError("'{}' not found in environment".format(
+                    six.ensure_str(e.args[0]),
+                ))
                 six.raise_from(new_e, None)
 
         self._msg.environment_variables.extend(

--- a/client/verta/verta/environment/_environment.py
+++ b/client/verta/verta/environment/_environment.py
@@ -5,6 +5,8 @@ from __future__ import print_function
 import os
 import sys
 
+from six.moves import collections_abc
+
 from verta.external import six
 from verta import _blob
 
@@ -30,8 +32,8 @@ class _Environment(_blob.Blob):
         # TODO: don't use proto to store data
         self._msg = _EnvironmentService.EnvironmentBlob()
 
-        if env_vars is not None:
-            self._capture_env_vars(env_vars)
+        if env_vars:
+            self.add_env_vars(env_vars)
         if autocapture:
             self._capture_cmd_line_args()
         if apt_packages:
@@ -63,15 +65,44 @@ class _Environment(_blob.Blob):
         """
         return self._msg
 
-    def _capture_env_vars(self, env_vars):
-        if env_vars is None:
-            return
+    def add_env_vars(self, env_vars):
+        """Add environment variables.
 
-        try:
-            env_vars_dict = {name: os.environ[name] for name in env_vars}
-        except KeyError as e:
-            new_e = KeyError("'{}' not found in environment".format(e.args[0]))
-            six.raise_from(new_e, None)
+        Parameters
+        ----------
+        env_vars : list of str, or dict of str to str
+            Environment variables. If a list of names is provided, the values will
+            be captured from the current environment.
+
+        Examples
+        --------
+        .. code-block:: python
+
+            from verta.environment import Python
+
+            env = Python(requirements=["verta"])
+            print(env.env_vars)
+            # {}
+
+            env.add_env_vars(["VERTA_HOST"])
+            print(env.env_vars)
+            # {'VERTA_HOST': 'app.verta.ai'}
+
+            env.add_env_vars({"CUDA_VISIBLE_DEVICES": "0,1"})
+            print(env.env_vars)
+            # {'VERTA_HOST': 'app.verta.ai', 'CUDA_VISIBLE_DEVICES': '0,1'}
+
+        """
+        if isinstance(env_vars, collections_abc.Mapping):
+            # as mapping
+            env_vars_dict = dict(env_vars)
+        else:
+            # as sequence
+            try:
+                env_vars_dict = {name: os.environ[name] for name in env_vars}
+            except KeyError as e:
+                new_e = KeyError("'{}' not found in environment".format(e.args[0]))
+                six.raise_from(new_e, None)
 
         self._msg.environment_variables.extend(
             _EnvironmentService.EnvironmentVariablesBlob(name=name, value=value)

--- a/client/verta/verta/environment/_python.py
+++ b/client/verta/verta/environment/_python.py
@@ -34,8 +34,10 @@ class Python(_environment._Environment):
     constraints : list of str, optional
         List of PyPI package names with version specifiers. If not provided, nothing will be
         captured.
-    env_vars : list of str, optional
-        Names of environment variables to capture. If not provided, nothing will be captured.
+    env_vars : list of str, or dict of str to str, optional
+        Environment variables. If a list of names is provided, the values will
+        be captured from the current environment. If not provided, nothing
+        will be captured.
     apt_packages : list of str, optional
         Apt packages to be installed alongside a Python environment.
     _autocapture : bool, default True

--- a/client/verta/verta/environment/_python.py
+++ b/client/verta/verta/environment/_python.py
@@ -104,13 +104,12 @@ class Python(_environment._Environment):
         if self._msg.python.constraints or self._msg.python.raw_constraints:
             lines.append("constraints:")
             lines.extend(map("    {}".format, self.constraints))
-        if self._msg.environment_variables:
+        if self.env_vars:
             lines.append("environment variables:")
             lines.extend(
-                "    {}={}".format(env_var_msg.name, env_var_msg.value)
-                for env_var_msg in sorted(
-                    self._msg.environment_variables,
-                    key=lambda env_var_msg: env_var_msg.name,
+                sorted(
+                    "    {}={}".format(name, value)
+                    for name, value in self.env_vars.items()
                 )
             )
         if self.apt_packages:

--- a/client/verta/verta/environment/_python.py
+++ b/client/verta/verta/environment/_python.py
@@ -49,6 +49,8 @@ class Python(_environment._Environment):
         pip requirements.
     apt_packages : list of str
         Apt packages to be installed alongside a Python environment.
+    env_vars : dict of str to str
+        Environment variables.
 
     Examples
     --------

--- a/client/verta/verta/environment/_python.py
+++ b/client/verta/verta/environment/_python.py
@@ -51,7 +51,7 @@ class Python(_environment._Environment):
         pip requirements.
     apt_packages : list of str
         Apt packages to be installed alongside a Python environment.
-    env_vars : dict of str to str
+    env_vars : dict of str to str, or None
         Environment variables.
 
     Examples


### PR DESCRIPTION
## Impact and Context

Today, `Python(env_vars)` only accepts a list of environment variable names—the client captures the values from the current environment. However, a user should be able to manually pass in values for environment variables as well, e.g. if the deployment environment and the logging environment are different.

## Risks

This is a slight refactor which always runs the risk of regressions, but that's what testing is for. And test coverage has been greatly expanded around this functionality in this PR!

## Testing
<!-- Check all that are applicable. Explain why if any are not applicable. -->
- [ ] ~Deployed the service to dev env~
  - no new service
- [ ] ~Used functionality on dev env~
  - no new service
- [x] Added unit test(s)
- [ ] ~Added integration test(s)~
  - no new integration behavior

## How to Revert

Revert this PR.
