### PR TITLE
Downgrade raw requirements warning to info

### DIFF
--- a/client/verta/tests/versioning/environment/test_python.py
+++ b/client/verta/tests/versioning/environment/test_python.py
@@ -206,7 +206,7 @@ class TestRawRequirements:
 
         # each line gets logged raw
         for req in reqs:
-            with caplog.at_level(logging.WARNING, logger="verta"):
+            with caplog.at_level(logging.INFO, logger="verta"):
                 env = Python(requirements=[req])
 
             assert "failed to manually parse requirements; falling back to capturing raw contents" in caplog.text
@@ -252,7 +252,7 @@ class TestRawConstraints:
 
         # each line gets logged raw
         for constraint in constraints:
-            with caplog.at_level(logging.WARNING, logger="verta"):
+            with caplog.at_level(logging.INFO, logger="verta"):
                 env = Python(requirements=[], constraints=[constraint])
 
             assert "failed to manually parse constraints; falling back to capturing raw contents" in caplog.text
@@ -268,7 +268,7 @@ class TestRawConstraints:
         self, requirements_file_without_versions, caplog
     ):
         constraints = Python.read_pip_file(requirements_file_without_versions.name)
-        with caplog.at_level(logging.WARNING, logger="verta"):
+        with caplog.at_level(logging.INFO, logger="verta"):
             env = Python(requirements=[], constraints=constraints)
 
         assert "failed to manually parse constraints; falling back to capturing raw contents" in caplog.text

--- a/client/verta/verta/environment/_python.py
+++ b/client/verta/verta/environment/_python.py
@@ -265,7 +265,7 @@ class Python(_environment._Environment):
                 ),
             )
         except:
-            logger.warning(
+            logger.info(
                 "failed to manually parse requirements;"
                 " falling back to capturing raw contents",
                 exc_info=True,
@@ -296,7 +296,7 @@ class Python(_environment._Environment):
                 ),
             )
         except:
-            logger.warning(
+            logger.info(
                 "failed to manually parse constraints;"
                 " falling back to capturing raw contents",
                 exc_info=True,


### PR DESCRIPTION
## Impact and Context

When the client falls back to logging raw requirements, it displays this warning to the user:

![Screen Shot 2021-10-04 at 8 29 05 AM](https://user-images.githubusercontent.com/7754936/136243414-895f58e7-4a5f-42a4-85e0-557d9c326bca.png)

I've subsequently found that this warning is confusing and unhelpful, I suspect because:

- The behavior it describes is expected during normal client use.
- No actionable information is presented.

This PR downgrades the warning to info.

## Risks

A user will no longer be made aware that their requirements are being logged as-is and unparsed, though this may be for the best as an implementation detail that a user shouldn't worry about.

## Testing

- [ ] ~Deployed the service to dev env~
  - no new service
- [ ] ~Used functionality on dev env~
  - functionality is clientside only
- [ ] ~Added unit test(s)~
  - tests already exist
- [ ] ~Added integration test(s)~
  - tests already exist

```
pytest versioning/environment/test_python.py test_utils/test_pip_requirements.py
```

passes on my machine in Python 2.7 and 3.7.

## How to Revert

Revert this PR.
