### PR TITLE
Remove defunct comment

### DIFF
--- a/client/verta/verta/tracking/entities/_experimentrun.py
+++ b/client/verta/verta/tracking/entities/_experimentrun.py
@@ -1693,8 +1693,6 @@ class ExperimentRun(_DeployableEntity):
             raise ValueError(
                 "environment already exists; consider setting overwrite=True")
 
-        # need to call .environment on the proto object because ._as_proto produces
-        # ai.verta.modeldb.versioning.Blob, not ai.verta.modeldb.versioning.EnvironmentBlob
         msg = _ExperimentRunService.LogEnvironment(
             id=self.id, environment=env._as_env_proto())
         response = self._conn.make_proto_request(


### PR DESCRIPTION
## Impact and Context

#2257 Introduced `env._as_env_proto()` as an replacement for `env._as_proto().environment`, making this comment no longer applicable

## Risks

None.

## Testing

None—no new functionality added.

## How to Revert

Revert this PR.
