### PR TITLE
[VR-12958] Replace git-installed verta in requirements with a pinned version

### DIFF
--- a/client/verta/tests/test_utils/test_pip_requirements.py
+++ b/client/verta/tests/test_utils/test_pip_requirements.py
@@ -139,7 +139,11 @@ class TestPinVertaAndCloudpickle:
         other_library=libraries(),
     )
     def test_inject_requirement(self, library, version, other_library):
-        hypothesis.assume(library != other_library)
+        # limitation of current implementation
+        # uses startswith() to avoid dealing with the ==, etc. operators
+        # which is fine since this is only used for verta & cloudpickle
+        hypothesis.assume(not other_library.startswith(library))
+
         pinned_library_req = "{}=={}".format(library, version)
 
         requirements = []

--- a/client/verta/tests/test_utils/test_pip_requirements.py
+++ b/client/verta/tests/test_utils/test_pip_requirements.py
@@ -146,16 +146,25 @@ class TestPinVertaAndCloudpickle:
 
         pinned_library_req = "{}=={}".format(library, version)
 
-        requirements = []
-        _pip_requirements_utils.inject_requirement(requirements, library, version)
+        requirements = _pip_requirements_utils.inject_requirement(
+            [],
+            library,
+            version,
+        )
         assert requirements == [pinned_library_req]
 
-        requirements = [library]
-        _pip_requirements_utils.inject_requirement(requirements, library, version)
+        requirements = _pip_requirements_utils.inject_requirement(
+            [library],
+            library,
+            version,
+        )
         assert requirements == [pinned_library_req]
 
-        requirements = [other_library]
-        _pip_requirements_utils.inject_requirement(requirements, library, version)
+        requirements = _pip_requirements_utils.inject_requirement(
+            [other_library],
+            library,
+            version,
+        )
         assert requirements == [other_library, pinned_library_req]
 
     def test_preserve_req_suffixes(self):
@@ -188,5 +197,5 @@ class TestPinVertaAndCloudpickle:
             for suffix in cloudpickle_reqs_suffixes
         ]
         expected_reqs = expected_verta_reqs + expected_cloudpickle_reqs
-        _pip_requirements_utils.pin_verta_and_cloudpickle(reqs)
+        reqs = _pip_requirements_utils.pin_verta_and_cloudpickle(reqs)
         assert reqs == expected_reqs

--- a/client/verta/tests/versioning/environment/conftest.py
+++ b/client/verta/tests/versioning/environment/conftest.py
@@ -35,7 +35,6 @@ def requirements_file_with_unsupported_lines():
             "-c some_constraints.txt",
             "-f file://dummy",
             "-i https://pypi.org/simple",
-            "-e git+ssh://git@github.com/VertaAI/modeldb.git@master#egg=verta&subdirectory=client/verta",
             "-r more_requirements.txt",
             "en-core-web-sm==2.2.5",
         ]

--- a/client/verta/tests/versioning/environment/test_python.py
+++ b/client/verta/tests/versioning/environment/test_python.py
@@ -60,7 +60,7 @@ class TestObject:
             env_vars=env_vars,
         )
 
-        _pip_requirements_utils.pin_verta_and_cloudpickle(requirements)
+        requirements = _pip_requirements_utils.pin_verta_and_cloudpickle(requirements)
         for line in requirements:
             assert line in repr(env)
         for line in constraints:
@@ -82,7 +82,7 @@ class TestObject:
         assert env._msg.python.raw_requirements
         assert env._msg.python.raw_constraints
 
-        _pip_requirements_utils.pin_verta_and_cloudpickle(requirements)
+        requirements = _pip_requirements_utils.pin_verta_and_cloudpickle(requirements)
         for line in requirements:
             assert line in repr(env)
         for line in constraints:
@@ -145,7 +145,7 @@ class TestParsedRequirements:
         assert env._msg.python.requirements
         assert not env._msg.python.raw_requirements
 
-        _pip_requirements_utils.pin_verta_and_cloudpickle(reqs)
+        reqs = _pip_requirements_utils.pin_verta_and_cloudpickle(reqs)
         assert_parsed_reqs_match(env.requirements, reqs)
 
     def test_from_files(self, requirements_file):
@@ -154,7 +154,7 @@ class TestParsedRequirements:
         assert env._msg.python.requirements
         assert not env._msg.python.raw_requirements
 
-        _pip_requirements_utils.pin_verta_and_cloudpickle(reqs)
+        reqs = _pip_requirements_utils.pin_verta_and_cloudpickle(reqs)
         assert_parsed_reqs_match(env.requirements, reqs)
 
     def test_legacy_no_unsupported_lines(self, requirements_file_with_unsupported_lines):
@@ -223,8 +223,7 @@ class TestRawRequirements:
             assert not env._msg.python.requirements
             assert env._msg.python.raw_requirements
 
