### PR TITLE
The update_from_config is public, so maybe the update_from_dict should be too

### DIFF
--- a/client/verta/verta/endpoint/_endpoint.py
+++ b/client/verta/verta/endpoint/_endpoint.py
@@ -478,6 +478,9 @@ class Endpoint(object):
         if not update_dict:
             raise ValueError("input file must be a json or yaml")
 
+        return self.update_from_dict(update_dict, wait=wait)
+
+    def update_from_dict(self, update_dict, wait=False):
         return self._update_from_dict(update_dict, wait=wait)
 
     def _update_from_dict(self, update_dict, wait=False):


### PR DESCRIPTION
## Impact and Context

(this is mostly to serve as the start of a discussion)

The `endpoint.update_from_config` is a public api, so, perhaps if you have your config loaded in already, you could use the `endpoint.update_from_dict` instead of the private api `endpoint._update_from_dict`
