### PR TITLE
Add verta.credentials to public API documentation

### DIFF
--- a/client/verta/docs/python.rst
+++ b/client/verta/docs/python.rst
@@ -22,6 +22,7 @@ Verta
 
         code
         configuration
+        credentials
         data_types
         dataset
         deployment

--- a/client/verta/verta/credentials.py
+++ b/client/verta/verta/credentials.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
-"""Classes and functions related to credentials used with the Verta Platform."""
+"""Classes and functions related to credentials used with the Verta Platform.
+
+.. versionadded:: 0.20.0
+
+"""
 
 import abc
 import os


### PR DESCRIPTION
## Impact and Context

This PR adds `verta.credentials` to our API documentation, as a submodule on a public import path

## Risks and Area of Effect

No risks since there's no functional changes. A `versionadded` directive has been added to indicate that this isn't yet available.

## Testing

Built docs locally and verified that `credentials` appears.

## How to Revert

Revert this PR
