### PR TITLE
Fix docs link for Endpoint.update(autoscaling)

### DIFF
--- a/client/verta/verta/endpoint/_endpoint.py
+++ b/client/verta/verta/endpoint/_endpoint.py
@@ -251,7 +251,7 @@ class Endpoint(object):
             Whether to wait for the endpoint to finish updating before returning.
         resources : :class:`~verta.endpoint.resources.Resources`, optional
             Resources allowed for the updated endpoint.
-        autoscaling : :class:`~verta.endpoint.autoscaling._autoscaling.Autoscaling`, optional
+        autoscaling : :class:`~verta.endpoint.autoscaling.Autoscaling`, optional
             Autoscaling condition for the updated endpoint.
         env_vars : dict of str to str, optional
             Environment variables.


### PR DESCRIPTION
## Impact and Context

This link in the docs is broken because the class [is exposed as `verta.endpoint.autoscaling.Autoscaling`](https://verta.readthedocs.io/en/master/_autogen/verta.endpoint.autoscaling.Autoscaling.html?highlight=autoscaling#verta.endpoint.autoscaling.Autoscaling) as of a no-longer-recent package restructuring

## Risks

None.

## Testing

None.

## How to Revert

Revert this PR.
