### PR TITLE
[VR-13352] Support JWT Cookies as an authn mechanism in Python client

### DIFF
--- a/client/verta/.pylintrc
+++ b/client/verta/.pylintrc
@@ -257,7 +257,7 @@ contextmanager-decorators=contextlib.contextmanager
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E1101 when accessed. Python regular
 # expressions are accepted.
-generated-members=
+generated-members=requests.codes.*
 
 # Tells whether missing members accessed in mixin class should be ignored. A
 # mixin class is detected if its name ends with "mixin" (case insensitive).

--- a/client/verta/tests/http_requests/test_connection.py
+++ b/client/verta/tests/http_requests/test_connection.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+
+from verta._internal_utils import credentials
+from verta._internal_utils._utils import Connection, _GRPC_PREFIX
+
+
+https_scheme = "https"
+fake_socket = "test:8080"
+custom_headers = {"custom-header": "custom-header-value"}
+
+
+def assert_dictionary_is_subset(subset_dict, test_dict):
+    for key, value in subset_dict.items():
+        assert key in test_dict
+        assert test_dict.get(key) == value
+
+
+class TestConnection:
+    def test_no_headers(self):
+        conn = Connection(scheme=https_scheme, socket=fake_socket, credentials=None)
+        assert isinstance(conn.headers, dict)
+        conn.headers = None
+        assert isinstance(conn.headers, dict)
+        assert conn.headers.get(_GRPC_PREFIX + "scheme") == https_scheme
+
+    def test_no_auth(self):
+        conn = Connection(
+            scheme=https_scheme,
+            socket=fake_socket,
+            credentials=None,
+            headers=custom_headers,
+        )
+        assert conn.credentials is None
+        conn_headers = conn.headers
+        assert_dictionary_is_subset(custom_headers, conn_headers)
+
+    def test_dev_key_auth(self):
+        fake_email = "test@verta.ai"
+        fake_dev_key = "1234"
+        email_credentials = credentials.build(email=fake_email, dev_key=fake_dev_key)
+        conn = Connection(
+            scheme=https_scheme,
+            socket=fake_socket,
+            credentials=email_credentials,
+            headers=custom_headers,
+        )
+        conn_headers = conn.headers
+        expected = {
+            _GRPC_PREFIX + "scheme": https_scheme,
+            _GRPC_PREFIX + "source": "PythonClient",
+            _GRPC_PREFIX + "email": fake_email,
+            _GRPC_PREFIX + "developer_key": fake_dev_key,
+            _GRPC_PREFIX + "developer-key": fake_dev_key,
+        }
+        assert_dictionary_is_subset(custom_headers, conn_headers)
+        assert_dictionary_is_subset(expected, conn_headers)
+
+    def test_jwt_auth(self):
+        fake_token = "token"
+        fake_token_sig = "token_sig"
+        jwt_credentials = credentials.build(
+            jwt_token=fake_token, jwt_token_sig=fake_token_sig
+        )
+        conn = Connection(
+            scheme=https_scheme,
+            socket=fake_socket,
+            credentials=jwt_credentials,
+            headers=custom_headers,
+        )
+        conn_headers = conn.headers
+        expected = {
+            _GRPC_PREFIX + "scheme": https_scheme,
+            _GRPC_PREFIX + "source": "JWT",
+            _GRPC_PREFIX + "bearer_access_token": fake_token,
+            _GRPC_PREFIX + "bearer_access_token_sig": fake_token_sig,
+            _GRPC_PREFIX + "bearer-access-token": fake_token,
+            _GRPC_PREFIX + "bearer-access-token-sig": fake_token_sig,
+        }
+        assert_dictionary_is_subset(custom_headers, conn_headers)
+        assert_dictionary_is_subset(expected, conn_headers)

--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+#pylint: disable=E1101
 
 import datetime
 import glob

--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -112,7 +112,10 @@ class Connection:
 
     @headers.setter
     def headers(self, value):
-        self._headers = value
+        if value:
+            self._headers = value
+        else:
+            self._headers = dict()
         self._recompute_headers()
 
     def _init_headers(self):
