### PR TITLE
Fix and simplify test

### DIFF
--- a/client/verta/tests/registry/model_version/test_find.py
+++ b/client/verta/tests/registry/model_version/test_find.py
@@ -20,11 +20,9 @@ class TestFind:
 
         len(client.registered_model_versions)
 
-    def test_find(self, client, created_entities):
+    def test_find(self, registered_model, created_entities):
         name = "registered_model_test"
-        registered_model = client.set_registered_model()
-        created_entities.append(registered_model)
-        model_version = registered_model.get_or_create_version(name=name)
+        model_version = registered_model.create_version(name=name)
 
         find_result = registered_model.versions.find(["version == '{}'".format(name)])
         assert len(find_result) == 1
@@ -40,24 +38,18 @@ class TestFind:
         versions[name + "2"].add_label(tag_name)
         versions[name + "2"].add_label("label2")
 
-        for version in versions:
-            versions[version] = registered_model.get_version(version)
+        for version in versions.values():
+            version._refresh_cache()
 
         find_result = registered_model.versions.find(
             ['labels == "{}"'.format(tag_name)]
         )
         assert len(find_result) == 2
         for item in find_result:
-            assert versions[item._msg.version]
-            msg_other = versions[item._msg.version]._msg
-            item._msg.time_updated = msg_other.time_updated = 0
-            labels1 = set(item._msg.labels)
-            item._msg.labels[:] = []
-            labels2 = set(msg_other.labels)
-            msg_other.labels[:] = []
-            msg_other.model.CopyFrom(item._msg.model)
-            assert labels1 == labels2
-            assert item._msg == msg_other
+            assert item.name in versions
+            model_version = versions[item.name]
+
+            assert item._msg == model_version._msg
 
     def test_find_stage(self, registered_model):
         find = registered_model.versions.find


### PR DESCRIPTION
## Impact and Context

This test is currently failing, and based on my investigation it seems to come from the `CopyFrom` in the original line 58:

```python
msg_other.model.CopyFrom(item._msg.model)
```

But beyond that, the object manipulation occurring in this test is wholly unnecessary (and unreadable!); this PR simplifies the logic while maintaining validity.

## Risks

Maybe the original code tests for something that I'm missing, but I'm fairly certain this is not the case because we're using a straight no-frills equality check in this PR's line 52:

```python
assert item._msg == model_version._msg
```

so we should be covered.

## Testing

### Before

```bash
>           assert item._msg == msg_other
E           assert id: 1091\nregistered_model_id: 1149\nversion: "registered_model_test2"\ntime_created: 1633025678342\nexperime
nt_run_id: ""...rmance\n- {{How well has this model performed?}}\n"\nowner: "1026"\nstage: UNASSIGNED\nlock_level: OPEN\nversion
_number: 3\n == id: 1091\nregistered_model_id: 1149\nversion: "registered_model_test2"\ntime_created: 1633025678342\nexperiment_
run_id: ""...rmance\n- {{How well has this model performed?}}\n"\nowner: "1026"\nstage: UNASSIGNED\nlock_level: OPEN\nversion_nu
mber: 3\n
E            +  where id: 1091\nregistered_model_id: 1149\nversion: "registered_model_test2"\ntime_created: 1633025678342\nexper
iment_run_id: ""...rmance\n- {{How well has this model performed?}}\n"\nowner: "1026"\nstage: UNASSIGNED\nlock_level: OPEN\nvers
ion_number: 3\n = version: registered_model_test2\nstage: unassigned\nlock level: open\nurl: https://liu.dev.verta.ai/Michael_Li
u/registry/...:00:00\ndescription: \nlabels: []\nattributes: {}\nid: 1091\nregistered model id: 1149\nexperiment run id: \nartif
act keys: []._msg
```

### After

```bash
$ pytest registry/model_version/test_find.py::TestFind::test_find
===================================================== test session starts ======================================================
platform darwin -- Python 3.7.10, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
rootdir: /Users/miliu/Documents/modeldb/client/verta/tests, configfile: pytest.ini
plugins: hypothesis-6.22.0
collected 1 item                                                                                                               

registry/model_version/test_find.py .                                                                                    [100%]

================================================ 1 passed, 4 warnings in 16.66s ================================================
```

## How to Revert

Revert this PR