### PR TITLE
test: remove pytest-timeout

### DIFF
--- a/client/verta/requirements-unit-tests.txt
+++ b/client/verta/requirements-unit-tests.txt
@@ -1,6 +1,4 @@
-execnet == 1.8.0  # mitigates a bug between timeout and xdist; https://github.com/pytest-dev/pytest-xdist/issues/620#issuecomment-808175875
 hypothesis
 pytest >= 4.3
-pytest-timeout == 1.4.2
 pytest-xdist
 six >= 1.11

--- a/client/verta/tests/pytest.ini
+++ b/client/verta/tests/pytest.ini
@@ -9,5 +9,3 @@ filterwarnings =
     ignore:.*Create unlinked descriptors is going to go away.*:DeprecationWarning
     # ignore certain versions of NumPy complaining about internal C machinery
     ignore:.*numpy\.ufunc size changed, may indicate binary incompatibility.*:RuntimeWarning
-timeout = 300
-timeout_method = signal

--- a/client/verta/tests/pytest.ini
+++ b/client/verta/tests/pytest.ini
@@ -9,8 +9,5 @@ filterwarnings =
     ignore:.*Create unlinked descriptors is going to go away.*:DeprecationWarning
     # ignore certain versions of NumPy complaining about internal C machinery
     ignore:.*numpy\.ufunc size changed, may indicate binary incompatibility.*:RuntimeWarning
-timeout =
-    600
-timeout_method =
-    # "signal" crashes the xdist worker, but "thread" doesn't report timeout as failure
-    signal
+timeout = 300
+timeout_method = signal


### PR DESCRIPTION
## Impact and Context

Effectively reverts #2787 and #2690.

There is some sort of bad interaction between `pytest-timeout` and `pytest-xdist` that results in tests crashing. For references, see:

- https://github.com/pytest-dev/pytest-timeout/issues/8
- https://github.com/pytest-dev/pytest-xdist/issues/620

We had added `pytest-timeout` to fail faster when cases hang indefinitely. We can still rely on the pipeline timeout defined on the Jenkinsfile.

## Risks and Area of Effect

Low risk: Nothing is likely to break; it will just take longer for test pipelines to fail on indefinitely-hanging tests (we could tighten the pipeline timeout if we'd like, since `xdist` is running our suites faster).

Low AoE: Only affects how the client test suite is run (mostly in CI, from reading the above-linked GitHub issues)

## Testing

Ran test pipelines, which did not encounter the aforementioned bad interaction.

## How to Revert

Revert this PR.