@@ -121,7 +124,8 @@ class Connection:
         self._computed_headers = {}
 
     def _recompute_headers(self):
-        headers = self._headers.copy()
+        headers = self._headers or dict()
+        headers = headers.copy()
         headers[_GRPC_PREFIX+'scheme'] = self.scheme
         headers.update(self._auth_headers)
         self._computed_headers = headers

--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -71,9 +71,10 @@ class Connection:
         ignore_conn_err : bool, default False
             Whether to ignore connection errors and instead return successes with empty contents.
         credentials : :class:`~verta._internal_utils.credentials.EmailCredentials` or :class:`~verta._internal_utils.credentials.JWTCredentials`, optional
-            Either dev key or JWT token data to be used for authentication
+            Either dev key or JWT token data to be used for authentication.
         headers: dict, optional
-            Additional headers to attach to requests
+            Additional headers to attach to requests.
+
         """
         self._init_headers()
         self.scheme = scheme
@@ -97,7 +98,7 @@ class Connection:
     @credentials.setter
     def credentials(self, value):
         self._credentials = value
-        self._auth_headers = self._headers_for_credentials(value)
+        self._auth_headers = self._prefixed_headers_for_credentials(value)
         self._recompute_headers()
 
     @property
@@ -125,7 +126,7 @@ class Connection:
         headers.update(self._auth_headers)
         self._computed_headers = headers
 
-    def _headers_for_credentials(self, credentials):
+    def _prefixed_headers_for_credentials(self, credentials):
         if credentials:
             return {(_GRPC_PREFIX + k): v for (k,v) in credentials.headers().items()}
         return {}

--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -105,7 +105,7 @@ class Connection:
     def headers(self):
         return self._computed_headers
 
-    # NB: Added for temporary backwards compatibility. Remove when possible.
+    # Note: Added for temporary backwards compatibility. Remove when possible.
     @property
     def auth(self):
         return self.headers

--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -132,8 +132,27 @@ class Connection:
         return {}
 
     def test(self, print_success=True):
-        """
-        TODO: Describe me
+        """Verify connection viability with Verta Platform.
+
+        This method issues an API request against the Verta platform using the
+        configuration in this connection to validate that the Verta platform can
+        be connected to.
+
+        Parameters
+        ----------
+        print_success : bool, default True
+            Whether or not to print a success message.
+
+        Returns
+        -------
+        bool
+            Returns true upon success.
+
+        Raises
+        ------
+        :class:`requests.HTTPError`
+            If an HTTP error occured.
+
         """
         try:
             response = make_request("GET",

--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -189,10 +189,12 @@ class Connection:
     def must_response(response):
         raise_for_http_error(response)
 
-    # NB: Maybe replace use of this with a "not is_json_response" method?
     @staticmethod
     def is_html_response(response):
-        return response.text.strip().endswith("</html>")
+        content_type = response.headers.get('Content-Type')
+        if content_type:
+            return content_type.startswith('text/html')
+        return False
 
     @property
     def email(self):

--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -125,7 +125,8 @@ class Connection:
         headers.update(self._prefixed_headers_for_credentials(self.credentials))
         self._computed_headers = headers
 
-    def _prefixed_headers_for_credentials(self, credentials):
+    @staticmethod
+    def _prefixed_headers_for_credentials(credentials):
         if credentials:
             return {(_GRPC_PREFIX + k): v for (k,v) in credentials.headers().items()}
         return {}

--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -98,7 +98,6 @@ class Connection:
     @credentials.setter
     def credentials(self, value):
         self._credentials = value
-        self._auth_headers = self._prefixed_headers_for_credentials(value)
         self._recompute_headers()
 
     @property
@@ -120,14 +119,13 @@ class Connection:
 
     def _init_headers(self):
         self._headers = {}
-        self._auth_headers = {}
         self._computed_headers = {}
 
     def _recompute_headers(self):
         headers = self._headers or dict()
         headers = headers.copy()
         headers[_GRPC_PREFIX+'scheme'] = self.scheme
-        headers.update(self._auth_headers)
+        headers.update(self._prefixed_headers_for_credentials(self.credentials))
         self._computed_headers = headers
 
     def _prefixed_headers_for_credentials(self, credentials):

--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -28,6 +28,11 @@ from google.protobuf.struct_pb2 import Value, ListValue, Struct, NULL_VALUE
 from ..external import six
 from ..external.six.moves.urllib.parse import urljoin  # pylint: disable=import-error, no-name-in-module
 
+from .credentials import (
+    EmailCredentials,
+    JWTCredentials,
+)
+
 from .._protos.public.common import CommonService_pb2 as _CommonCommonService
 from .._protos.public.uac import Organization_pb2, UACService_pb2, Workspace_pb2
 
@@ -122,18 +127,18 @@ class Connection:
     def _recompute_headers(self):
         headers = self._headers.copy()
         headers[_GRPC_PREFIX+'scheme'] = self.scheme
-        copied_headers.update(self._DEFAULT_HEADERS)
-        copied_headers.update(self._auth_headers)
-        self._computed_headers = copied_headers
+        headers.update(self._DEFAULT_HEADERS)
+        headers.update(self._auth_headers)
+        self._computed_headers = headers
 
     def _headers_for_credentials(self, credentials):
         if isinstance(credentials, EmailCredentials):
             return {
-                _utils._GRPC_PREFIX+'email': credentials.email,
-                _utils._GRPC_PREFIX+'developer_key': credentials.dev_key,
+                _GRPC_PREFIX+'email': credentials.email,
+                _GRPC_PREFIX+'developer_key': credentials.dev_key,
                 # without underscore, for NGINX support
                 # https://www.nginx.com/resources/wiki/start/topics/tutorials/config_pitfalls#missing-disappearing-http-headers
-                _utils._GRPC_PREFIX+'developer-key': credentials.dev_key,
+                _GRPC_PREFIX+'developer-key': credentials.dev_key,
             }
         else:
             return {}
@@ -166,7 +171,7 @@ class Connection:
                 e.args = ("authentication failed; please check `VERTA_EMAIL` and `VERTA_DEV_KEY` or JWT credentials\n\n{}".format(
                     e.args[0]),) + e.args[1:]
                 raise e
-        _utils.raise_for_http_error(response)
+        raise_for_http_error(response)
         if print_success:
             print("connection successfully established")
         return True

--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -206,46 +206,6 @@ class Connection:
     def must_response(response):
         raise_for_http_error(response)
 
-    @staticmethod # TODO: update with possible cookie
-    def _request_to_curl(request):
-        """
-        Prints a cURL to reproduce `request`.
-
-        Parameters
-        ----------
-        request : :class:`requests.PreparedRequest`
-
-        Examples
-        --------
-        From a :class:`~requests.Response`:
-
-        .. code-block:: python
-
-            response = _utils.make_request("GET", "https://www.google.com/", conn)
-            conn._request_to_curl(response.request)
-
-        From a :class:`~requests.HTTPError`:
-
-        .. code-block:: python
-
-            try:
-                pass  # insert bad call here
-            except Exception as e:
-                client._conn._request_to_curl(e.request)
-                raise
-
-        """
-        lines = []
-        lines.append("curl -X {} \"{}\"".format(request.method, request.url))
-        if request.headers:
-            lines.extend('-H "{}: {}"'.format(key, val) for key, val in request.headers.items())
-        if request.body:
-            lines.append("-d '{}'".format(request.body.decode()))
-
-        curl = " \\\n    ".join(lines)
-        print(curl)
-
-
     # NB: Maybe replace use of this with a "not is_json_response" method?
     @staticmethod
     def is_html_response(response):

--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -111,10 +111,7 @@ class Connection:
 
     @headers.setter
     def headers(self, value):
-        if value:
-            self._headers = value
-        else:
-            self._headers = dict()
+        self._headers = value or dict()
         self._recompute_headers()
 
     def _init_headers(self):

--- a/client/verta/verta/_internal_utils/credentials.py
+++ b/client/verta/verta/_internal_utils/credentials.py
@@ -12,6 +12,10 @@ def build(email=None, dev_key=None, jwt_token=None, jwt_token_sig=None):
         return EmailCredentials(email, dev_key)
     elif jwt_token and jwt_token_sig:
         return JWTCredentials(jwt_token, jwt_token_sig)
+    elif email or dev_key:
+        raise ValueError("`email` and `dev_key` must be provided together")
+    elif jwt_token or jwt_token_sig:
+        raise ValueError("`jwt_token` and `jwt_token_sig` must be provided together")
     else:
         return None
 

--- a/client/verta/verta/_internal_utils/credentials.py
+++ b/client/verta/verta/_internal_utils/credentials.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+
+import abc
+import os
+
+from verta.external import six
+
+
+def build(email=None, dev_key=None, jwt_token=None, jwt_token_sig=None):
+    if email and dev_key:
+        return EmailCredentials(email, dev_key)
+    elif jwt_token and jwt_token_sig:
+        return JWTCredentials(jwt_token, jwt_token_sig)
+    else:
+        return None
+
+
+@six.add_metaclass(abc.ABCMeta)
+class Credentials(object):
+
+    @abc.abstractmethod
+    def export_env_vars_to_os(self):
+        raise NotImplementedError
+
+class EmailCredentials:
+
+    EMAIL_ENV = "VERTA_EMAIL"
+    DEV_KEY_ENV = "VERTA_DEV_KEY"
+
+    def __init__(self, email, dev_key):
+        self.email = email
+        self.dev_key = dev_key
+
+    def export_env_vars_to_os(self):
+        os.environ[self.EMAIL_ENV] = self.email
+        os.environ[self.DEV_KEY_ENV] = self.dev_key
+
+    def __repr__(self):
+        return "" # TODO: implement and obscure dev key to avoid printing accidentally
+
+class JWTCredentials:
+
+    JWT_TOKEN_ENV = "VERTA_JWT_TOKEN"
+    JWT_TOKEN_SIG_ENV = "VERTA_JWT_TOKEN_SIG"
+
+    def __init__(self, jwt_token, jwt_token_sig):
+        self.jwt_token = jwt_token
+        self.jwt_token_sig = jwt_token_sig
+
+    def export_env_vars_to_os(self):
+        os.environ[self.JWT_TOKEN_ENV] = self.jwt_token
+        os.environ[self.JWT_TOKEN_SIG_ENV] = self.jwt_token_sig
+
+    def __repr__(self):
+        return "" # TODO: implement and obscure as appropriate to avoid accidentally printing

--- a/client/verta/verta/_internal_utils/credentials.py
+++ b/client/verta/verta/_internal_utils/credentials.py
@@ -23,6 +23,10 @@ class Credentials(object):
     def export_env_vars_to_os(self):
         raise NotImplementedError
 
+    @abc.abstractmethod
+    def headers(self):
+        raise NotImplementedError
+
 
 class EmailCredentials(Credentials):
 
@@ -36,6 +40,16 @@ class EmailCredentials(Credentials):
     def export_env_vars_to_os(self):
         os.environ[self.EMAIL_ENV] = self.email
         os.environ[self.DEV_KEY_ENV] = self.dev_key
+
+    def headers(self):
+        return {
+            'source': 'PythonClient',
+            'email': self.email,
+            'developer_key': self.dev_key,
+            # without underscore, for NGINX support
+            # https://www.nginx.com/resources/wiki/start/topics/tutorials/config_pitfalls#missing-disappearing-http-headers
+            'developer-key': self.dev_key,
+        }
 
     def __repr__(self):
         key = self.dev_key[:8] + re.sub(r"[^-]", '*', self.dev_key[8:])
@@ -53,6 +67,17 @@ class JWTCredentials(Credentials):
     def export_env_vars_to_os(self):
         os.environ[self.JWT_TOKEN_ENV] = self.jwt_token
         os.environ[self.JWT_TOKEN_SIG_ENV] = self.jwt_token_sig
+
+    def headers(self):
+        return {
+            'source': 'JWT',
+            'bearer_access_token': self.jwt_token,
+            'bearer_access_token_sig': self.jwt_token_sig,
+            # without underscore, for NGINX support
+            # https://www.nginx.com/resources/wiki/start/topics/tutorials/config_pitfalls#missing-disappearing-http-headers
+            'bearer-access-token': self.jwt_token,
+            'bearer-access-token-sig': self.jwt_token_sig,
+        }
 
     def __repr__(self):
         token = self.jwt_token[:8] + re.sub(r"[^-]", '*', self.jwt_token[8:])

--- a/client/verta/verta/_internal_utils/credentials.py
+++ b/client/verta/verta/_internal_utils/credentials.py
@@ -2,6 +2,7 @@
 
 import abc
 import os
+import re
 
 from verta.external import six
 
@@ -22,7 +23,8 @@ class Credentials(object):
     def export_env_vars_to_os(self):
         raise NotImplementedError
 
-class EmailCredentials:
+
+class EmailCredentials(Credentials):
 
     EMAIL_ENV = "VERTA_EMAIL"
     DEV_KEY_ENV = "VERTA_DEV_KEY"
@@ -36,9 +38,10 @@ class EmailCredentials:
         os.environ[self.DEV_KEY_ENV] = self.dev_key
 
     def __repr__(self):
-        return "" # TODO: implement and obscure dev key to avoid printing accidentally
+        key = self.dev_key[:8] + re.sub(r"[^-]", '*', self.dev_key[8:])
+        return "EmailCredentials({}, {})".format(self.email, key)
 
-class JWTCredentials:
+class JWTCredentials(Credentials):
 
     JWT_TOKEN_ENV = "VERTA_JWT_TOKEN"
     JWT_TOKEN_SIG_ENV = "VERTA_JWT_TOKEN_SIG"
@@ -52,4 +55,5 @@ class JWTCredentials:
         os.environ[self.JWT_TOKEN_SIG_ENV] = self.jwt_token_sig
 
     def __repr__(self):
-        return "" # TODO: implement and obscure as appropriate to avoid accidentally printing
+        token = self.jwt_token[:8] + re.sub(r"[^-]", '*', self.jwt_token[8:])
+        return "JWTCredentials({}, {})".format(token, self.jwt_token_sig)

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -145,8 +145,6 @@ class Client(object):
                 print("[DEBUG] credentials not found; auth disabled")
         else:
             if debug:
-                # print("[DEBUG] using email: {}".format(email))
-                # print("[DEBUG] using developer key: {}".format(dev_key[:8] + re.sub(r"[^-]", '*', dev_key[8:])))
                 print("[DEBUG] using credentials: {}".format(repr(self.auth_credentials)))
             # save credentials to env for other Verta Client features
             self.auth_credentials.export_env_vars_to_os()

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -19,6 +19,7 @@ from ._internal_utils import (
     _config_utils,
     _request_utils,
     _utils,
+    credentials,
 )
 
 from .tracking import _Context
@@ -123,18 +124,20 @@ class Client(object):
         self._load_config()
 
         host = self._get_with_fallback(host, env_var="VERTA_HOST", config_var="host")
+        if host is None:
+            raise ValueError("`host` must be provided")
+
         email = self._get_with_fallback(email, env_var="VERTA_EMAIL", config_var="email")
         dev_key = self._get_with_fallback(dev_key, env_var="VERTA_DEV_KEY", config_var="dev_key")
-
         jwt_token = self._get_with_fallback(jwt_token, env_var="VERTA_JWT_TOKEN", config_var="jwt_token")
         jwt_token_sig = self._get_with_fallback(jwt_token_sig, env_var="VERTA_JWT_TOKEN_SIG", config_var="jwt_token_sig")
 
+        self.auth_credentials = credentials.build(email=email, dev_key=dev_key, jwt_token=jwt_token, jwt_token_sig)
         self.workspace = self._get_with_fallback(None, env_var="VERTA_WORKSPACE")
 
-        if host is None:
-            raise ValueError("`host` must be provided")
         auth = extra_auth_headers.copy()
         auth.update({_utils._GRPC_PREFIX+'source': "PythonClient"})
+
         if email is None and dev_key is None:
             if debug:
                 print("[DEBUG] email and developer key not found; auth disabled")

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -125,7 +125,7 @@ class Client(object):
 
     """
     def __init__(self, host=None, port=None, email=None, dev_key=None,
-                 max_retries=5, ignore_conn_err=False, use_git=True, debug=False, extra_auth_headers={}, _connect=True, jwt_token=None, jwt_token_sig=None):
+                 max_retries=5, ignore_conn_err=False, use_git=True, debug=False, extra_auth_headers={}, jwt_token=None, jwt_token_sig=None, _connect=True):
         self._load_config()
 
         host = self._get_with_fallback(host, env_var="VERTA_HOST", config_var="host")

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -169,7 +169,6 @@ class Client(object):
 
         self._conn = conn
         self._conf = _utils.Configuration(use_git, debug)
-
         self._ctx = _Context(self._conn, self._conf)
 
     @property

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -149,7 +149,7 @@ class Client(object):
             # save credentials to env for other Verta Client features
             self.auth_credentials.export_env_vars_to_os()
 
-        # NB: Perhaps these things should move into Connection as well?
+        # TODO: Perhaps these things should move into Connection as well?
         back_end_url = urlparse(host)
         socket = back_end_url.netloc + back_end_url.path.rstrip('/')
         if port is not None:

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -125,7 +125,7 @@ class Client(object):
 
     """
     def __init__(self, host=None, port=None, email=None, dev_key=None,
-                 max_retries=5, ignore_conn_err=False, use_git=True, debug=False, extra_auth_headers={}, _connect=True):
+                 max_retries=5, ignore_conn_err=False, use_git=True, debug=False, extra_auth_headers={}, _connect=True, jwt_token=None, jwt_token_sig=None):
         self._load_config()
 
         host = self._get_with_fallback(host, env_var="VERTA_HOST", config_var="host")

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -138,7 +138,7 @@ class Client(object):
         jwt_token_sig = self._get_with_fallback(jwt_token_sig, env_var=JWTCredentials.JWT_TOKEN_SIG_ENV, config_var="jwt_token_sig")
 
         self.auth_credentials = credentials.build(email=email, dev_key=dev_key, jwt_token=jwt_token, jwt_token_sig=jwt_token_sig)
