### PR TITLE
[VR-12755] Add registered_model.create_containerized_model()

### DIFF
--- a/client/verta/tests/registry/test_containerized_model.py
+++ b/client/verta/tests/registry/test_containerized_model.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+
+
+class TestContainerizedModels:
+    def test_log(self, registered_model, docker_image):
+        model_ver = registered_model.create_containerized_model(docker_image)
+
+        assert model_ver.get_docker() == docker_image


### PR DESCRIPTION
## Impact and Context

Similar to our `registered_model.create_standard_model*()` methods, we ought to have a convenience function for creating a containerized model directly from a `RegisteredModel`.

~Linting checks fail because this PR depends on #2641.~

## Risks

Because the method isn't atomic—if the lock level is restrictive when the model version is created, `log_docker()` may fail because the version is locked.

This drawback is also present in the `registered_model.create_standard_model*()` methods, and is to be addressed in VRP-23.

## Testing

- [ ] ~Deployed the service to dev env~
  - no new service added
- [x] Used functionality on dev env
  - test run against my dev env
- [ ] ~Added unit test(s)~
- [x] Added integration test(s)

## How to Revert

Revert this PR.
