### PR TITLE
Update test

### DIFF
--- a/client/verta/tests/monitoring/alerts/test_entities.py
+++ b/client/verta/tests/monitoring/alerts/test_entities.py
@@ -102,8 +102,6 @@ class TestAlert:
 
         yesterday = time_utils.now() - datetime.timedelta(days=1)
         yesterday_millis = time_utils.epoch_millis(yesterday)
-        # TODO: remove following line when backend stops round to nearest sec
-        yesterday_millis = round(yesterday_millis, -3)
         alert._update_last_evaluated_at(yesterday)
         alert._fetch_with_no_cache()
         assert alert._msg.last_evaluated_at_millis == yesterday_millis


### PR DESCRIPTION
## Impact and Context

This client integration test had a workaround because the backend was rounding this time value to the nearest second.

The backend no longer does this, so this workaround needs to be removed for the test to succeed.

## Risks

None.

## Testing

```bash
pytest monitoring/alerts/test_entities.py::TestAlert::test_update_last_evaluated_at
```

succeeds against my dev environment in Python 2 and 3.

## How to Revert

Revert this PR
