### PR TITLE
fix: [VR-13543] Make sure everything subclasses object

### DIFF
--- a/client/verta/verta/_cli/AsciiTable.py
+++ b/client/verta/verta/_cli/AsciiTable.py
@@ -1,4 +1,4 @@
-class AsciiTable:
+class AsciiTable(object):
     GAP = "   "
     def __init__(self, table):
         self.table = ""

--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -47,7 +47,7 @@ THREAD_LOCALS = threading.local()
 THREAD_LOCALS.active_experiment_run = None
 
 
-class Connection:
+class Connection(object):
     _OSS_DEFAULT_WORKSPACE = "personal"
 
     def __init__(self, scheme=None, socket=None, auth=None, max_retries=0, ignore_conn_err=False, credentials=None, headers=None):
@@ -306,7 +306,7 @@ class NoneProtoResponse(object):
         return False
 
 
-class Configuration:
+class Configuration(object):
     def __init__(self, use_git=True, debug=False):
         """
         Client behavior configuration utility struct.

--- a/client/verta/verta/_internal_utils/access_token.py
+++ b/client/verta/verta/_internal_utils/access_token.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-class AccessToken:
+class AccessToken(object):
 
     def __init__(self, token):
         self.access_token = token

--- a/client/verta/verta/deployment/_deployedmodel.py
+++ b/client/verta/verta/deployment/_deployedmodel.py
@@ -22,7 +22,7 @@ from .._internal_utils.access_token import AccessToken
 # issues during parallelism, whereas DeployedModel persists a Session for its
 # lifetime to use HTTP keep-alive and speed up consecutive predictions.
 
-class DeployedModel:
+class DeployedModel(object):
     """
     Object for interacting with deployed models.
 

--- a/client/verta/verta/monitoring/summaries/summaries.py
+++ b/client/verta/verta/monitoring/summaries/summaries.py
@@ -19,7 +19,7 @@ from .summary import Summary
 from .queries import SummaryQuery
 
 
-class Summaries:
+class Summaries(object):
     """Collection object for creating and finding summaries.
 
     Parameters

--- a/client/verta/verta/monitoring/summaries/summary_samples.py
+++ b/client/verta/verta/monitoring/summaries/summary_samples.py
@@ -10,7 +10,7 @@ from .queries import SummarySampleQuery
 from .summary_sample import SummarySample
 
 
-class SummarySamples:
+class SummarySamples(object):
     """Collection object for finding summary samples.
 
     Parameters

--- a/client/verta/verta/registry/_constants.py
+++ b/client/verta/verta/registry/_constants.py
@@ -7,7 +7,7 @@ MODEL_LANGUAGE_ATTR_KEY = "__verta_reserved__model_language"
 MODEL_TYPE_ATTR_KEY = "__verta_reserved__model_type"
 
 
-class ModelLanguage:
+class ModelLanguage(object):
     UNKNOWN = ModelMetadata_pb2.ModelLanguageEnum.ModelLanguage.Name(
         ModelMetadata_pb2.ModelLanguageEnum.Unknown,
     )
@@ -16,7 +16,7 @@ class ModelLanguage:
     )
 
 
-class ModelType:
+class ModelType(object):
     CUSTOM = ModelMetadata_pb2.ModelTypeEnum.ModelType.Name(
         ModelMetadata_pb2.ModelTypeEnum.Custom,
     )

--- a/client/verta/verta/tracking/_organization.py
+++ b/client/verta/verta/tracking/_organization.py
@@ -3,7 +3,7 @@ from .._protos.public.uac import Organization_pb2 as _Organization
 from .._protos.public.common import CommonService_pb2 as _CommonCommonService
 
 
-class CollaboratorType:
+class CollaboratorType(object):
     def __init__(self, global_collaborator_type=None, default_repo_collaborator_type=None,
                  default_endpoint_collaborator_type=None, default_dataset_collaborator_type=None):
         self.global_collaborator_type = global_collaborator_type
@@ -12,7 +12,7 @@ class CollaboratorType:
         self.default_dataset_collaborator_type = default_dataset_collaborator_type
 
 
-class Organization:
+class Organization(object):
     """
     Object representing an Organization.
 


### PR DESCRIPTION
## Impact and Context

Python 2 famously has a distinction between old-style and new-style classes for historical compatibility reasons. Because `Connection` wasn't subclassing `object`, `@property`s don't work on it, which results in an inability to set auth headers, which results in an inability to make backend requests.

![Screen Shot 2021-12-06 at 2 27 15 PM](https://user-images.githubusercontent.com/7754936/144932868-87e4bf30-fe43-461f-acf4-0729ded04ab9.png)

I've gone through the client codebase using `/^class .*(?<!\)):/` to make sure everything subclasses something.

## Risks and Area of Effect

Low risk: Subclassing `object` has no negative effects unless someone out there is really abusing Python 2's type system through our client.

Moderate AoE: Quite a handful of classes are being fixed in this PR.

## Testing

In Python 2, I am able to instantiate `Client` as well as use `Connection`.

```zsh
(dev2) miliu@yana tests % python 
Python 2.7.18 (default, Mar 30 2021, 14:20:09) 
[GCC 4.2.1 Compatible Apple LLVM 10.0.1 (clang-1001.0.46.4)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from verta._internal_utils._utils import Connection
>>> conn = Connection()
>>> conn.headers = None
>>> conn.headers
{'Grpc-Metadata-scheme': None}
```

## How to Revert

Revert this PR.
