### PR TITLE
Add tests for reserved registry attributes

### DIFF
--- a/client/verta/tests/registry/test_containerized_model.py
+++ b/client/verta/tests/registry/test_containerized_model.py
@@ -1,8 +1,20 @@
 # -*- coding: utf-8 -*-
 
+from verta.registry import _constants
+
 
 class TestContainerizedModels:
     def test_log(self, registered_model, docker_image):
         model_ver = registered_model.create_containerized_model(docker_image)
 
         assert model_ver.get_docker() == docker_image
+
+        attrs = model_ver.get_attributes()
+        assert (
+            attrs[_constants.MODEL_LANGUAGE_ATTR_KEY]
+            == _constants.ModelLanguage.UNKNOWN
+        )
+        assert (
+            attrs[_constants.MODEL_TYPE_ATTR_KEY]
+            == _constants.ModelType.USER_CONTAINERIZED_MODEL
+        )

--- a/client/verta/tests/registry/test_containerized_model.py
+++ b/client/verta/tests/registry/test_containerized_model.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+
+
+class TestContainerizedModels:
+    def test_log(self, registered_model, docker_image):
+        model_ver = registered_model.create_containerized_model(docker_image)
+
+        assert model_ver.get_docker() == docker_image

--- a/client/verta/tests/registry/test_standard_model.py
+++ b/client/verta/tests/registry/test_standard_model.py
@@ -12,7 +12,7 @@ import pytest
 from verta._internal_utils import _artifact_utils, model_validator
 from verta.environment import Python
 from verta.external import six
-from verta.registry import verify_io
+from verta.registry import _constants, verify_io
 
 from ..models import standard_models
 from ..strategies import json_strategy
@@ -204,6 +204,19 @@ class TestModelValidator:
 
 
 class TestStandardModels:
+
+    @staticmethod
+    def assert_reserved_attributes(model_ver):
+        attrs = model_ver.get_attributes()
+        assert (
+            attrs[_constants.MODEL_LANGUAGE_ATTR_KEY]
+            == _constants.ModelLanguage.PYTHON
+        )
+        assert (
+            attrs[_constants.MODEL_TYPE_ATTR_KEY]
+            == _constants.ModelType.STANDARD_VERTA_MODEL
+        )
+
     @pytest.mark.parametrize(
         "model",
         verta_models,
@@ -230,6 +243,8 @@ class TestStandardModels:
                 artifacts={model.ARTIFACT_KEY: artifact_value},
             )
 
+        self.assert_reserved_attributes(model_ver)
+
         endpoint.update(model_ver, wait=True)
         deployed_model = endpoint.get_deployed_model()
         assert deployed_model.predict(artifact_value) == artifact_value
@@ -247,6 +262,8 @@ class TestStandardModels:
                 Python(["pytest"]),  # source module imports pytest
             )
         assert not record  # no warning of missing decorator on predict()
+
+        self.assert_reserved_attributes(model_ver)
 
         endpoint.update(model_ver, wait=True)
         deployed_model = endpoint.get_deployed_model()
@@ -287,6 +304,8 @@ class TestStandardModels:
             Python(["tensorflow"]),
         )
 
+        self.assert_reserved_attributes(model_ver)
+
         endpoint.update(model_ver, wait=True)
         deployed_model = endpoint.get_deployed_model()
         assert deployed_model.predict(np.random.random(size=(3, 3)))
@@ -324,6 +343,8 @@ class TestStandardModels:
             Python(["scikit-learn"]),
         )
 
+        self.assert_reserved_attributes(model_ver)
+
         endpoint.update(model_ver, wait=True)
         deployed_model = endpoint.get_deployed_model()
         assert deployed_model.predict(np.random.random(size=(3, 3)))
@@ -358,6 +379,8 @@ class TestStandardModels:
             Python(reqs),
         )
 
+        self.assert_reserved_attributes(model_ver)
+
         endpoint.update(model_ver, wait=True)
         deployed_model = endpoint.get_deployed_model()
         assert deployed_model.predict(np.random.random(size=(3, 3)))
@@ -384,6 +407,8 @@ class TestStandardModels:
             model,
             Python(["scikit-learn", "xgboost"]),
         )
+
+        self.assert_reserved_attributes(model_ver)
 
         endpoint.update(model_ver, wait=True)
         deployed_model = endpoint.get_deployed_model()

