### PR TITLE
Mark 0.20.0's docker image functionality as experimental.

### DIFF
--- a/client/verta/docs/conf.py
+++ b/client/verta/docs/conf.py
@@ -100,22 +100,6 @@ pygments_style = None
 
 # reStructuredText to be included at the beginning of every source file.
 rst_prolog = '\n'.join([
-".. |tags description| replace:: Tags are short textual labels used to help"
-    " identify a run, such as its purpose or its environment.",
-".. |attributes description| replace:: Attributes are descriptive metadata,"
-    " such as the team responsible for this model or the expected training"
-    " time.",
-".. |hyperparameters description| replace:: Hyperparameters are model"
-    " configuration metadata, such as the loss function or the regularization"
-    " penalty.",
-".. |metrics description| replace:: Metrics are unique performance metadata,"
-    " such as accuracy or loss on the full training set.",
-".. |observations description| replace:: Observations are recurring metadata"
-    " that are repeatedly measured over time, such as batch losses over an"
-    " epoch or memory usage.",
-".. |dataset versioning overhaul| replace:: In ``verta==0.16.0``, the dataset"
-    " versioning interface was overhauled to be more flexible, robust, and"
-    " consistent with other ModelDB entities.",
 ])
 
 

--- a/client/verta/docs/conf.py
+++ b/client/verta/docs/conf.py
@@ -100,6 +100,8 @@ pygments_style = None
 
 # reStructuredText to be included at the beginning of every source file.
 rst_prolog = '\n'.join([
+".. |experimental| replace:: This functionality is experimental—please reach"
+    " out to us to verify its availability in your version of our platform.",
 ])
 
 

--- a/client/verta/docs/conf.py
+++ b/client/verta/docs/conf.py
@@ -100,8 +100,9 @@ pygments_style = None
 
 # reStructuredText to be included at the beginning of every source file.
 rst_prolog = '\n'.join([
-".. |experimental| replace:: This functionality is experimental—please reach"
-    " out to us to verify its availability in your version of our platform.",
+".. |experimental| replace:: This feature may require an upgrade to the"
+    " platform; please reach out to the Verta team at support@verta.ai to"
+    " verify its availability in your version of the system.",
 ])
 
 

--- a/client/verta/verta/environment/__init__.py
+++ b/client/verta/verta/environment/__init__.py
@@ -9,6 +9,6 @@ from ._python import Python
 
 
 documentation.reassign_module(
-    [Docker, Python],
+    [Python],
     module_name=__name__,
 )

--- a/client/verta/verta/environment/_docker.py
+++ b/client/verta/verta/environment/_docker.py
@@ -14,8 +14,12 @@ from . import _environment
 logger = logging.getLogger(__name__)
 
 
+# TODO: Add back to documentation.reassign_module() in environment/__init__.py
+#       when this has user-facing functionality.
 class Docker(_environment._Environment):
     """Information to identify a Docker image environment.
+
+    .. versionadded:: 0.20.0
 
     Parameters
     ----------

--- a/client/verta/verta/registry/entities/_model.py
+++ b/client/verta/verta/registry/entities/_model.py
@@ -638,6 +638,10 @@ class RegisteredModel(_entity._ModelDBEntity):
 
         .. versionadded:: 0.20.0
 
+        .. note::
+
+            |experimental|
+
         Parameters
         ----------
         docker_image : :class:`~verta.registry.DockerImage`

--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -285,6 +285,10 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
 
         .. note::
 
+            |experimental|
+
+        .. note::
+
             This method cannot be used alongside :meth:`log_environment`.
 
         Parameters


### PR DESCRIPTION
## Impact and Context

`verta==0.20.0` will introduce functionality that is new to our platform—this PR highlights that potential non-availability in the API docs.

![Screen Shot 2021-09-24 at 4 17 39 PM](https://user-images.githubusercontent.com/7754936/134748628-af4fcfa7-5ec4-4c44-8129-6d69cf11f328.png)

## Risks

None.

## Testing

None—this is documentation-only

## How to Revert

Revert this PR.
