### PR TITLE
Don't use six.collections_abc

### DIFF
--- a/client/verta/verta/environment/_environment.py
+++ b/client/verta/verta/environment/_environment.py
@@ -2,11 +2,9 @@
 
 from __future__ import print_function
 
+import collections
 import os
 import sys
-
-import six
-from six.moves import collections_abc
 
 from verta.external import six
 from verta import _blob
@@ -104,7 +102,7 @@ class _Environment(_blob.Blob):
             # {'VERTA_HOST': 'app.verta.ai', 'CUDA_VISIBLE_DEVICES': '0,1'}
 
         """
-        if isinstance(env_vars, collections_abc.Mapping):
+        if isinstance(env_vars, collections.Mapping):
             # as mapping
             env_vars_dict = dict(env_vars)
         else:


### PR DESCRIPTION
## Impact and Context

#2634 introduced a mistake in using the user environment's `six` rather than the client's vendored `six`. In addition, `six.moves.collections_abc` is not available in the version of `six` we have vendored. So the current code can result in an `ImportError` when a custom model is deployed.

VR-12980 has been filed to upgrade our vendored six for Python 3.10 compatibility.

## Risks

Our code will [continue to] not be ready as-is for Python 3.10.

## Testing

- [ ] ~Deployed the service to dev env~
  - no new service added
- [x] Used functionality on dev env
  - deployed a model that failed before this change.
- [ ] ~Added unit test(s)~
  - no new functionality added
- [ ] ~Added integration test(s)~
  - no new functionality added

## How to Revert

Revert this PR.
