### PR TITLE
Fix broken repository test due to collation

### DIFF
--- a/backend/src/main/java/ai/verta/modeldb/versioning/FindRepositoriesQuery.java
+++ b/backend/src/main/java/ai/verta/modeldb/versioning/FindRepositoriesQuery.java
@@ -151,11 +151,11 @@ public class FindRepositoriesQuery {
                 var joinClauses = new String[2];
                 joinClauses[0] =
                     joinAlias
-                        + ".id.entity_hash = CAST("
+                        + ".id.entity_hash = concat("
                         + alias
                         + "."
                         + ModelDBConstants.ID
-                        + " as string)";
+                        + " ) ";
                 joinClauses[1] =
                     joinAlias
                         + ".id.entity_type = "


### PR DESCRIPTION
## Impact and Context
<!-- Brief description of why these changes are necessary. Don't rewrite the entire Jira ticket. -->

**failed test Job:** https://jenkins.dev.verta.ai/job/test/job/integration-mdb/18/testReport/ai.verta.modeldb/RepositoryTest/findRepositoryTest/

**Issue:** In the query when we are casting any column it will complain like 
```
SQL Error [1267] [HY000]: Illegal mix of collations (utf8mb4_general_ci,IMPLICIT) and (utf8mb4_0900_ai_ci,IMPLICIT) for operation '='
```
**Problem with Query:**
```
SELECT  repo.*  FROM repository repo 
INNER JOIN labels_mapping label_alias_0_1639729468088 
ON label_alias_0_1639729468088.entity_hash = CAST( repo.id as string) 
AND label_alias_0_1639729468088.entity_type = 1 
WHERE repo.deleted = false  
AND  repo.created = true  AND  repo.repository_access_modifier = 1 
ORDER BY repo.date_updated desc
```
because table have `utf8mb4_general_ci` and casting will create   `utf8mb4_0900_ai_ci` so the mysql will throwing eroor on `=` of that relevant where clause. 
**Solution:** instead of casting from number to string we are creating string using `concat` function and archive the same goal.

## Risks and Area of Effect
<!--
  Describe both risk (how likely this is to break) and area of effect (how wide potential breakages could reach).
  These should be smaller scale than those documented in a design doc.
-->

## Testing
<!-- Explain how this contribution has been tested, e.g. what tests were added and where they have been run. -->

## How to Revert
<!-- List steps required to revert this change. For example, note if we'd need to revert liquibase changes. -->
