### PR TITLE
[VR-12990] Enable RMV stage change

### DIFF
--- a/client/verta/tests/registry/model_version/test_crud.py
+++ b/client/verta/tests/registry/model_version/test_crud.py
@@ -7,7 +7,7 @@ import verta
 import verta.dataset
 from verta import visibility
 from verta import data_types
-from verta.registry import lock
+from verta.registry import lock, stage_change
 from verta._internal_utils import importer
 
 pytestmark = pytest.mark.not_oss  # skip if run in oss setup. Applied to entire module
@@ -303,6 +303,27 @@ class TestLockLevels:
             user_model_ver.delete()
         admin_model_ver.delete()
 
+
+class TestStages:
+
+    def test_update_stage(self, model_version):
+        assert model_version.stage == "unassigned"
+
+        assert model_version.change_stage(
+            stage_change.Development("Working on it."),
+        ) == model_version.stage == "development"
+
+        assert model_version.change_stage(
+            stage_change.Staging("Undergoing final testing."),
+        ) == model_version.stage == "staging"
+
+        assert model_version.change_stage(
+            stage_change.Production("Rolling out to prod."),
+        ) == model_version.stage == "production"
+
+        assert model_version.change_stage(
+            stage_change.Archived("Deprioritized; keeping for posterity."),
+        ) == model_version.stage == "archived"
 
 # TODO: combine with test_experimentrun/test_attributes.py::TestComplexAttributes
 @pytest.mark.skipif(

--- a/client/verta/tests/registry/test_stage_change.py
+++ b/client/verta/tests/registry/test_stage_change.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+import hypothesis
+import hypothesis.strategies as st
+import pytest
+
+from verta._protos.public.registry import StageService_pb2
+from verta.registry import stage_change
+
+
+class TestStageChange:
+
+    @pytest.mark.parametrize(
+        "stage_change_cls", stage_change._StageChange.__subclasses__(),
+    )
+    @hypothesis.given(
+        comment=st.one_of(st.none(), st.text()),
+        model_version_id=st.integers(min_value=0, max_value=2 ** 64 - 1),
+    )
+    def test_to_proto_request(
+        self,
+        stage_change_cls,
+        comment,
+        model_version_id,
+    ):
+        stage_change = stage_change_cls(comment=comment)
+        proto_request = stage_change._to_proto_request(model_version_id)
+
+        assert proto_request == StageService_pb2.UpdateStageRequest(
+            model_version_id=model_version_id,
+            stage=stage_change_cls._STAGE,
+            comment=comment,
+        )
+
+    @pytest.mark.parametrize(
+        "stage_change_cls", stage_change._StageChange.__subclasses__(),
+    )
+    @hypothesis.given(
+        comment=st.one_of(st.none(), st.text()),
+    )
+    def test_comment(self, stage_change_cls, comment):
+        stage_change = stage_change_cls(comment=comment)
+        assert stage_change.comment == comment

--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -63,6 +63,8 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
         Whether there is a model associated with this Model Version.
     registered_model_id : int
         ID of this version's Registered Model.
+    stage : str
+        Model version stage.
 
     """
 
@@ -83,9 +85,7 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
         return "\n".join(
             (
                 "version: {}".format(msg.version),
-                "stage: {}".format(
-                    _StageService.StageEnum.Stage.Name(msg.stage).lower()
-                ),
+                "stage: {}".format(self.stage),
                 "lock level: {}".format(
                     _RegistryService.ModelVersionLockLevelEnum.ModelVersionLockLevel.Name(
                         msg.lock_level
@@ -140,6 +140,11 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
     def registered_model_id(self):
         self._refresh_cache()
         return self._msg.registered_model_id
+
+    @property
+    def stage(self):
+        self._refresh_cache()
+        return _StageService.StageEnum.Stage.Name(self._msg.stage).lower()
 
     # @property
     # def is_archived(self):

--- a/client/verta/verta/registry/stage_change/__init__.py
+++ b/client/verta/verta/registry/stage_change/__init__.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+
+"""Stage changes for registered model versions."""
+
+from verta._internal_utils import documentation
+
+
+documentation.reassign_module(
+    [],
+    module_name=__name__,
+)

--- a/client/verta/verta/registry/stage_change/__init__.py
+++ b/client/verta/verta/registry/stage_change/__init__.py
@@ -4,6 +4,7 @@
 
 from verta._internal_utils import documentation
 
+from ._stage_change import _StageChange
 from ._archived import Archived
 from ._development import Development
 from ._production import Production

--- a/client/verta/verta/registry/stage_change/__init__.py
+++ b/client/verta/verta/registry/stage_change/__init__.py
@@ -4,8 +4,18 @@
 
 from verta._internal_utils import documentation
 
+from ._archived import Archived
+from ._development import Development
+from ._production import Production
+from ._staging import Staging
+
 
 documentation.reassign_module(
-    [],
+    [
+        Archived,
+        Development,
+        Production,
+        Staging,
+    ],
     module_name=__name__,
 )

--- a/client/verta/verta/registry/stage_change/_archived.py
+++ b/client/verta/verta/registry/stage_change/_archived.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+
+from verta._protos.public.registry import StageService_pb2
+
+from . import _stage_change
+
+
+class Archived(_stage_change._StageChange):
+    """The model version is archived.
+
+    Parameters
+    ----------
+    comment : str, optional
+        Comment associated with this stage change.
+
+    Attributes
+    ----------
+    comment : str or None
+        Comment associated with this stage change.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        from verta.registry.stage_change import Archived
+
+        model_ver.change_stage(Archived("Deprioritized; keeping for posterity."))
+        model_ver.stage
+        # "archived"
+
+    """
+
+    _STAGE = StageService_pb2.StageEnum.ARCHIVED

--- a/client/verta/verta/registry/stage_change/_development.py
+++ b/client/verta/verta/registry/stage_change/_development.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+
+from verta._protos.public.registry import StageService_pb2
+
+from . import _stage_change
+
+
+class Development(_stage_change._StageChange):
+    """The model version is in active development.
+
+    Parameters
+    ----------
+    comment : str, optional
+        Comment associated with this stage change.
+
+    Attributes
+    ----------
+    comment : str or None
+        Comment associated with this stage change.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        from verta.registry.stage_change import Development
+
+        model_ver.change_stage(Development("Working on it."))
+        model_ver.stage
+        # "development"
+
+    """
+
+    _STAGE = StageService_pb2.StageEnum.DEVELOPMENT

--- a/client/verta/verta/registry/stage_change/_production.py
+++ b/client/verta/verta/registry/stage_change/_production.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+
+from verta._protos.public.registry import StageService_pb2
+
+from . import _stage_change
+
+
+class Production(_stage_change._StageChange):
+    """The model version is in production.
+
+    Parameters
+    ----------
+    comment : str, optional
+        Comment associated with this stage change.
+
+    Attributes
+    ----------
+    comment : str or None
+        Comment associated with this stage change.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        from verta.registry.stage_change import Production
+
+        model_ver.change_stage(Production("Rolling out to prod."))
+        model_ver.stage
+        # "production"
+
+    """
+
+    _STAGE = StageService_pb2.StageEnum.PRODUCTION

--- a/client/verta/verta/registry/stage_change/_stage_change.py
+++ b/client/verta/verta/registry/stage_change/_stage_change.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+
+import abc
+
+from verta.external import six
+
+from verta._protos.public.registry import StageService_pb2
+
+
+@six.add_metaclass(abc.ABCMeta)
+class _StageChange(object):
+    """Base class for registry stage changes. Not for external use."""
+
+    # StageService_pb2.StageEnum variant
+    _STAGE = None
+
+    def __init__(self, comment=None):
+        if comment and not isinstance(comment, six.string_types):
+            raise TypeError("`comment` must be type str, not {}".format(type(comment)))
+
+        self._comment = comment
+
+    def __repr__(self):
+        lines = [type(self).__name__]
+
+        if self._comment:
+            lines.append("comment: {}".format(self._comment))
+
+        return "\t\n".join(lines)
+
+    @property
+    def comment(self):
+        return self._comment
+
+    def _to_proto_request(self, model_version_id):
+        return StageService_pb2.UpdateStageRequest(
+            model_version_id=model_version_id,
+            stage=self._STAGE,
+            comment=self._comment,
+        )

--- a/client/verta/verta/registry/stage_change/_staging.py
+++ b/client/verta/verta/registry/stage_change/_staging.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+
+from verta._protos.public.registry import StageService_pb2
+
+from . import _stage_change
+
+
+class Staging(_stage_change._StageChange):
+    """The model version is staged for production.
+
+    Parameters
+    ----------
+    comment : str, optional
+        Comment associated with this stage change.
+
+    Attributes
+    ----------
+    comment : str or None
+        Comment associated with this stage change.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        from verta.registry.stage_change import Staging
+
+        model_ver.change_stage(Staging("Undergoing final testing."))
+        model_ver.stage
+        # "staging"
+
+    """
+
+    _STAGE = StageService_pb2.StageEnum.STAGING


### PR DESCRIPTION
## Impact and Context

Supporting RMV stage changes in our Python API will facilitate automated model release workflows.

## Risks

Since this functionality is new to the client, it may have bugs, but they would be isolated to this feature and a best attempt has been made at test coverage.

## Testing
<!-- Check all that are applicable. Explain why if any are not applicable. -->
- [ ] ~Deployed the service to dev env~
  - no new service
- [x] Used functionality on dev env
  - tests run against my dev env
- [x] Added unit test(s)
  ```
  pytest registry/test_stage_change.py
  ```
- [x] Added integration test(s)
  ```
  pytest registry/model_version/test_crud.py::TestStages registry/model_version/test_find.py::TestFind::test_find_stage
  ```

## How to Revert

Revert this PR.
