### PR TITLE
Fix repository string examples

### DIFF
--- a/client/verta/tests/deployable_entity/conftest.py
+++ b/client/verta/tests/deployable_entity/conftest.py
@@ -37,7 +37,7 @@ def environment(request):
     cls = request.param
     if cls is Docker:
         env = Docker(
-            repository="012345678901.dkr.ecr.apne2-az1.amazonaws.com/models/example",
+            repository="models/example",
             tag="example",
         )
     elif cls is Python:

--- a/client/verta/tests/registry/conftest.py
+++ b/client/verta/tests/registry/conftest.py
@@ -12,7 +12,7 @@ def docker_image():
         request_path="/predict_json",
         health_path="/health",
 
-        repository="012345678901.dkr.ecr.apne2-az1.amazonaws.com/models/example",
+        repository="models/example",
         tag="example",
 
         env_vars={"CUDA_VISIBLE_DEVICES": "0,1"},

--- a/client/verta/verta/environment/_docker.py
+++ b/client/verta/verta/environment/_docker.py
@@ -50,7 +50,7 @@ class Docker(_environment._Environment):
     .. code-block:: python
 
         Docker(
-            repository="012345678901.dkr.ecr.apne2-az1.amazonaws.com/models/example",
+            repository="models/example",
             tag="example",
         )
 

--- a/client/verta/verta/registry/_docker_image.py
+++ b/client/verta/verta/registry/_docker_image.py
@@ -62,7 +62,7 @@ class DockerImage(object):
             request_path="/predict_json",
             health_path="/health",
 
-            repository="012345678901.dkr.ecr.apne2-az1.amazonaws.com/models/example",
+            repository="models/example",
             tag="example",
 
             env_vars={"CUDA_VISIBLE_DEVICES": "0,1"},

--- a/client/verta/verta/registry/entities/_model.py
+++ b/client/verta/verta/registry/entities/_model.py
@@ -670,7 +670,7 @@ class RegisteredModel(_entity._ModelDBEntity):
                 request_path="/predict_json",
                 health_path="/health",
 
-                repository="012345678901.dkr.ecr.apne2-az1.amazonaws.com/models/example",
+                repository="models/example",
                 tag="example",
 
                 env_vars={"CUDA_VISIBLE_DEVICES": "0,1"},

--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -357,7 +357,7 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
                     request_path="/predict_json",
                     health_path="/health",
 
-                    repository="012345678901.dkr.ecr.apne2-az1.amazonaws.com/models/example",
+                    repository="models/example",
                     tag="example",
 
                     env_vars={"CUDA_VISIBLE_DEVICES": "0,1"},


### PR DESCRIPTION
## Impact and Context

I realized that I was using "registry/repository" instead of just "repository" in these examples and tests.

## Risks

None.

## Testing

I re-ran

```
pytest registry/test_docker_image.py versioning/environment/test_docker.py
```

on my machine, and the tests still pass.

## How to Revert

Revert this PR.