-            expected_reqs = [req]
-            _pip_requirements_utils.pin_verta_and_cloudpickle(expected_reqs)
+            expected_reqs = _pip_requirements_utils.pin_verta_and_cloudpickle([req])
             assert env.requirements == expected_reqs
 
     def test_inject_verta_cloudpickle(self):

--- a/client/verta/tests/versioning/environment/test_python.py
+++ b/client/verta/tests/versioning/environment/test_python.py
@@ -198,7 +198,7 @@ class TestParsedRequirements:
         assert requirement.split("+")[0] in env_ver.requirements
 
     def test_inject_verta_cloudpickle(self):
-        env = Python(requirements=[])
+        env = Python(requirements=["pytest"])
         requirements = {req.library for req in env._msg.python.requirements}
 
         assert "verta" in requirements
@@ -229,7 +229,7 @@ class TestRawRequirements:
 
     def test_inject_verta_cloudpickle(self):
         reqs = [
-            "-e client/verta"
+            "--no-binary :all:",
         ]
         env = Python(requirements=reqs)
 
@@ -288,3 +288,21 @@ class TestRawConstraints:
 
         assert env._msg.python.raw_constraints == requirements_file_without_versions.read()
         assert set(env.constraints) == set(constraints)
+
+
+class TestVCSInstalledVerta:
+    @pytest.mark.parametrize(
+        "requirements",
+        [
+            ["-e git+git@github.com:VertaAI/modeldb.git@master#egg=verta&subdirectory=client/verta"],
+            ["-e git+https://github.com/VertaAI/modeldb.git@master#egg=verta&subdirectory=client/verta"],
+            ["-e git+ssh://git@github.com/VertaAI/modeldb.git@master#egg=verta&subdirectory=client/verta"],
+        ],
+    )
+    def test_vcs_installed_verta(self, requirements):
+        vcs_verta_req = requirements[0]
+        pinned_verta_req = "verta=={}".format(verta.__version__)
+
+        env = Python(requirements=requirements)
+        assert vcs_verta_req not in env.requirements
+        assert pinned_verta_req in env.requirements

--- a/client/verta/verta/_internal_utils/_pip_requirements_utils.py
+++ b/client/verta/verta/_internal_utils/_pip_requirements_utils.py
@@ -277,7 +277,7 @@ def pin_verta_and_cloudpickle(requirements):
         conflicts with the version in the current environment.
 
     """
-    # replace VCS-installed verta (`pip install -e verta`) with "verta"
+    # replace git-installed verta (`pip install -e verta`) with "verta"
     for i, req in enumerate(requirements):
         if "VertaAI/modeldb.git" in req and "#egg=verta" in req:
             # git+git is not installable

--- a/client/verta/verta/environment/_python.py
+++ b/client/verta/verta/environment/_python.py
@@ -225,8 +225,7 @@ class Python(_environment._Environment):
                 " not {}".format(type(requirements))
             )
 
-        requirements = copy.copy(requirements)
-        _pip_requirements_utils.pin_verta_and_cloudpickle(requirements)
+        requirements = _pip_requirements_utils.pin_verta_and_cloudpickle(requirements)
 
         try:
             requirements_copy = copy.copy(requirements)


### PR DESCRIPTION
**Recommend reviewing with "hide whitespace changes"**

## Impact and Context

This PR addresses two issues:

1. If a user's environment has `git+https://github.com/VertaAI/modeldb.git#egg=verta`, `Python(requirements)` wouldn't recognize this and would append `verta=={current_version}`, resulting in a duplicate requirement and an installation error.
2. If a user's environment has `git+ssh://git@github.com/VertaAI/modeldb.git#egg=verta`, this has the above issue, but also wouldn't work anyway because the model build machinery may not have the requisite ssh credentials.

The solution chosen is to deliberately replace _all_ git installations of the verta package with `verta=={current_version}`.

## Risks

This means that a user working locally with a non-publicly-published version of the client—when they deploy a model—will have their client version effectively "rounded down" to the nearest public version. But aside from the brief window of this past week, this has always been the case!

## Testing

- [ ] ~Deployed the service to dev env~
  - no new service
- [x] Used functionality on dev env
   - deployed a model using `Python(Python.read_pip_environment())` and it worked
- [x] Added unit test(s)
  - `test_utils/test_pip_requirements.py::TestPinVertaAndCloudpickle::test_inject_requirement`
- [x] Added integration test(s)
  - `versioning/environment/test_python.py::TestVCSInstalledVerta::test_vcs_installed_verta`

`test_utils/test_pip_requirements.py` and `versioning/environment/test_python.py` all pass in Jenkins in Python 2.7 and 3.7.

## How to Revert

Revert this PR.
