### PR TITLE
Fix import of verta.credentials

### DIFF
--- a/client/verta/tests/http_requests/test_connection.py
+++ b/client/verta/tests/http_requests/test_connection.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from verta._internal_utils import credentials
+from verta import credentials
 from verta._internal_utils._utils import Connection, _GRPC_PREFIX
 
 

--- a/client/verta/tests/http_requests/test_connection.py
+++ b/client/verta/tests/http_requests/test_connection.py
@@ -37,7 +37,7 @@ class TestConnection:
     def test_dev_key_auth(self):
         fake_email = "test@verta.ai"
         fake_dev_key = "1234"
-        email_credentials = credentials.build(email=fake_email, dev_key=fake_dev_key)
+        email_credentials = credentials._build(email=fake_email, dev_key=fake_dev_key)
         conn = Connection(
             scheme=https_scheme,
             socket=fake_socket,
@@ -58,7 +58,7 @@ class TestConnection:
     def test_jwt_auth(self):
         fake_token = "token"
         fake_token_sig = "token_sig"
-        jwt_credentials = credentials.build(
+        jwt_credentials = credentials._build(
             jwt_token=fake_token, jwt_token_sig=fake_token_sig
         )
         conn = Connection(

--- a/client/verta/tests/test_deployment/test_unit_deployedmodel.py
+++ b/client/verta/tests/test_deployment/test_unit_deployedmodel.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from verta.credentials import (EmailCredentials, JWTCredentials)
+from verta.credentials import EmailCredentials, JWTCredentials
 from verta.deployment import DeployedModel
 
 from verta._internal_utils._utils import _GRPC_PREFIX

--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -27,10 +27,7 @@ from google.protobuf.struct_pb2 import Value, ListValue, Struct, NULL_VALUE
 from ..external import six
 from ..external.six.moves.urllib.parse import urljoin  # pylint: disable=import-error, no-name-in-module
 
-from verta.credentials import (
-    EmailCredentials,
-    JWTCredentials,
-)
+from verta.credentials import EmailCredentials, JWTCredentials
 
 from .._protos.public.common import CommonService_pb2 as _CommonCommonService
 from .._protos.public.uac import Organization_pb2, UACService_pb2, Workspace_pb2

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -22,10 +22,7 @@ from ._internal_utils import (
 )
 
 from verta import credentials
-from verta.credentials import (
-    EmailCredentials,
-    JWTCredentials,
-)
+from verta.credentials import EmailCredentials, JWTCredentials
 
 from .tracking import _Context
 from .tracking.entities import (


### PR DESCRIPTION
## Impact and Context

Fixes an old `from verta._internal_utils import credentials`.

Also sneaks in https://github.com/VertaAI/modeldb/pull/2727/files#r762109250 😬 

## Risks and Area of Effect

Low risk and low area of effect. This fixes an import that wasn't working.

## Testing

—

## How to Revert

Revert this PR
