### PR TITLE
[VR-13061] Fix bringing up the OSS mdb backend container

### DIFF
--- a/backend/src/main/java/ai/verta/modeldb/App.java
+++ b/backend/src/main/java/ai/verta/modeldb/App.java
@@ -123,7 +123,8 @@ public class App implements ApplicationContextAware {
 
   @Bean
   public GracefulShutdown gracefulShutdown() {
-    if (mdbConfig == null) {
+    MDBConfig mdbConfig = App.getInstance().mdbConfig;
+    if (mdbConfig == null || mdbConfig.getSpringServer().getShutdownTimeout() == null) {
       return new GracefulShutdown(30L);
     }
     return new GracefulShutdown(mdbConfig.getSpringServer().getShutdownTimeout());


### PR DESCRIPTION
## Impact and Context
<!-- Brief description of why these changes are necessary. Don't rewrite the entire Jira ticket. -->
**Jira Ticket:** https://vertaai.atlassian.net/browse/VR-13061

**Reason:** Expected configuration for spring server is like :
```
springServer:
  port: 8086
  shutdownTimeout: 30

OR

springServer:
  port: 8086
```

but might be OSS user configured it like:
```
springServer:
  port: 8086
  shutdownTimeout: 
```
So MDB code do not used the default value for `shutdownTimeout` because it expect some value there and that null value had create the cause.

**Solution:**
- Added null check for `shutdownTimeout`, now if that value is null then MDB backend will use default value.

## Risks
<!-- Describe any risks. These should be smaller scale than those documented in a design doc. -->

## Testing
<!-- Check all that are applicable. Explain why if any are not applicable. -->
- [ ] Deployed the service to dev env
- [ ] Used functionality on dev env <!-- Explain. For example, you hit the endpoint via Postman. -->
- [ ] Added unit test(s)
- [ ] Added integration test(s)

## How to Revert
<!-- List steps required to revert this change. For example, note if we'd need to revert liquibase changes. -->
