### PR TITLE
test: Add deployment pytest marker

### DIFF
--- a/client/verta/tests/README.md
+++ b/client/verta/tests/README.md
@@ -83,5 +83,7 @@ Note that for CLI tests, `click` provides [its own testing utilities](https://cl
 
 [`pytest` fixtures](https://docs.pytest.org/en/stable/fixture.html) are reusable items that are passed to test functions.
 Most fixtures are defined in [`conftest.py`](conftest.py).
+
 To use a fixture: simply write the name of the fixture as a parameter to your test function; `pytest` will automatically pass it in at runtime.
+
 To write a fixture: write code for setup, `yield` the object that should be passed to the test function, then write code for cleanup.

--- a/client/verta/tests/README.md
+++ b/client/verta/tests/README.md
@@ -35,6 +35,11 @@ pytest test_entities.py::TestProject # specific class
 pytest test_entities.py::TestProject::test_create # specific function within specific class
 ```
 
+Tests can also be run by specifying markers (defined in [`pytest.ini`](pytest.ini)):
+```bash
+pytest -m deployment
+```
+
 ### Pytest invocation flags
 
 `pytest` has a few flags that can be mixed and matched to customize output while tests are running.
@@ -77,6 +82,6 @@ Note that for CLI tests, `click` provides [its own testing utilities](https://cl
 ### Fixtures
 
 [`pytest` fixtures](https://docs.pytest.org/en/stable/fixture.html) are reusable items that are passed to test functions.
-Most fixtures are defined in [`conftest.py`](conftest.py).  
-To use a fixture: simply write the name of the fixture as a parameter to your test function; `pytest` will automatically pass it in at runtime.  
+Most fixtures are defined in [`conftest.py`](conftest.py).
+To use a fixture: simply write the name of the fixture as a parameter to your test function; `pytest` will automatically pass it in at runtime.
 To write a fixture: write code for setup, `yield` the object that should be passed to the test function, then write code for cleanup.

--- a/client/verta/tests/deployable_entity/test_deployment.py
+++ b/client/verta/tests/deployable_entity/test_deployment.py
@@ -184,6 +184,7 @@ class TestLogModel:
                 artifacts=strs[1:],
             )
 
+    @pytest.mark.deployment
     def test_overwrite_artifacts(self, deployable_entity, endpoint, in_tempdir):
         key = "foo"
         val = {'a': 1}
@@ -547,6 +548,7 @@ class TestDeployability:
                 map(os.path.basename, zipf.namelist())
             )
 
+    @pytest.mark.deployment
     def test_download_docker_context(
         self, deployable_entity, model_for_deployment, in_tempdir, registered_model
     ):
@@ -588,6 +590,7 @@ class TestDeployability:
         finally:
             shutil.rmtree(_CACHE_DIR, ignore_errors=True)
 
+    @pytest.mark.deployment
     def test_model_artifacts(self, deployable_entity, endpoint, in_tempdir):
         key = "foo"
         val = {"a": 1}

--- a/client/verta/tests/http_requests/test_deployed_model.py
+++ b/client/verta/tests/http_requests/test_deployed_model.py
@@ -9,11 +9,10 @@ from verta.environment import Python
 from verta._internal_utils._utils import generate_default_name
 
 
-pytestmark = pytest.mark.not_oss  # skip if run in oss setup
+pytestmark = [pytest.mark.deployment, pytest.mark.not_oss]
 
 
 class TestDeployedModel:
-    @pytest.mark.not_oss
     def test_ca_bundle_env_var(self, https_client, created_entities):
         """Verify predict() honors REQUESTS_CA_BUNDLE env var."""
         LogisticRegression = pytest.importorskip(

--- a/client/verta/tests/pytest.ini
+++ b/client/verta/tests/pytest.ini
@@ -10,4 +10,4 @@ filterwarnings =
     # ignore certain versions of NumPy complaining about internal C machinery
     ignore:.*numpy\.ufunc size changed, may indicate binary incompatibility.*:RuntimeWarning
 timeout = 300
-timeout_method = signal
+timeout_method = thread

--- a/client/verta/tests/pytest.ini
+++ b/client/verta/tests/pytest.ini
@@ -10,4 +10,4 @@ filterwarnings =
     # ignore certain versions of NumPy complaining about internal C machinery
     ignore:.*numpy\.ufunc size changed, may indicate binary incompatibility.*:RuntimeWarning
 timeout = 300
-timeout_method = thread
+timeout_method = signal

--- a/client/verta/tests/pytest.ini
+++ b/client/verta/tests/pytest.ini
@@ -2,6 +2,7 @@
 markers =
     oss: mark the given test function as only applicable to OSS.
     not_oss: mark the given test function not available in OSS.
+    deployment: mark the given test function as covering Verta model deployment.
     tensorflow: mark the given test function as covering TensorFlow--useful for comparing 1.X vs 2.X.
 filterwarnings =
     # ignore DeprecationWarning from protobuf generated code

--- a/client/verta/tests/registry/model_version/test_deployment.py
+++ b/client/verta/tests/registry/model_version/test_deployment.py
@@ -27,6 +27,7 @@ from ...monitoring import strategies
 pytestmark = pytest.mark.not_oss  # skip if run in oss setup. Applied to entire module
 
 
+@pytest.mark.deployment
 class TestDeployability:
     def test_from_run_download_docker_context(
         self, experiment_run, model_for_deployment, in_tempdir, registered_model

--- a/client/verta/tests/registry/test_standard_model.py
+++ b/client/verta/tests/registry/test_standard_model.py
@@ -217,6 +217,7 @@ class TestStandardModels:
             == _constants.ModelType.STANDARD_VERTA_MODEL
         )
 
+    @pytest.mark.deployment
     @pytest.mark.parametrize(
         "model",
         verta_models,
@@ -249,6 +250,7 @@ class TestStandardModels:
         deployed_model = endpoint.get_deployed_model()
         assert deployed_model.predict(artifact_value) == artifact_value
 
+    @pytest.mark.deployment
     @pytest.mark.parametrize(
         "model",
         decorated_verta_models,
@@ -291,6 +293,7 @@ class TestStandardModels:
                 Python([]),
             )
 
+    @pytest.mark.deployment
     @pytest.mark.tensorflow
     @pytest.mark.parametrize(
         "model",
@@ -331,6 +334,7 @@ class TestStandardModels:
                 Python(["tensorflow"]),
             )
 
+    @pytest.mark.deployment
     @pytest.mark.parametrize(
         "model",
         sklearn_models,
@@ -361,6 +365,7 @@ class TestStandardModels:
                 Python(["scikit-learn"]),
             )
 
+    @pytest.mark.deployment
     @pytest.mark.parametrize(
         "model",
         torch_models,
@@ -396,6 +401,7 @@ class TestStandardModels:
                 Python(["torch"]),
             )
 
+    @pytest.mark.deployment
     @pytest.mark.parametrize(
         "model",
         xgboost_models,

--- a/client/verta/tests/test_cli/test_endpoint.py
+++ b/client/verta/tests/test_cli/test_endpoint.py
@@ -14,7 +14,7 @@ from verta.endpoint.resources import Resources
 
 from ..utils import get_build_ids
 
-pytestmark = pytest.mark.not_oss  # skip if run in oss setup. Applied to entire module
+pytestmark = [pytest.mark.deployment, pytest.mark.not_oss]
 
 
 class TestList:

--- a/client/verta/tests/test_cli/test_registry.py
+++ b/client/verta/tests/test_cli/test_registry.py
@@ -207,6 +207,7 @@ class TestCreate:
         created_entities.append(model)
         assert model.workspace == organization.name
 
+    @pytest.mark.deployment
     def test_create_version_with_custom_modules(self, client, registered_model, created_entities):
         torch = pytest.importorskip("torch")
         np = pytest.importorskip("numpy")

--- a/client/verta/tests/test_endpoint/test_endpoint.py
+++ b/client/verta/tests/test_endpoint/test_endpoint.py
@@ -20,7 +20,7 @@ from verta.utils import ModelAPI
 
 from ..utils import (get_build_ids, sys_path_manager)
 
-pytestmark = pytest.mark.not_oss  # skip if run in oss setup. Applied to entire module
+pytestmark = [pytest.mark.deployment, pytest.mark.not_oss]
 
 
 class TestEndpoint:

--- a/client/verta/tests/test_endpoint/test_kafka.py
+++ b/client/verta/tests/test_endpoint/test_kafka.py
@@ -63,8 +63,8 @@ class TestKafkaSettings:
             KafkaSettings(input_topic, output_topic, error_topic)
 
 
+@pytest.mark.deployment
 class TestConfigureEndpoint:
-
     def test_configure_endpoint(self, client, model_version, strs):
         LogisticRegression = pytest.importorskip("sklearn.linear_model").LogisticRegression
         strs = iter(strs)

--- a/client/verta/tests/test_endpoint/test_resources.py
+++ b/client/verta/tests/test_endpoint/test_resources.py
@@ -5,7 +5,7 @@ from verta.endpoint.update import DirectUpdateStrategy
 
 pytestmark = pytest.mark.not_oss  # skip if run in oss setup. Applied to entire module
 
-
+@pytest.mark.deployment
 @pytest.mark.parametrize("data, strategy", [(3, DirectUpdateStrategy()), (64, None)])
 def test_download_endpoint_manifest(client, data, strategy, in_tempdir):
     resources = Resources(cpu=data)
@@ -35,6 +35,7 @@ def test_cpu_milli_negative_type(data):
         Resources(cpu=data)
 
 
+@pytest.mark.deployment
 @pytest.mark.parametrize("data", ['128974848', '129e6', '129M', '123Mi'])
 def test_memory(client, data, in_tempdir):
     resources = Resources(memory=data)

--- a/client/verta/tests/test_permissions/test_lazy_lists.py
+++ b/client/verta/tests/test_permissions/test_lazy_lists.py
@@ -72,6 +72,7 @@ class TestClient:
 
         assert set(model_ver.id for model_ver in client.registered_model_versions) == model_ver_ids
 
+    @pytest.mark.deployment
     def test_endpoints(self, client, organization, created_entities):
         client.set_workspace(organization.name)
 

--- a/client/verta/tests/test_permissions/test_visibility_api.py
+++ b/client/verta/tests/test_permissions/test_visibility_api.py
@@ -32,6 +32,7 @@ def assert_visibility(entity, visibility, entity_name):
         assert entity._msg.visibility == visibility._visibility
 
 
+@pytest.mark.deployment
 def assert_endpoint_visibility(endpoint, visibility):
     endpoint_json = endpoint._get_json_by_id(endpoint._conn, endpoint.workspace, endpoint.id)
     if 'custom_permission' not in endpoint_json['creator_request']:
@@ -95,6 +96,7 @@ class TestSet:
             entity.delete()
             client._ctx.proj = None  # otherwise client teardown tries to delete
 
+    @pytest.mark.deployment
     def test_endpoint(self, client, organization, created_entities):
         visibility = OrgCustom(write=True)
 
@@ -128,6 +130,7 @@ class TestPublicWithinOrg:
         else:
             assert dataset._msg.dataset_visibility == _DatasetService.DatasetVisibilityEnum.PRIVATE
 
+    @pytest.mark.deployment
     def test_endpoint(self, client, organization, created_entities):
         visibility = OrgCustom(write=True)
         endpoint = client.set_endpoint(

--- a/client/verta/tests/test_permissions/test_visibility_e2e.py
+++ b/client/verta/tests/test_permissions/test_visibility_e2e.py
@@ -144,6 +144,7 @@ class TestLink:
         model_ver = reg_model.create_version_from_run(run.id)
         assert model_ver._msg.experiment_run_id == run.id
 
+    @pytest.mark.deployment
     def test_endpoint_update_run(self, client_2, client_3, organization, created_entities):
         """Update endpoint from someone else's run."""
         LogisticRegression = pytest.importorskip("sklearn.linear_model").LogisticRegression
@@ -179,6 +180,7 @@ class TestLink:
         run.log_environment(Python(["scikit-learn"]))
         assert endpoint.update(run)
 
+    @pytest.mark.deployment
     def test_endpoint_update_model_version(self, client_2, client_3, organization, created_entities):
         """Update endpoint from someone else's model version."""
         LogisticRegression = pytest.importorskip("sklearn.linear_model").LogisticRegression


### PR DESCRIPTION
## Impact and Context

Adds a new `deployment` pytest marker to:

- anything on `Endpoint` (updates, predictions, visibility, permissions, Docker context)
- `client.download_endpoint_manifest()`
- CLI tests encompassing the above

## Risks and Area of Effect

Low risk and AoE: this does not change existing test execution behavior.

There's certainly a chance I've missed some tests, but I've checked twice!

## Testing

I ran our pytest-3.7 pipeline (build 6) which has a few unrelated failures but executes without configuration errors.

## How to Revert

Revert this PR.