### PR TITLE
fix: [VR-12865] Add validation for class model artifacts in RMV

### DIFF
--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -476,6 +476,10 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
 
         serialized_model, method, model_type = _artifact_utils.serialize_model(model)
 
+        if artifacts and model_type != "class":
+            raise ValueError(
+                "`artifacts` can only be provided if `model` is a class")
+
         # Create artifact message and update ModelVersion's message:
         model_msg = self._create_artifact_msg(
             self._MODEL_KEY,


### PR DESCRIPTION
## Impact and Context

The `artifacts` parameter in `log_model()` is only applicable if the model is a `class` (it specifies what logged artifacts to pass to the class model's `__init__()`). ER had logic to check that the model is a class, but RMV didn't...until now!

## Risks and Area of Effect

Low risk and AoE: Adds a safeguard to what would be a broken user flow, with minimal impact on further functionality.

## Testing

```
% pytest deployable_entity/test_deployment.py::TestLogModel::test_not_class_model_artifacts_error          
======================================================= test session starts =======================================================
platform darwin -- Python 2.7.18, pytest-4.6.11, py-1.11.0, pluggy-0.13.1                                                          
rootdir: /Users/miliu/Documents/modeldb/client/verta/tests, inifile: pytest.ini                                                    
plugins: hypothesis-4.57.1, timeout-1.4.2                                                                                          
timeout: 300.0s                                                                                                                    
timeout method: signal                                                                                                             
timeout func_only: False                                                                                                           
collected 2 items                                                                                                                  
                                                                                                                                   
deployable_entity/test_deployment.py ..                                                                                     [100%] 
                                                                                                                                   
============================================== 2 passed, 4 warnings in 76.67 seconds ==============================================
```

## How to Revert

Revert this PR.
