### PR TITLE
Clarify that model_api is an optional param

### DIFF
--- a/client/verta/verta/registry/entities/_model.py
+++ b/client/verta/verta/registry/entities/_model.py
@@ -256,7 +256,7 @@ class RegisteredModel(_entity._ModelDBEntity):
             Paths to local Python code files that `model_cls` depends on. This
             parameter has the same behavior as ``custom_modules`` in
             :meth:`RegisteredModelVersion.log_model`.
-        model_api : :class:`~verta.utils.ModelAPI`
+        model_api : :class:`~verta.utils.ModelAPI`, optional
             Model API specifying the model's expected input and output
         artifacts : dict of str to obj
             A mapping from artifact keys to artifacts. These will be logged
@@ -341,7 +341,7 @@ class RegisteredModel(_entity._ModelDBEntity):
             Keras model.
         environment : :class:`~verta.environment.Python`
             pip and apt dependencies.
-        model_api : :class:`~verta.utils.ModelAPI`
+        model_api : :class:`~verta.utils.ModelAPI`, optional
             Model API specifying the model's expected input and output
         name : str, optional
             Name of the model version. If no name is provided, one will be
@@ -414,7 +414,7 @@ class RegisteredModel(_entity._ModelDBEntity):
             scikit-learn model.
         environment : :class:`~verta.environment.Python`
             pip and apt dependencies.
-        model_api : :class:`~verta.utils.ModelAPI`
+        model_api : :class:`~verta.utils.ModelAPI`, optional
             Model API specifying the model's expected input and output
         name : str, optional
             Name of the model version. If no name is provided, one will be
@@ -484,7 +484,7 @@ class RegisteredModel(_entity._ModelDBEntity):
             PyTorch model.
         environment : :class:`~verta.environment.Python`
             pip and apt dependencies.
-        model_api : :class:`~verta.utils.ModelAPI`
+        model_api : :class:`~verta.utils.ModelAPI`, optional
             Model API specifying the model's expected input and output
         name : str, optional
             Name of the model version. If no name is provided, one will be
@@ -570,7 +570,7 @@ class RegisteredModel(_entity._ModelDBEntity):
             XGBoost model using their scikit-learn wrapper interface.
         environment : :class:`~verta.environment.Python`
             pip and apt dependencies.
-        model_api : :class:`~verta.utils.ModelAPI`
+        model_api : :class:`~verta.utils.ModelAPI`, optional
             Model API specifying the model's expected input and output
         name : str, optional
             Name of the model version. If no name is provided, one will be


### PR DESCRIPTION
## Impact and Context

`model_api` is an optional parameter in these methods, but it was not documented as such.

## Risks

None—documentation change.

## Testing

None—documentation change.

## How to Revert

Revert this PR.