-        self.workspace = self._get_with_fallback(None, env_var="VERTA_WORKSPACE")
+        self._workspace = self._get_with_fallback(None, env_var="VERTA_WORKSPACE")
 
         if self.auth_credentials is None:
             if debug:

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -137,7 +137,7 @@ class Client(object):
         jwt_token = self._get_with_fallback(jwt_token, env_var=JWTCredentials.JWT_TOKEN_ENV, config_var="jwt_token")
         jwt_token_sig = self._get_with_fallback(jwt_token_sig, env_var=JWTCredentials.JWT_TOKEN_SIG_ENV, config_var="jwt_token_sig")
 
-        self.auth_credentials = credentials.build(email=email, dev_key=dev_key, jwt_token=jwt_token, jwt_token_sig)
+        self.auth_credentials = credentials.build(email=email, dev_key=dev_key, jwt_token=jwt_token, jwt_token_sig=jwt_token_sig)
         self.workspace = self._get_with_fallback(None, env_var="VERTA_WORKSPACE")
 
         if self.auth_credentials is None:

--- a/client/verta/verta/dataset/_s3.py
+++ b/client/verta/verta/dataset/_s3.py
@@ -11,8 +11,11 @@ from ..external.six.moves.urllib.parse import urlparse  # pylint: disable=import
 
 from .._protos.public.modeldb.versioning import VersioningService_pb2 as _VersioningService
 
