### PR TITLE
Factor out ensure_starts_with_slash() as a separate util function

### DIFF
--- a/client/verta/tests/test_endpoint/test_endpoint.py
+++ b/client/verta/tests/test_endpoint/test_endpoint.py
@@ -24,7 +24,7 @@ pytestmark = pytest.mark.not_oss  # skip if run in oss setup. Applied to entire 
 
 
 class TestEndpoint:
-    def test_path_prepend_slash(self, client, created_entities):
+    def test_path_ensure_starts_with_slash(self, client, created_entities):
         # without slash
         path = _utils.generate_default_name()
         endpoint = client.create_endpoint(path)

--- a/client/verta/tests/test_endpoint/test_endpoint.py
+++ b/client/verta/tests/test_endpoint/test_endpoint.py
@@ -24,6 +24,22 @@ pytestmark = pytest.mark.not_oss  # skip if run in oss setup. Applied to entire 
 
 
 class TestEndpoint:
+    def test_path_prepend_slash(self, client, created_entities):
+        # without slash
+        path = _utils.generate_default_name()
+        endpoint = client.create_endpoint(path)
+        created_entities.append(endpoint)
+
+        expected_path = "/" + path
+        assert endpoint.path == expected_path
+
+        # with slash
+        path = "/" + _utils.generate_default_name()
+        endpoint = client.create_endpoint(path)
+        created_entities.append(endpoint)
+
+        assert endpoint.path == path
+
     def test_create(self, client, created_entities):
         name = _utils.generate_default_name()
         endpoint = client.set_endpoint(name)

--- a/client/verta/tests/test_utils/test_arg_handler.py
+++ b/client/verta/tests/test_utils/test_arg_handler.py
@@ -11,11 +11,11 @@ class TestPrependSlash:
     def test_with_slash(self, path):
         path = "/" + path
 
-        assert arg_handler.prepend_slash(path) == path
+        assert arg_handler.ensure_starts_with_slash(path) == path
 
     @hypothesis.given(path=st.text(min_size=1))
     def test_without_slash(self, path):
         hypothesis.assume(not path.startswith("/"))
 
         expected_path = "/" + path
-        assert arg_handler.prepend_slash(path) == expected_path
+        assert arg_handler.ensure_starts_with_slash(path) == expected_path

--- a/client/verta/tests/test_utils/test_arg_handler.py
+++ b/client/verta/tests/test_utils/test_arg_handler.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+
+import hypothesis
+import hypothesis.strategies as st
+
+from verta._internal_utils import arg_handler
+
+
+class TestPrependSlash:
+    @hypothesis.given(path=st.text(min_size=1))
+    def test_with_slash(self, path):
+        path = "/" + path
+
+        assert arg_handler.prepend_slash(path) == path
+
+    @hypothesis.given(path=st.text(min_size=1))
+    def test_without_slash(self, path):
+        hypothesis.assume(not path.startswith("/"))
+
+        expected_path = "/" + path
+        assert arg_handler.prepend_slash(path) == expected_path

--- a/client/verta/verta/_internal_utils/arg_handler.py
+++ b/client/verta/verta/_internal_utils/arg_handler.py
@@ -94,3 +94,22 @@ def maybe(fn, val):
         return fn(val)
     else:
         return None
+
+
+def prepend_slash(path):
+    """Prepends ``"/"`` to `path` if it doesn't already start with one.
+
+    Parameters
+    ----------
+    path : str
+        Request path
+
+    Returns
+    -------
+    str
+        `path` prepended with ``"/"`` if it wasn't already.
+
+    """
+    if path.startswith("/"):
+        return path
+    return "/" + path

--- a/client/verta/verta/_internal_utils/arg_handler.py
+++ b/client/verta/verta/_internal_utils/arg_handler.py
@@ -96,7 +96,7 @@ def maybe(fn, val):
         return None
 
 
-def prepend_slash(path):
+def ensure_starts_with_slash(path):
     """Prepends ``"/"`` to `path` if it doesn't already start with one.
 
     Parameters

--- a/client/verta/verta/endpoint/_endpoint.py
+++ b/client/verta/verta/endpoint/_endpoint.py
@@ -139,7 +139,7 @@ class Endpoint(object):
         public_within_org=None,
         visibility=None,
     ):
-        path = arg_handler.prepend_slash(path)
+        path = arg_handler.ensure_starts_with_slash(path)
         (
             visibility,
             public_within_org,

--- a/client/verta/verta/endpoint/_endpoint.py
+++ b/client/verta/verta/endpoint/_endpoint.py
@@ -9,7 +9,7 @@ import yaml
 from verta.external import six
 
 from verta.deployment import DeployedModel
-from verta._internal_utils import _utils
+from verta._internal_utils import _utils, arg_handler
 from verta.tracking.entities import ExperimentRun
 from verta.registry.entities import RegisteredModelVersion
 from verta.visibility import _visibility
@@ -139,8 +139,7 @@ class Endpoint(object):
         public_within_org=None,
         visibility=None,
     ):
-        if not path.startswith("/"):
-            path = "/" + path
+        path = arg_handler.prepend_slash(path)
         (
             visibility,
             public_within_org,


### PR DESCRIPTION
## Impact and Context

This small behavior of "ensure an endpoint path begins with a slash" is going to be used for our Docker image model support, so this PR factors it out to a reusable utility function.

## Risks

This could introduce bugs, but I think there's ample test coverage to rule it out.

## Testing
<!-- Check all that are applicable. Explain why if any are not applicable. -->
- [ ] ~Deployed the service to dev env~
  - no new service
- [ ] ~Used functionality on dev env~
  - no new backend integration behavior
- [x] Added unit test(s)
- [x] Added integration test(s)

```bash
pytest test_utils/test_arg_handler.py test_endpoint/test_endpoint.py::TestEndpoint::test_path_ensure_starts_with_slash
```
passes on my machine in both Python 2.7 and 3.7.

## How to Revert

Revert this PR.
