### PR TITLE
[VR-13087] Fix bug which clone an ER with an artifact, the new ER doesn't keep `upload_completed:true`

### DIFF
--- a/backend/src/main/java/ai/verta/modeldb/entities/ArtifactEntity.java
+++ b/backend/src/main/java/ai/verta/modeldb/entities/ArtifactEntity.java
@@ -51,7 +51,11 @@ public class ArtifactEntity implements Serializable {
     }
 
     this.field_type = fieldType;
-    setUploadCompleted(!artifactStoreConfig.getArtifactStoreType().equals(ModelDBConstants.S3));
+    var uploadCompleted = !artifactStoreConfig.getArtifactStoreType().equals(ModelDBConstants.S3);
+    if (artifact.getUploadCompleted()) {
+      uploadCompleted = true;
+    }
+    setUploadCompleted(uploadCompleted);
   }
 
   @Id

--- a/backend/src/main/java/ai/verta/modeldb/experimentRun/subtypes/ArtifactHandlerBase.java
+++ b/backend/src/main/java/ai/verta/modeldb/experimentRun/subtypes/ArtifactHandlerBase.java
@@ -264,6 +264,11 @@ public class ArtifactHandlerBase {
                 jdbi.useHandle(
                     handle -> {
                       for (final var artifact : artifacts) {
+                        var uploadCompleted =
+                            !artifactStoreConfig.getArtifactStoreType().equals(ModelDBConstants.S3);
+                        if (artifact.getUploadCompleted()) {
+                          uploadCompleted = true;
+                        }
                         var storeTypePath =
                             !artifact.getPathOnly()
                                 ? artifactStoreConfig.storeTypePathPrefix() + artifact.getPath()
@@ -282,11 +287,7 @@ public class ArtifactHandlerBase {
                             .bind("path_only", artifact.getPathOnly())
                             .bind("linked_artifact_id", artifact.getLinkedArtifactId())
                             .bind("filename_extension", artifact.getFilenameExtension())
-                            .bind(
-                                "upload_completed",
-                                !artifactStoreConfig
-                                    .getArtifactStoreType()
-                                    .equals(ModelDBConstants.S3))
+                            .bind("upload_completed", uploadCompleted)
                             .bind("store_type_path", storeTypePath)
                             .bind("serialization", artifact.getSerialization())
                             .bind("artifact_subtype", artifact.getArtifactSubtype())


### PR DESCRIPTION


## Impact and Context
<!-- Brief description of why these changes are necessary. Don't rewrite the entire Jira ticket. -->
Jira Ticket: https://vertaai.atlassian.net/browse/VR-13087

## Risks
<!-- Describe any risks. These should be smaller scale than those documented in a design doc. -->

## Testing
<!-- Check all that are applicable. Explain why if any are not applicable. -->
- [ ] Deployed the service to dev env
- [ ] Used functionality on dev env <!-- Explain. For example, you hit the endpoint via Postman. -->
- [ ] Added unit test(s)
- [ ] Added integration test(s)

## How to Revert
<!-- List steps required to revert this change. For example, note if we'd need to revert liquibase changes. -->
