### PR TITLE
[VR-12461] Bump PyYAML version constraint

### DIFF
--- a/client/verta/setup.py
+++ b/client/verta/setup.py
@@ -31,7 +31,7 @@ setup(
         "pathlib2>=2.2, <3.0",
         "protobuf>=3.8, <3.18",
         "pytimeparse>=1.1.8, <2.0",
-        "pyyaml>=5.1, <5.4",
+        "pyyaml>=5.1, <6.0",
         "requests>=2.21, <3.0"
     ],
     entry_points={


### PR DESCRIPTION
## Impact and Context

PyYAML has a security vulnerability that was addressed in `pyyaml==5.4`. Although `verta` itself doesn't use that vulnerable code, its dependency version constraint was conflicting with other libraries'.

This PR bumps the upper constraint on our `pyyaml` dependency from `<5.4` to `<6.0`, which is when Python 2 support is dropped.

Closes #2536.

## Risks and Area of Effect

Low risk: From [PyYAML's changelog](https://github.com/yaml/pyyaml/blob/8cdff2c80573b8be8e8ad28929264a913a63aa33/CHANGES#L20-L30), the new versions we're allowing do not introduce any relevant breakages.

Low area of effect: `verta` only uses PyYAML for reading user-optional config files (currently only client config & endpoint update config).

## Testing

I ran
```zsh
pytest test_config.py test_endpoint/test_endpoint.py
```
from my machine on both Python 2 and 3, which encompasses all our config file-related functionality.

There were a handful of unrelated failures:

- `FAILED test_endpoint/test_endpoint.py::TestEndpoint::test_update_init_error`
  - VR-12994
- `FAILED test_endpoint/test_endpoint.py::TestEndpoint::test_update_with_custom_module` in Python 2
  - VR-11973
- `FAILED test_endpoint/test_endpoint.py::TestEndpoint::test_update_twice`
  - updating an endpoint twice in one test exceeds the timeout, and should probably be moved out of our client test suite

## How to Revert

Revert this PR.
