### PR TITLE
chore: Make test collection order deterministic

### DIFF
--- a/client/verta/tests/deployable_entity/conftest.py
+++ b/client/verta/tests/deployable_entity/conftest.py
@@ -11,8 +11,10 @@ from verta.environment import (
     Python,
 )
 
+from .. import utils
 
-@pytest.fixture(params=_DeployableEntity.__subclasses__())
+
+@pytest.fixture(params=utils.sorted_subclasses(_DeployableEntity))
 def deployable_entity(request, client, created_entities):
     cls = request.param
     if cls is ExperimentRun:
@@ -32,7 +34,7 @@ def deployable_entity(request, client, created_entities):
     return entity
 
 
-@pytest.fixture(params=_Environment.__subclasses__())
+@pytest.fixture(params=utils.sorted_subclasses(_Environment))
 def environment(request):
     cls = request.param
     if cls is Docker:

--- a/client/verta/tests/registry/test_stage_change.py
+++ b/client/verta/tests/registry/test_stage_change.py
@@ -5,13 +5,15 @@ import hypothesis.strategies as st
 import pytest
 
 from verta._protos.public.registry import StageService_pb2
-from verta.registry import stage_change
+from verta.registry.stage_change import _StageChange
+
+from .. import utils
 
 
 class TestStageChange:
 
     @pytest.mark.parametrize(
-        "stage_change_cls", stage_change._StageChange.__subclasses__(),
+        "stage_change_cls", utils.sorted_subclasses(_StageChange),
     )
     @hypothesis.given(
         comment=st.one_of(st.none(), st.text()),
@@ -33,7 +35,7 @@ class TestStageChange:
         )
 
     @pytest.mark.parametrize(
-        "stage_change_cls", stage_change._StageChange.__subclasses__(),
+        "stage_change_cls", utils.sorted_subclasses(_StageChange),
     )
     @hypothesis.given(
         comment=st.one_of(st.none(), st.text()),

--- a/client/verta/tests/utils.py
+++ b/client/verta/tests/utils.py
@@ -136,3 +136,24 @@ def assert_dirs_match(dir1, dir2):
     assert not dircmp.diff_files
     assert not dircmp.left_only
     assert not dircmp.right_only
+
+
+def sorted_subclasses(cls):
+    """Return subclasses of `cls`, sorted alphabetically by name.
+
+    ``pytest-xdist`` requires tests to be collected in a deterministic order.
+    This function is to be used for tests parametrized on subclasses.
+
+    Parameters
+    ----------
+    cls
+
+    Returns
+    -------
+    list of cls
+
+    """
+    return sorted(
+        cls.__subclasses__(),
+        key=lambda subcls: subcls.__name__,
+    )


### PR DESCRIPTION
## Impact and Context

https://github.com/VertaAI/cluster-setup/pull/3043 will use `pytest-xdist` to run our tests in parallel to speed up suite execution in CI. The plugin requires that tests be collected in a deterministic order before distributing them to workers (which we also effected in https://github.com/VertaAI/modeldb/pull/2372), and apparently `__subclasses__()` needs to be `sorted()` to make this happen.

## Risks and Area of Effect

Low risk: fixing the order of test parametrization shouldn't affect much of anything.

Low AoE: this only touches on a small handful of tests.

## Testing

I've run the client test suite with parallelism enabled (https://github.com/VertaAI/cluster-setup/pull/3043) and collection issues did not occur.

## How to Revert

Revert this PR.
