### PR TITLE
refactor: [VR-12957] Move package dependencies into requirements.txt

### DIFF
--- a/client/verta/requirements.txt
+++ b/client/verta/requirements.txt
@@ -1,0 +1,8 @@
+click ~= 7.0
+cloudpickle ~= 1.0
+googleapis-common-protos >= 1.5, < 2.0
+pathlib2 >= 2.2, < 3.0
+protobuf >= 3.8, < 3.18
+pytimeparse >= 1.1.8, < 2.0
+pyyaml >= 5.1, < 6.0
+requests >= 2.21, < 3.0

--- a/client/verta/setup.py
+++ b/client/verta/setup.py
@@ -12,6 +12,9 @@ with open(os.path.join(HERE, "verta", "__about__.py"), "r") as f:
 with open("README.md", "r") as f:
     readme = f.read()
 
+with open("requirements.txt", "r") as f:
+    install_requires = f.read().splitlines()
+
 setup(
     name=about["__title__"],
     version=about["__version__"],
@@ -24,16 +27,7 @@ setup(
     url=about["__url__"],
     packages=find_packages(),
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
-    install_requires=[
-        "click~=7.0",
-        "cloudpickle~=1.0",
-        "googleapis-common-protos>=1.5, <2.0",
-        "pathlib2>=2.2, <3.0",
-        "protobuf>=3.8, <3.18",
-        "pytimeparse>=1.1.8, <2.0",
-        "pyyaml>=5.1, <6.0",
-        "requests>=2.21, <3.0"
-    ],
+    install_requires=install_requires,
     entry_points={
         "console_scripts": [
             "verta = verta._cli:cli",


### PR DESCRIPTION
## Impact and Context

Snyk (and similar tools) work better when dependencies are listed in a `requirements.txt` rather than defined within `setup.py`.

This does not change any dependencies themselves. Installation behavior before and after should be identical.

## Risks and Area of Effect

low risk: This change is extremely simple.

wide area of effect: This is a part of the client's packaging/installation process, so if something goes wrong it would have a wide impact.

## Testing

On my machine, in both Python 2 and 3, I verified that installing

- the client alone (`pip install .`)
- our [dev requirements](https://github.com/VertaAI/modeldb/blob/master/client/verta/dev-requirements.txt) (`pip install -r dev-requirements.txt`)

installed all expected dependencies.

## How to Revert

Revert this PR.
