### PR TITLE
Rename test

### DIFF
--- a/client/verta/tests/test_endpoint/test_endpoint.py
+++ b/client/verta/tests/test_endpoint/test_endpoint.py
@@ -220,8 +220,8 @@ class TestEndpoint:
         excinfo_value = str(excinfo.value).strip()
         assert "Could not find a version that satisfies the requirement blahblahblah==3.6.0" in excinfo_value
 
-    def test_update_runtime_error(self, client, model_version, endpoint):
-        """Propagate errors from model being initialized at container runtime."""
+    def test_update_init_error(self, client, model_version, endpoint):
+        """Propagate errors from model being initialized at container init."""
         LogisticRegression = pytest.importorskip("sklearn.linear_model").LogisticRegression
 
         model_version.log_model(LogisticRegression(), custom_modules=[])


### PR DESCRIPTION
## Impact and Context

This test is actually validating a model container init error, rather than one at runtime.

It was named this was because the Python exception being raised is a `RuntimeError`, but that's less relevant for the actual context of the test.

## Risks

A test is being renamed, so we'll lose some continuity in our test report history.

## Testing

None—no change to test code

## How to Revert

Revert this PR.