### PR TITLE
[VR-13366] Add ModelError class to be caught in model wrapping infra

### DIFF
--- a/client/verta/verta/registry/errors.py
+++ b/client/verta/verta/registry/errors.py
@@ -15,4 +15,4 @@ class CustomModelError(Exception):
     def __init__(self, http_code, message):
         self.http_code = http_code
         self.message = message
-        super().__init__(self.message)
+        super(CustomModelError, self).__init__(self.message)

--- a/client/verta/verta/registry/errors.py
+++ b/client/verta/verta/registry/errors.py
@@ -1,4 +1,4 @@
-class CustomModelError(Exception):
+class ModelError(Exception):
     """Exception to be raised in user-defined models.
 
     Messages of this class are caught in model containers and converted to
@@ -6,13 +6,13 @@ class CustomModelError(Exception):
 
     Attributes
     ----------
-    http_code : int
-        The http code to be returned by a wrapping service.
     message : str
         The response message.
+    http_code : int
+        The http code to be returned by a wrapping service.
     """
 
-    def __init__(self, http_code, message):
-        self.http_code = http_code
+    def __init__(self, message, http_code):
         self.message = message
-        super(CustomModelError, self).__init__(self.message)
+        self.http_code = http_code
+        super(ModelError, self).__init__(self.message)

--- a/client/verta/verta/registry/errors.py
+++ b/client/verta/verta/registry/errors.py
@@ -1,0 +1,18 @@
+class CustomModelError(Exception):
+    """Exception to be raised in user-defined models.
+
+    Messages of this class are caught in model containers and converted to
+    HTTP errors with the specified HTTP code and message in the response body.
+
+    Attributes
+    ----------
+    http_code : int
+        The http code to be returned by a wrapping service.
+    message : str
+        The response message.
+    """
+
+    def __init__(self, http_code, message):
+        self.http_code = http_code
+        self.message = message
+        super().__init__(self.message)


### PR DESCRIPTION
## Impact and Context
<!-- Brief description of why these changes are necessary. Don't rewrite the entire Jira ticket. -->
- Users have requested the ability to raise custom errors in order to have better control over the error behavior of their deployed models
- The introduced `ModelError` may be handled specially in the provided HTTP server wrapping models

## Risks and Area of Effect
<!--
  Describe both risk (how likely this is to break) and area of effect (how wide potential breakages could reach).
  These should be smaller scale than those documented in a design doc.
-->
- introduces public API for custom errors which will need stability after release

## Testing
<!-- Explain how this contribution has been tested, e.g. what tests were added and where they have been run. -->
```
from verta.registry.errors import CustomModelError
import traceback
import sys

msg, code, printed_tb = None, None, None

try:
    raise CustomModelError(418, "teapot does not support tensorflow")
except CustomModelError as cme:
    msg = cme.message
    code = cme.http_code
    _, _, tb = sys.exc_info()
    printed_tb = traceback.format_tb(tb)
```


## How to Revert
<!-- List steps required to revert this change. For example, note if we'd need to revert liquibase changes. -->
- revert this PR