### PR TITLE
[VR-13379] Warn instead of error on version mismatch of verta and cloudpickle

### DIFF
--- a/client/verta/verta/_internal_utils/_pip_requirements_utils.py
+++ b/client/verta/verta/_internal_utils/_pip_requirements_utils.py
@@ -345,8 +345,8 @@ def inject_requirement(requirements, library, version, error_on_conflict=True):
                 if "==" in req:  # version pin: check version
                     their_ver = req.split('==')[-1]
                     if version != their_ver:  # versions conflict: raise exception
-                        msg = "Client is running with {} v{}, but the provided requirements specify v{};"
-                        " these should match".format(library, version, their_ver)
+                        msg = ("Client is running with {} v{}, but the provided requirements specify v{};"
+                               " these should match").format(library, version, their_ver)
                         if error_on_conflict:
                             raise ValueError(msg)
                         else:

--- a/client/verta/verta/_internal_utils/_pip_requirements_utils.py
+++ b/client/verta/verta/_internal_utils/_pip_requirements_utils.py
@@ -275,12 +275,6 @@ def pin_verta_and_cloudpickle(requirements):
     list of str
         Copy of `requirements` with pinned verta and cloudpickle.
 
-    Raises
-    ------
-    ValueError
-        If verta or cloudpickle already have a version pin specified in `requirements`, but it
-        conflicts with the version in the current environment.
-
     """
     requirements = copy.copy(requirements)
 
@@ -301,12 +295,12 @@ def pin_verta_and_cloudpickle(requirements):
         (__about__.__title__, __about__.__version__),  # verta
         (cloudpickle.__name__, cloudpickle.__version__),  # cloudpickle
     ]:
-        requirements = inject_requirement(requirements, library, version)
+        requirements = inject_requirement(requirements, library, version, error_on_conflict=False)
 
     return requirements
 
 
-def inject_requirement(requirements, library, version):
+def inject_requirement(requirements, library, version, error_on_conflict=True):
     """Return a copy of `requirements` with `library` pinned to `version`.
 
     If `library` is already in `requirements` and has a version pin, this
@@ -324,11 +318,20 @@ def inject_requirement(requirements, library, version):
         Python library, e.g. "verta".
     version : str
         Desired version number, e.g. "0.20.0".
+    error_on_conflict : bool
+        If true, raise a `ValueError` on version mismatches. Otherwise issue a
+        warning. Defaults to true.
 
     Returns
     -------
     list of str
         Copy of `requirements` with `library` pinned to `version`.
+
+    Raises
+    ------
+    ValueError
+        If the provided library version conflicts with an already pinned version
+        of the library and `error_on_conflict` is True.
 
     """
     requirements = copy.copy(requirements)
@@ -342,10 +345,12 @@ def inject_requirement(requirements, library, version):
                 if "==" in req:  # version pin: check version
                     their_ver = req.split('==')[-1]
                     if version != their_ver:  # versions conflict: raise exception
-                        raise ValueError(
-                            "Client is running with {} v{}, but the provided requirements specify v{};"
-                            " these must match".format(library, version, their_ver)
-                        )
+                        msg = "Client is running with {} v{}, but the provided requirements specify v{};"
+                        " these should match".format(library, version, their_ver)
+                        if error_on_conflict:
+                            raise ValueError(msg)
+                        else:
+                            warnings.warn(msg)
                     else:  # versions match: no action needed
                         continue
                 # TODO: check other operators (>=, >, ...)

--- a/client/verta/verta/_internal_utils/_pip_requirements_utils.py
+++ b/client/verta/verta/_internal_utils/_pip_requirements_utils.py
@@ -350,7 +350,7 @@ def inject_requirement(requirements, library, version, error_on_conflict=True):
                         if error_on_conflict:
                             raise ValueError(msg)
                         else:
-                            warnings.warn(msg)
+                            warnings.warn(msg, stacklevel=2)
                     else:  # versions match: no action needed
                         continue
                 # TODO: check other operators (>=, >, ...)

--- a/client/verta/verta/_internal_utils/_pip_requirements_utils.py
+++ b/client/verta/verta/_internal_utils/_pip_requirements_utils.py
@@ -318,7 +318,7 @@ def inject_requirement(requirements, library, version, error_on_conflict=True):
         Python library, e.g. "verta".
     version : str
         Desired version number, e.g. "0.20.0".
-    error_on_conflict : bool
+    error_on_conflict : bool, default True
         If true, raise a `ValueError` on version mismatches. Otherwise issue a
         warning. Defaults to true.
 


### PR DESCRIPTION
## Impact and Context
<!-- Brief description of why these changes are necessary. Don't rewrite the entire Jira ticket. -->
- Some users make use of slightly different versions of `verta` and `cloudpickle` and it's been observed that a warning on mismatches of these versions would work better than outright failure for these users


## Risks and Area of Effect
<!--
  Describe both risk (how likely this is to break) and area of effect (how wide potential breakages could reach).
  These should be smaller scale than those documented in a design doc.
-->
- Small area of effect with explicit warning introduced to replace failure. Some models may get uploaded which don't correctly pickle/unpickle objects, but users may follow the warning to remedy any faulty models produced.

## Testing
<!-- Explain how this contribution has been tested, e.g. what tests were added and where they have been run. -->

### Unit Testing

*In progress. Currently debugging CI testing issues, and I expect there may be a unit test or two which needs its behavior updated.*

### Manual Testing
```
Python 3.7.9 (default, May  1 2021, 12:41:31)
Type 'copyright', 'credits' or 'license' for more information
IPython 7.21.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from verta.environment import Python

In [2]: local_env = Python.read_pip_environment()

In [3]: local_env[:3]
Out[3]: ['absl-py==0.11.0', 'aiohttp==3.7.4.post0', 'alabaster==0.7.12']

In [4]: list(filter(lambda req: "verta" in req or "cloudpickle" in req, local_env))
Out[4]:
['cloudpickle==1.6.0',
 '-e git+ssh://git@github.com/VertaAI/modeldb.git@796e0f1c21ea6ef0f6e509b57e3f3f163df1ff46#egg=verta&subdirectory=client/verta']

In [5]: env = Python(["cloudpickle==2.0.0"])
/Users/daniel/workspace/modeldb/client/verta/verta/_internal_utils/_pip_requirements_utils.py:298: UserWarning: Client is running with cloudpickle v1.6.0, but the provided requirements specify v2.0.0; these should match
  requirements = inject_requirement(requirements, library, version, error_on_conflict=False)
```

## How to Revert
<!-- List steps required to revert this change. For example, note if we'd need to revert liquibase changes. -->
- Revert this PR