-from .._internal_utils import _artifact_utils
-from .._internal_utils import _utils
+from .._internal_utils import (
+    _artifact_utils,
+    _config_utils,
+    _utils,
+)
 
 from . import _dataset
 
@@ -196,7 +199,7 @@ class S3(_dataset._Dataset):
             s3_loc = S3Location(component.path, component.s3_version_id)
 
             # download to file in ~/.verta/temp/
-            tempdir = os.path.join(_utils.HOME_VERTA_DIR, "temp")
+            tempdir = os.path.join(_config_utils.HOME_VERTA_DIR, "temp")
             pathlib2.Path(tempdir).mkdir(parents=True, exist_ok=True)
             print("downloading {} from S3".format(component.path))
             with tempfile.NamedTemporaryFile('w+b', dir=tempdir, delete=False) as tempf:


### PR DESCRIPTION
## Impact and Context
<!-- Brief description of why these changes are necessary. Don't rewrite the entire Jira ticket. -->
- Adds support for authentication via `Grpc-Metadata-bearer_access_token` and `Grpc-Metadata-bearer_access_token_sig` HTTP headers
- The values for these headers may now be set with the environment variables `VERTA_JWT_TOKEN` and `VERTA_JWT_TOKEN_SIG`

## Risks and Area of Effect
<!--
  Describe both risk (how likely this is to break) and area of effect (how wide potential breakages could reach).
  These should be smaller scale than those documented in a design doc.
