### PR TITLE
[Task] Add pytest-timeout with config

### DIFF
--- a/client/verta/requirements.txt
+++ b/client/verta/requirements.txt
@@ -10,6 +10,7 @@ wheel>=0.32
 hypothesis
 six>=1.11
 pytest>=4.3
+pytest-timeout==1.4.2
 
 # unit testing dependencies
 boto3

--- a/client/verta/tests/pytest.ini
+++ b/client/verta/tests/pytest.ini
@@ -8,3 +8,5 @@ filterwarnings =
     ignore:.*Create unlinked descriptors is going to go away.*:DeprecationWarning
     # ignore certain versions of NumPy complaining about internal C machinery
     ignore:.*numpy\.ufunc size changed, may indicate binary incompatibility.*:RuntimeWarning
+timeout = 300
+timeout_method = signal


### PR DESCRIPTION
## Impact and Context
Some bugs have led to hanging test suites rather than clear timeouts, and test suites which take overly long are run less frequently or get disabled.

## Risks and Area of Effect
The test suite which would have more failures does not automatically gate anything at this time, so risk should be minimal.

## Testing
- [x] Run locally with a test module that has hanging tests and verify that tests fail with timeouts
- [x] Run in CI

## How to Revert
- Revert this PR. No public APIs or data persistence introduced.
