### PR TITLE
test: Increase test timeout

### DIFF
--- a/client/verta/tests/pytest.ini
+++ b/client/verta/tests/pytest.ini
@@ -8,5 +8,5 @@ filterwarnings =
     ignore:.*Create unlinked descriptors is going to go away.*:DeprecationWarning
     # ignore certain versions of NumPy complaining about internal C machinery
     ignore:.*numpy\.ufunc size changed, may indicate binary incompatibility.*:RuntimeWarning
-timeout = 300
+timeout = 600
 timeout_method = signal

--- a/client/verta/tests/pytest.ini
+++ b/client/verta/tests/pytest.ini
@@ -8,5 +8,8 @@ filterwarnings =
     ignore:.*Create unlinked descriptors is going to go away.*:DeprecationWarning
     # ignore certain versions of NumPy complaining about internal C machinery
     ignore:.*numpy\.ufunc size changed, may indicate binary incompatibility.*:RuntimeWarning
-timeout = 600
-timeout_method = signal
+timeout =
+    600
+timeout_method =
+    # "signal" crashes the xdist worker, but "thread" doesn't report timeout as failure
+    signal

--- a/client/verta/tests/pytest.ini
+++ b/client/verta/tests/pytest.ini
@@ -9,4 +9,4 @@ filterwarnings =
     # ignore certain versions of NumPy complaining about internal C machinery
     ignore:.*numpy\.ufunc size changed, may indicate binary incompatibility.*:RuntimeWarning
 timeout = 600
-timeout_method = thread
+timeout_method = signal

--- a/client/verta/tests/pytest.ini
+++ b/client/verta/tests/pytest.ini
@@ -9,4 +9,4 @@ filterwarnings =
     # ignore certain versions of NumPy complaining about internal C machinery
     ignore:.*numpy\.ufunc size changed, may indicate binary incompatibility.*:RuntimeWarning
 timeout = 600
-timeout_method = signal
+timeout_method = thread


### PR DESCRIPTION
## Impact and Context

5m isn't enough for a small handful of tests (there's one that updates an endpoint _twice_) so I'm doubling it to 10m across the board.

Ideally the timed-out tests themselves should be fixed, but an interaction between `pytest-timeout` and `pytest-xdist` causes a loss of test coverage (timeouts cause `xdist` workers to crash) so I'd like to resolve this first.

## Risks and Area of Effect

Low risk and AoE: We're using `pytest-timeout` to fail faster on indefinitely-hanging tests; increasing the timeout means we're giving more slow tests a pass, but still failing faster on hanging ones.

## Testing

I ran our pytest-3.7 pipeline (build 9) which has a few unrelated failures but executes without configuration errors.

## How to Revert

Revert this PR.