-->
- Although some of the refactoring and changes introduced touch upon the core `Client` and `Connection` classes, behavior has been checked with our extensive E2E test suite.

## Testing
<!-- Explain how this contribution has been tested, e.g. what tests were added and where they have been run. -->

### Unit Testing

- Added `tests/http_requests/test_connection.py` to validate header computation behavior

```
(verta-py3) ➜  verta git:(df/vr-13352) pytest tests/http_requests/test_connection.py
============================================================================== test session starts ===============================================================================
platform darwin -- Python 3.7.9, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /Users/daniel/workspace/modeldb/client/verta/tests, configfile: pytest.ini
plugins: hypothesis-6.3.4, timeout-1.4.2
timeout: 300.0s
timeout method: signal
timeout func_only: False
collected 4 items

tests/http_requests/test_connection.py ....                                                                                                                                [100%]

================================================================================ warnings summary ================================================================================
http_requests/test_connection.py::TestConnection::test_no_headers
http_requests/test_connection.py::TestConnection::test_no_headers
http_requests/test_connection.py::TestConnection::test_no_auth
http_requests/test_connection.py::TestConnection::test_dev_key_auth
http_requests/test_connection.py::TestConnection::test_jwt_auth
  /Users/daniel/.pyenv/versions/verta-py3/lib/python3.7/site-packages/urllib3/util/retry.py:255: DeprecationWarning: Using 'method_whitelist' with Retry is deprecated and will be removed in v2.0. Use 'allowed_methods' instead
    DeprecationWarning,

-- Docs: https://docs.pytest.org/en/stable/warnings.html
========================================================================= 4 passed, 5 warnings in 2.91s ==========================================================================
```