--- a/client/verta/verta/registry/_constants.py
+++ b/client/verta/verta/registry/_constants.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+
+from verta._protos.public.registry import ModelMetadata_pb2
+
+
+MODEL_LANGUAGE_ATTR_KEY = "__verta_reserved__model_language"
+MODEL_TYPE_ATTR_KEY = "__verta_reserved__model_type"
+
+
+class ModelLanguage:
+    UNKNOWN = ModelMetadata_pb2.ModelLanguageEnum.ModelLanguage.Name(
+        ModelMetadata_pb2.ModelLanguageEnum.Unknown,
+    )
+    PYTHON = ModelMetadata_pb2.ModelLanguageEnum.ModelLanguage.Name(
+        ModelMetadata_pb2.ModelLanguageEnum.Python,
+    )
+
+
+class ModelType:
+    CUSTOM = ModelMetadata_pb2.ModelTypeEnum.ModelType.Name(
+        ModelMetadata_pb2.ModelTypeEnum.Custom,
+    )
+    STANDARD_VERTA_MODEL = ModelMetadata_pb2.ModelTypeEnum.ModelType.Name(
+        ModelMetadata_pb2.ModelTypeEnum.StandardVertaModel,
+    )
+    USER_CONTAINERIZED_MODEL = ModelMetadata_pb2.ModelTypeEnum.ModelType.Name(
+        ModelMetadata_pb2.ModelTypeEnum.UserContainerizedModel,
+    )

--- a/client/verta/verta/registry/entities/_model.py
+++ b/client/verta/verta/registry/entities/_model.py
@@ -9,9 +9,8 @@ from verta._internal_utils import _artifact_utils, _utils, arg_handler, model_va
 
 from verta._protos.public.common import CommonService_pb2 as _CommonCommonService
 from verta._protos.public.registry import RegistryService_pb2 as _RegistryService
-from verta._protos.public.registry.ModelMetadata_pb2 import ModelLanguageEnum, ModelTypeEnum
 
-from .. import VertaModelBase
+from .. import _constants, VertaModelBase
 from ._modelversion import RegisteredModelVersion
 from ._modelversions import RegisteredModelVersions
 
@@ -183,12 +182,8 @@ class RegisteredModel(_entity._ModelDBEntity):
             _artifact_utils.validate_key(key)
         attrs = attrs or {}
         attrs.update({
-            "__verta_reserved__model_language": ModelLanguageEnum.ModelLanguage.Name(
-                ModelLanguageEnum.Python,
-            ),
-            "__verta_reserved__model_type": ModelTypeEnum.ModelType.Name(
-                ModelTypeEnum.StandardVertaModel,
-            ),
+            _constants.MODEL_LANGUAGE_ATTR_KEY: _constants.ModelLanguage.PYTHON,
+            _constants.MODEL_TYPE_ATTR_KEY: _constants.ModelType.STANDARD_VERTA_MODEL,
         })
 
         model_ver = self.create_version(
@@ -686,12 +681,8 @@ class RegisteredModel(_entity._ModelDBEntity):
         """
         attrs = attrs or {}
         attrs.update({
-            "__verta_reserved__model_language": ModelLanguageEnum.ModelLanguage.Name(
-                ModelLanguageEnum.Unknown,
-            ),
-            "__verta_reserved__model_type": ModelTypeEnum.ModelType.Name(
-                ModelTypeEnum.UserContainerizedModel,
-            ),
+            _constants.MODEL_LANGUAGE_ATTR_KEY: _constants.ModelLanguage.UNKNOWN,
+            _constants.MODEL_TYPE_ATTR_KEY: _constants.ModelType.USER_CONTAINERIZED_MODEL,
         })
 
         model_ver = self.create_version(


### PR DESCRIPTION
## Impact and Context

`RegisteredModel`'s `create_standard_model*()` and `create_dockerized_model()` log internal attributes to describe properties of the model, but they're not covered by existing tests.

This PR consolidates those attribute keys and values and constants, and covers them in tests.

## Risks

None—improving existing tests.

## Testing
<!-- Check all that are applicable. Explain why if any are not applicable. -->
- [ ] ~Deployed the service to dev env~
  - no new service
- [ ] ~Used functionality on dev env~
  - no new functionality
- [ ] ~Added unit test(s)~
  - robustified existing tests, passes against my dev env
- [ ] ~Added integration test(s)~
  - robustified existing tests, passes against my dev env

## How to Revert

Revert this PR.