### Manual Testing

*Checking for relevant environment variables*
```
(verta-py3) ➜  verta git:(df/vr-13352) ✗ env | grep VERTA
VERTA_HOST=df2.dev.verta.ai
VERTA_BEARER_TOKEN_SIG=XXXXX
VERTA_BEARER_TOKEN=XXXXXX
```

*Testing some client functionality*
```
Python 3.7.9 (default, May  1 2021, 12:41:31)
Type 'copyright', 'credits' or 'license' for more information
IPython 7.21.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from verta import Client

In [2]: client = Client()
got VERTA_HOST from environment
got VERTA_BEARER_TOKEN from environment
got VERTA_BEARER_TOKEN_SIG from environment
connection successfully established

In [3]: projects = list(client.projects)

In [4]: projects
Out[4]:
[name: Example Project 2
 url: https://df2.dev.verta.ai/Daniel_Fennelly/projects/c54728a1-bccc-49fa-a916-a82c0b2bc84a/summary,
 name: Example Project 1
 url: https://df2.dev.verta.ai/Daniel_Fennelly/projects/004a6d87-f09f-4dcb-a6a0-2dcf63456960/summary]
```

## How to Revert
<!-- List steps required to revert this change. For example, note if we'd need to revert liquibase changes. -->
- Revert this PR