### PR TITLE
test: [VRD-53] Add tests for collecting installed custom modules

### DIFF
--- a/client/verta/requirements-unit-tests.txt
+++ b/client/verta/requirements-unit-tests.txt
@@ -1,4 +1,4 @@
 hypothesis
 pytest >= 4.3
-pytest-xdist
+pytest-xdist >= 1.32
 six >= 1.11

--- a/client/verta/tests/conftest.py
+++ b/client/verta/tests/conftest.py
@@ -23,6 +23,7 @@ from verta.environment import Python
 
 import hypothesis
 import pytest
+pytest.register_assert_rewrite("tests.utils")
 from . import constants, utils
 from . import clean_test_accounts
 from .env_fixtures import (

--- a/client/verta/tests/conftest.py
+++ b/client/verta/tests/conftest.py
@@ -332,20 +332,11 @@ def random_data():
             return data
 
 
-@pytest.fixture(scope="session")
-def tempdir_root():
-    return os.environ.get("TEMPDIR_ROOT")
-
-
 @pytest.fixture
-def in_tempdir(tempdir_root):
+def in_tempdir():
     """Moves test to execute inside a temporary directory."""
-    dirpath = tempfile.mkdtemp(dir=tempdir_root)
-    try:
-        with utils.chdir(dirpath):
-            yield dirpath
-    finally:
-        shutil.rmtree(dirpath)
+    with utils.chtempdir() as dirpath:
+        yield dirpath
 
 
 @pytest.fixture

--- a/client/verta/tests/custom_modules/conftest.py
+++ b/client/verta/tests/custom_modules/conftest.py
@@ -31,3 +31,33 @@ def in_fake_venv():
             yield dirpath
     finally:
         shutil.rmtree(dirpath)
+
+
+# TODO: move to root conftest and substitute for `mkdtemp`s in tests
+@pytest.fixture(scope="class")
+def make_tempdir():
+    """Make temporary directories.
+
+    Analogous to ``pytest``'s built-in ``tmp_path_factory`` fixture, except
+    this doesn't require explicit names for its directories.
+
+    """
+    created_dirs = []
+
+    def _make_tempdir():
+        """Make a temporary directory.
+
+        Returns
+        -------
+        str
+            Absolute path to the created directory.
+
+        """
+        dirpath = tempfile.mkdtemp(dir=utils.TEMPDIR_ROOT)
+        created_dirs.append(dirpath)
+        return dirpath
+
+    yield _make_tempdir
+
+    for dirpath in created_dirs:
+        shutil.rmtree(dirpath)

--- a/client/verta/tests/custom_modules/conftest.py
+++ b/client/verta/tests/custom_modules/conftest.py
@@ -2,12 +2,8 @@
 
 import os
 import shutil
-import subprocess
-import sys
 import tempfile
-import textwrap
 
-import hypothesis
 import pytest
 
 from .. import constants
@@ -15,9 +11,9 @@ from .. import utils
 
 
 @pytest.fixture(scope="class")
-def in_fake_venv(tempdir_root):
+def in_fake_venv():
     """Move test to execute inside a mocked, empty virtual environment."""
-    dirpath = tempfile.mkdtemp(dir=tempdir_root)
+    dirpath = tempfile.mkdtemp(dir=utils.TEMPDIR_ROOT)
 
     # empty site-packages/
     os.makedirs(os.path.join(dirpath, constants.LIB_SITE_PACKAGES))
@@ -35,124 +31,3 @@ def in_fake_venv(tempdir_root):
             yield dirpath
     finally:
         shutil.rmtree(dirpath)
-
-
-@pytest.fixture()
-def make_package():
-    """Make simple pip-installable packages.
-
-    Warnings
-    --------
-    Packages should not be moved in the filesystem after they are created,
-    otherwise teardown will be unable to delete them.
-
-    Notes
-    -----
-    In the spirit of general convention, the package and its root module have
-    the same name. This isn't required nor universal however, and they have
-    divergent character restrictions.
-
-    """
-    created_packages = []
-
-    def _make_package(name, dir=None):
-        """Make a simple pip-installable package.
-
-        Parameters
-        ----------
-        name : str
-            Name of the package.
-        dir : str, optional
-            Directory in which to create the package. If not provided, the
-            current directory will be used.
-
-        Returns
-        -------
-        str
-            Absolute path to the created package.
-
-        Notes
-        -----
-        The package is declared using a ``setup.py`` to reflect today's
-        ecosystem; it could be migrated to ``setup.cfg`` in the future [1]_.
-
-        References
-        ----------
-        .. [1] https://setuptools.pypa.io/en/latest/userguide/quickstart.html?highlight=setup.py#transitioning-from-setup-py-to-setup-cfg
-
-        """
-        if not dir:
-            dir = os.curdir
-
-        dir = os.path.abspath(dir)
-        pkg_dir = os.path.join(dir, name)
-        code_dir = os.path.join(pkg_dir, name)
-
-        os.mkdir(pkg_dir)
-        created_packages.append(pkg_dir)
-        with open(os.path.join(pkg_dir, "setup.py"), "w") as f:
-            content = textwrap.dedent(
-                """\
-                # -*- coding: utf-8 -*-
-
-                from setuptools import find_packages, setup
-
-                setup(
-                    name="{}",
-                    version="0.0.1",
-                    packages=find_packages(),
-                )
-                """.format(name)
-            )
-            f.write(content)
-        os.mkdir(code_dir)
-        with open(os.path.join(code_dir, "__init__.py"), "w") as f:
-            content = textwrap.dedent(
-                """\
-                # -*- coding: utf-8 -*-
-
-                is_successful = True
-                """
-            )
-            f.write(content)
-
-        return pkg_dir
-
-    yield _make_package
-
-    for pkg_dir in created_packages:
-        shutil.rmtree(pkg_dir, ignore_errors=True)
-
-
-@pytest.fixture
-def install_local_package():
-    """pip install locally-defined packages.
-
-    Warnings
-    --------
-    While packages are uninstalled on teardown, their dependencies may not be.
-
-    """
-    installed_packages = []
-
-    def _install_local_package(pkg_dir, name):
-        """pip install a locally-defined package.
-
-        Parameters
-        ----------
-        pkg_dir : str
-            Absolute path to the package.
-        name : str
-            Name of the package. This is used to uninstall the package on
-            teardown.
-
-        """
-        subprocess.check_call([sys.executable, "-m", "pip", "install", pkg_dir])
-        installed_packages.append(name)
-
-    yield _install_local_package
-
-    for name in installed_packages:
-        subprocess.check_call(
-            [sys.executable, "-m", "pip", "uninstall", "-y", name],
-        )

--- a/client/verta/tests/custom_modules/conftest.py
+++ b/client/verta/tests/custom_modules/conftest.py
@@ -31,33 +31,3 @@ def in_fake_venv():
             yield dirpath
     finally:
         shutil.rmtree(dirpath)
-
-
-# TODO: move to root conftest and substitute for `mkdtemp`s in tests
-@pytest.fixture(scope="class")
-def make_tempdir():
-    """Make temporary directories.
-
-    Analogous to ``pytest``'s built-in ``tmp_path_factory`` fixture, except
-    this doesn't require explicit names for its directories.
-
-    """
-    created_dirs = []
-
-    def _make_tempdir():
-        """Make a temporary directory.
-
-        Returns
-        -------
-        str
-            Absolute path to the created directory.
-
-        """
-        dirpath = tempfile.mkdtemp(dir=utils.TEMPDIR_ROOT)
-        created_dirs.append(dirpath)
-        return dirpath
-
-    yield _make_tempdir
-
-    for dirpath in created_dirs:
-        shutil.rmtree(dirpath)

--- a/client/verta/tests/custom_modules/conftest.py
+++ b/client/verta/tests/custom_modules/conftest.py
@@ -3,7 +3,9 @@
 import os
 import shutil
 import tempfile
+import textwrap
 
+import hypothesis
 import pytest
 
 from .. import constants
@@ -31,3 +33,90 @@ def in_fake_venv(tempdir_root):
             yield dirpath
     finally:
         shutil.rmtree(dirpath)
+
+
+@pytest.fixture()
+def make_package():
+    """Make simple pip-installable packages.
+
+    Warnings
+    --------
+    Packages should not be moved in the filesystem after they are created,
+    otherwise teardown will be unable to delete them.
+
+    Notes
+    -----
+    In the spirit of general convention, the package and its root module have
+    the same name. This isn't required nor universal however, and they have
+    divergent character restrictions.
+
+    """
+    created_packages = []
+
+    def _make_package(name, dir=None):
+        """Make a simple pip-installable package
+
+        Parameters
+        ----------
+        name : str
+            Name of the package.
+        dir : str, optional
+            Directory in which to create the package. If not provided, the
+            current directory will be used.
+
+        Returns
+        -------
+        str
+            Absolute path to the created package.
+
+        Notes
+        -----
+        The package is declared using a ``setup.py`` to reflect today's
+        ecosystem; it could be migrated to ``setup.cfg`` in the future [1]_.
+
+        References
+        ----------
+        .. [1] https://setuptools.pypa.io/en/latest/userguide/quickstart.html?highlight=setup.py#transitioning-from-setup-py-to-setup-cfg
+
+        """
+        if not dir:
+            dir = os.curdir
+
+        dir = os.path.abspath(dir)
+        pkg_dir = os.path.join(dir, name)
+        code_dir = os.path.join(pkg_dir, name)
+
+        os.mkdir(pkg_dir)
+        created_packages.append(pkg_dir)
+        with open(os.path.join(pkg_dir, "setup.py"), "w") as f:
+            content = textwrap.dedent(
+                """\
+                # -*- coding: utf-8 -*-
+
+                from setuptools import find_packages, setup
+
+                setup(
+                    name="{}",
+                    version="0.0.1",
+                    packages=find_packages(),
+                )
+                """.format(name)
+            )
+            f.write(content)
+        os.mkdir(code_dir)
+        with open(os.path.join(code_dir, "__init__.py"), "w") as f:
+            content = textwrap.dedent(
+                """\
+                # -*- coding: utf-8 -*-
+
+                is_successful = True
+                """
+            )
+            f.write(content)
+
+        return pkg_dir
+
+    yield _make_package
+
+    for package in created_packages:
+        shutil.rmtree(package)

--- a/client/verta/tests/custom_modules/contexts.py
+++ b/client/verta/tests/custom_modules/contexts.py
@@ -87,7 +87,8 @@ def installable_package(name, dir=None):
         shutil.rmtree(pkg_dir)
 
 
-# TODO: try to get this to work in a virtual environment
+# TODO: try to create and install into a virtual environment
+#       pytest-venv looks good, but need to be able to import from it in the test
 @contextlib.contextmanager
 def installed_local_package(pkg_dir, name):
     """pip install a locally-defined package.

--- a/client/verta/tests/custom_modules/contexts.py
+++ b/client/verta/tests/custom_modules/contexts.py
@@ -1,11 +1,14 @@
 # -*- coding: utf-8 -*-
 
+import ast
 import contextlib
 import os
 import shutil
 import subprocess
 import sys
 import textwrap
+
+from verta._internal_utils.custom_modules import CustomModules
 
 
 @contextlib.contextmanager
@@ -103,6 +106,7 @@ def installed_local_package(pkg_dir, name):
 
     """
     subprocess.check_call([sys.executable, "-m", "pip", "install", pkg_dir])
+    assert CustomModules.is_importable(name)  # verify installation
 
     try:
         yield

--- a/client/verta/tests/custom_modules/contexts.py
+++ b/client/verta/tests/custom_modules/contexts.py
@@ -87,8 +87,6 @@ def installable_package(name, dir=None):
         shutil.rmtree(pkg_dir)
 
 
-# TODO: try to create and install into a virtual environment
-#       pytest-venv looks good, but need to be able to import from it in the test
 @contextlib.contextmanager
 def installed_local_package(pkg_dir, name):
     """pip install a locally-defined package.

--- a/client/verta/tests/custom_modules/contexts.py
+++ b/client/verta/tests/custom_modules/contexts.py
@@ -104,7 +104,9 @@ def installed_local_package(pkg_dir, name):
     While packages are uninstalled on cleanup, their dependencies might not be.
 
     """
-    subprocess.check_call([sys.executable, "-m", "pip", "install", pkg_dir])
+    subprocess.check_call(
+        [sys.executable, "-m", "pip", "install", "-qq", pkg_dir],
+    )
     assert CustomModules.is_importable(name)  # verify installation
 
     try:

--- a/client/verta/tests/custom_modules/contexts.py
+++ b/client/verta/tests/custom_modules/contexts.py
@@ -67,7 +67,9 @@ def installable_package(name, dir=None):
                 version="0.0.1",
                 packages=find_packages(),
             )
-            """.format(name)
+            """.format(
+                name,
+            ),
         )
         f.write(content)
     os.mkdir(code_dir)
@@ -105,7 +107,15 @@ def installed_local_package(pkg_dir, name):
 
     """
     subprocess.check_call(
-        [sys.executable, "-m", "pip", "install", "-qq", pkg_dir],
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "--no-python-version-warning",
+            "install",
+            "-qq",
+            pkg_dir,
+        ],
     )
     assert CustomModules.is_importable(name)  # verify installation
 
@@ -113,5 +123,13 @@ def installed_local_package(pkg_dir, name):
         yield
     finally:
         subprocess.check_call(
-            [sys.executable, "-m", "pip", "uninstall", "-y", name],
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "--no-python-version-warning",
+                "uninstall",
+                "-y",
+                name,
+            ],
         )

--- a/client/verta/tests/custom_modules/test_custom_modules.py
+++ b/client/verta/tests/custom_modules/test_custom_modules.py
@@ -79,13 +79,10 @@ class TestCollectPipInstalledModule:
         for name in names:
             self.assert_in_custom_modules(custom_modules, name)
 
-    @hypothesis.settings(deadline=None)
-    @hypothesis.given(
-        name=strategies.python_module_name(),  # pylint: disable=no-value-for-parameter
-    )
-    def test_module_and_local_dir_have_same_name(self, name, worker_id):
+    def test_module_and_local_dir_have_same_name(self, worker_id):
         """If a pip-installed module and a local directory share a name, the module is collected."""
-        name += worker_id
+        name = worker_id
+        del worker_id
 
         # avoid using an existing package name
         hypothesis.assume(not CustomModules.is_importable(name))
@@ -107,18 +104,15 @@ class TestCollectPipInstalledModule:
                         )
                         self.assert_in_custom_modules(custom_modules, name)
 
-    @hypothesis.settings(deadline=None)
-    @hypothesis.given(
-        name=strategies.python_module_name(),  # pylint: disable=no-value-for-parameter
-    )
-    def test_module_and_local_pkg_have_same_name(self, name, worker_id):
+    def test_module_and_local_pkg_have_same_name(self, worker_id):
         """A specific case of :meth:`test_module_and_local_dir_have_same_name`.
 
         The local directory *is* a Python package repository
         (but not directly importable without ``cd``ing one level into it).
 
         """
-        name += worker_id
+        name = worker_id
+        del worker_id
 
         # avoid using an existing package name
         hypothesis.assume(not CustomModules.is_importable(name))

--- a/client/verta/tests/custom_modules/test_custom_modules.py
+++ b/client/verta/tests/custom_modules/test_custom_modules.py
@@ -2,10 +2,10 @@
 
 import json
 import os
+import pkgutil
 import zipfile
 
 import hypothesis
-import pytest
 
 from verta.tracking.entities._deployable_entity import _DeployableEntity
 from verta._internal_utils.custom_modules import CustomModules
@@ -35,18 +35,18 @@ class TestCollection:
                 with contexts.installed_local_package(pkg_dir, name):
                     # collect and extract custom modules
                     custom_modules = _DeployableEntity._custom_modules_as_artifact([name])
-                    custom_modules_dir = os.path.abspath("custom_modules")
+                    custom_modules_dir = make_tempdir()
                     with zipfile.ZipFile(custom_modules, "r") as zipf:
                         zipf.extractall(custom_modules_dir)
 
                     utils.assert_dirs_match(
                         os.path.join(custom_modules_dir, name),
-                        local_dir,  # TODO: this is incorrect
+                        pkgutil.find_loader(name).filename,
                     )
 
     @hypothesis.settings(deadline=None)
     @hypothesis.given(name=strategies.python_module_name())  # pylint: disable=no-value-for-parameter
-    def test_module_and_local_pkg_have_same_name(self, name):
+    def test_module_and_local_pkg_have_same_name(self, name, make_tempdir):
         """A specific case of :meth:`test_module_and_local_dir_have_same_name`.
 
         The local package is *not* directly ``import``able because it is
@@ -62,11 +62,11 @@ class TestCollection:
                 with contexts.installed_local_package(pkg_dir, name):
                     # collect and extract custom modules
                     custom_modules = _DeployableEntity._custom_modules_as_artifact([name])
-                    custom_modules_dir = os.path.abspath("custom_modules")
+                    custom_modules_dir = make_tempdir()
                     with zipfile.ZipFile(custom_modules, "r") as zipf:
                         zipf.extractall(custom_modules_dir)
 
                     utils.assert_dirs_match(
                         os.path.join(custom_modules_dir, name),
-                        pkg_dir,  # TODO: this is incorrect
+                        pkgutil.find_loader(name).filename,
                     )

--- a/client/verta/tests/custom_modules/test_custom_modules.py
+++ b/client/verta/tests/custom_modules/test_custom_modules.py
@@ -48,11 +48,7 @@ class TestCollectPipInstalledModule:
     )
     def test_module(self, name):
         """pip-installed module can be collected."""
-        if (
-            name == "tests"
-            or name == "conftest"
-            or name.startswith("test_")
-        ):
+        if name == "tests" or name == "conftest" or name.startswith("test_"):
             pytest.skip(
                 "pytest modifies both import mechanisms and module objects,"
                 " which we can't handle right now"
@@ -84,7 +80,9 @@ class TestCollectPipInstalledModule:
             self.assert_in_custom_modules(custom_modules, name)
 
     @hypothesis.settings(deadline=None)
-    @hypothesis.given(name=strategies.python_module_name())  # pylint: disable=no-value-for-parameter
+    @hypothesis.given(
+        name=strategies.python_module_name(),  # pylint: disable=no-value-for-parameter
+    )
     def test_module_and_local_dir_have_same_name(self, name, worker_id):
         """If a pip-installed module and a local directory share a name, the module is collected."""
         name += worker_id
@@ -104,11 +102,15 @@ class TestCollectPipInstalledModule:
                 with contexts.installable_package(name, dir=tempd) as pkg_dir:
                     with contexts.installed_local_package(pkg_dir, name):
                         # collect and validate custom modules
-                        custom_modules = _DeployableEntity._custom_modules_as_artifact([name])
+                        custom_modules = _DeployableEntity._custom_modules_as_artifact(
+                            [name],
+                        )
                         self.assert_in_custom_modules(custom_modules, name)
 
     @hypothesis.settings(deadline=None)
-    @hypothesis.given(name=strategies.python_module_name())  # pylint: disable=no-value-for-parameter
+    @hypothesis.given(
+        name=strategies.python_module_name(),  # pylint: disable=no-value-for-parameter
+    )
     def test_module_and_local_pkg_have_same_name(self, name, worker_id):
         """A specific case of :meth:`test_module_and_local_dir_have_same_name`.
 
@@ -126,5 +128,7 @@ class TestCollectPipInstalledModule:
             with contexts.installable_package(name, dir=".") as pkg_dir:
                 with contexts.installed_local_package(pkg_dir, name):
                     # collect and validate custom modules
-                    custom_modules = _DeployableEntity._custom_modules_as_artifact([name])
+                    custom_modules = _DeployableEntity._custom_modules_as_artifact(
+                        [name],
+                    )
                     self.assert_in_custom_modules(custom_modules, name)

--- a/client/verta/tests/custom_modules/test_custom_modules.py
+++ b/client/verta/tests/custom_modules/test_custom_modules.py
@@ -62,7 +62,7 @@ class TestCollectPipInstalledModule:
                 "pytest_forked insists on having an empty __pycache__,"
                 " which custom modules ignores, which fails our match check"
             )
-        if CustomModules.get_module_path(name) == "built-in":
+        if CustomModules.get_module_path(name) in ("built-in", "frozen"):
             pytest.skip("built into Python; no module file to collect")
         if six.PY2 and (name.startswith("tensorflow_") or name == "torch"):
             pytest.skip("takes too long")

--- a/client/verta/tests/custom_modules/test_custom_modules.py
+++ b/client/verta/tests/custom_modules/test_custom_modules.py
@@ -19,7 +19,7 @@ from . import contexts
 class TestCollectPipInstalledModule:
     @staticmethod
     def assert_in_custom_modules(custom_modules, module_name):
-        module = pkgutil.find_loader(module_name).filename  # TODO: Python 3
+        module = CustomModules.get_module_path(module_name)
 
         with utils.tempdir() as custom_modules_dir:
             with zipfile.ZipFile(custom_modules, "r") as zipf:

--- a/client/verta/tests/custom_modules/test_custom_modules.py
+++ b/client/verta/tests/custom_modules/test_custom_modules.py
@@ -57,10 +57,15 @@ class TestCollectPipInstalledModule:
                 "pytest modifies both import mechanisms and module objects,"
                 " which we can't handle right now"
             )
-        if six.PY2 and (name.startswith("tensorflow_") or name == "torch"):
-            pytest.skip("takes too long")
+        if six.Py2 and name == "pytest_forked":
+            pytest.skip(
+                "pytest_forked insists on having an empty __pycache__,"
+                " which custom modules ignores, which fails our match check"
+            )
         if CustomModules.get_module_path(name) == "built-in":
             pytest.skip("built into Python; no module file to collect")
+        if six.PY2 and (name.startswith("tensorflow_") or name == "torch"):
+            pytest.skip("takes too long")
 
         custom_modules = _DeployableEntity._custom_modules_as_artifact([name])
         self.assert_in_custom_modules(custom_modules, name)
@@ -105,14 +110,14 @@ class TestCollectPipInstalledModule:
     @hypothesis.settings(deadline=None)
     @hypothesis.given(name=strategies.python_module_name())  # pylint: disable=no-value-for-parameter
     def test_module_and_local_pkg_have_same_name(self, name, testrun_uid):
-        name += testrun_uid
-
         """A specific case of :meth:`test_module_and_local_dir_have_same_name`.
 
         The local directory *is* a Python package repository
         (but not directly importable without ``cd``ing one level into it).
 
         """
+        name += testrun_uid
+
         # avoid using an existing package name
         hypothesis.assume(not CustomModules.is_importable(name))
 

--- a/client/verta/tests/custom_modules/test_custom_modules.py
+++ b/client/verta/tests/custom_modules/test_custom_modules.py
@@ -69,7 +69,9 @@ class TestCollectPipInstalledModule:
 
     @hypothesis.settings(deadline=None)
     @hypothesis.given(name=strategies.python_module_name())  # pylint: disable=no-value-for-parameter
-    def test_module_and_local_dir_have_same_name(self, name):
+    def test_module_and_local_dir_have_same_name(self, name, testrun_uid):
+        name += testrun_uid
+
         # avoid using an existing package name
         hypothesis.assume(not CustomModules.is_importable(name))
 
@@ -90,7 +92,9 @@ class TestCollectPipInstalledModule:
 
     @hypothesis.settings(deadline=None)
     @hypothesis.given(name=strategies.python_module_name())  # pylint: disable=no-value-for-parameter
-    def test_module_and_local_pkg_have_same_name(self, name):
+    def test_module_and_local_pkg_have_same_name(self, name, testrun_uid):
+        name += testrun_uid
+
         """A specific case of :meth:`test_module_and_local_dir_have_same_name`.
 
         The local package is *not* directly ``import``able because it is

--- a/client/verta/tests/custom_modules/test_custom_modules.py
+++ b/client/verta/tests/custom_modules/test_custom_modules.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 
+import filecmp
 import json
 import os
 import pkgutil
 import zipfile
 
 import hypothesis
+import pytest
 
 from verta.tracking.entities._deployable_entity import _DeployableEntity
 from verta._internal_utils.custom_modules import CustomModules
@@ -14,10 +16,46 @@ from .. import strategies, utils
 from . import contexts
 
 
-class TestCollection:
+class TestCollectPipInstalledModule:
+    @staticmethod
+    def assert_in_custom_modules(custom_modules, module_name):
+        module = pkgutil.find_loader(module_name).filename  # TODO: Python 3
+
+        with utils.tempdir() as custom_modules_dir:
+            with zipfile.ZipFile(custom_modules, "r") as zipf:
+                zipf.extractall(custom_modules_dir)
+
+            # TODO: extract sys.path from _verta_config.py instead of walking
+            for parent_dir, dirnames, filenames in os.walk(custom_modules_dir):
+                if os.path.basename(module) in dirnames + filenames:
+                    retrieved_module = os.path.join(
+                        parent_dir,
+                        os.path.basename(module),
+                    )
+                    break
+            else:
+                raise ValueError("module not found in custom modules")
+
+            if os.path.isfile(module):
+                assert filecmp.cmp(module, retrieved_module)
+            else:
+                utils.assert_dirs_match(module, retrieved_module)
+
+    @pytest.mark.parametrize(
+        "names",
+        [
+            ["cloudpickle"],
+            ["cloudpickle", "hypothesis"],
+        ],
+    )
+    def test_module(self, names):
+        custom_modules = _DeployableEntity._custom_modules_as_artifact(names)
+        for name in names:
+            self.assert_in_custom_modules(custom_modules, name)
+
     @hypothesis.settings(deadline=None)
     @hypothesis.given(name=strategies.python_module_name())  # pylint: disable=no-value-for-parameter
-    def test_module_and_local_dir_have_same_name(self, name, make_tempdir):
+    def test_module_and_local_dir_have_same_name(self, name):
         # avoid using an existing package name
         hypothesis.assume(not CustomModules.is_importable(name))
 
@@ -29,22 +67,16 @@ class TestCollection:
                 json.dump({}, f)
 
             # create package in another directory and install
-            with contexts.installable_package(name, dir=str(make_tempdir())) as pkg_dir:
-                with contexts.installed_local_package(pkg_dir, name):
-                    # collect and extract custom modules
-                    custom_modules = _DeployableEntity._custom_modules_as_artifact([name])
-                    custom_modules_dir = make_tempdir()
-                    with zipfile.ZipFile(custom_modules, "r") as zipf:
-                        zipf.extractall(custom_modules_dir)
-
-                    utils.assert_dirs_match(
-                        os.path.join(custom_modules_dir, name),
-                        pkgutil.find_loader(name).filename,
-                    )
+            with utils.tempdir() as tempd:
+                with contexts.installable_package(name, dir=tempd) as pkg_dir:
+                    with contexts.installed_local_package(pkg_dir, name):
+                        # collect and validate custom modules
+                        custom_modules = _DeployableEntity._custom_modules_as_artifact([name])
+                        self.assert_in_custom_modules(custom_modules, name)
 
     @hypothesis.settings(deadline=None)
     @hypothesis.given(name=strategies.python_module_name())  # pylint: disable=no-value-for-parameter
-    def test_module_and_local_pkg_have_same_name(self, name, make_tempdir):
+    def test_module_and_local_pkg_have_same_name(self, name):
         """A specific case of :meth:`test_module_and_local_dir_have_same_name`.
 
         The local package is *not* directly ``import``able because it is
@@ -58,13 +90,6 @@ class TestCollection:
             # create package in *current* directory and install
             with contexts.installable_package(name, dir=".") as pkg_dir:
                 with contexts.installed_local_package(pkg_dir, name):
-                    # collect and extract custom modules
+                    # collect and validate custom modules
                     custom_modules = _DeployableEntity._custom_modules_as_artifact([name])
-                    custom_modules_dir = make_tempdir()
-                    with zipfile.ZipFile(custom_modules, "r") as zipf:
-                        zipf.extractall(custom_modules_dir)
-
-                    utils.assert_dirs_match(
-                        os.path.join(custom_modules_dir, name),
-                        pkgutil.find_loader(name).filename,
-                    )
+                    self.assert_in_custom_modules(custom_modules, name)

--- a/client/verta/tests/custom_modules/test_custom_modules.py
+++ b/client/verta/tests/custom_modules/test_custom_modules.py
@@ -85,9 +85,9 @@ class TestCollectPipInstalledModule:
 
     @hypothesis.settings(deadline=None)
     @hypothesis.given(name=strategies.python_module_name())  # pylint: disable=no-value-for-parameter
-    def test_module_and_local_dir_have_same_name(self, name, testrun_uid):
+    def test_module_and_local_dir_have_same_name(self, name, worker_id):
         """If a pip-installed module and a local directory share a name, the module is collected."""
-        name += testrun_uid
+        name += worker_id
 
         # avoid using an existing package name
         hypothesis.assume(not CustomModules.is_importable(name))
@@ -109,14 +109,14 @@ class TestCollectPipInstalledModule:
 
     @hypothesis.settings(deadline=None)
     @hypothesis.given(name=strategies.python_module_name())  # pylint: disable=no-value-for-parameter
-    def test_module_and_local_pkg_have_same_name(self, name, testrun_uid):
+    def test_module_and_local_pkg_have_same_name(self, name, worker_id):
         """A specific case of :meth:`test_module_and_local_dir_have_same_name`.
 
         The local directory *is* a Python package repository
         (but not directly importable without ``cd``ing one level into it).
 
         """
-        name += testrun_uid
+        name += worker_id
 
         # avoid using an existing package name
         hypothesis.assume(not CustomModules.is_importable(name))

--- a/client/verta/tests/custom_modules/test_custom_modules.py
+++ b/client/verta/tests/custom_modules/test_custom_modules.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+
+import json
+import os
+import zipfile
+
+import hypothesis
+import pytest
+
+from verta.tracking.entities._deployable_entity import _DeployableEntity
+from verta._internal_utils.custom_modules import CustomModules
+
+from .. import strategies, utils
+from . import contexts
+
+# also deployable_entity/test_deployment.py::TestLogModel::test_custom_modules
+
+
+class TestCollection:
+    @hypothesis.settings(deadline=None)
+    @hypothesis.given(name=strategies.python_module_name())  # pylint: disable=no-value-for-parameter
+    def test_module_and_local_dir_have_same_name(self, name, make_tempdir):
+        # avoid using an existing package name
+        hypothesis.assume(not CustomModules.is_importable(name))
+
+        with utils.chtempdir():
+            # create local directory with same name as package
+            local_dir = os.path.abspath(name)
+            os.mkdir(local_dir)
+            with open(os.path.join(local_dir, "empty.json"), "w") as f:
+                json.dump({}, f)
+
+            # create package in another directory and install
+            with contexts.installable_package(name, dir=str(make_tempdir())) as pkg_dir:
+                with contexts.installed_local_package(pkg_dir, name):
+                    # collect and extract custom modules
+                    custom_modules = _DeployableEntity._custom_modules_as_artifact([name])
+                    custom_modules_dir = os.path.abspath("custom_modules")
+                    with zipfile.ZipFile(custom_modules, "r") as zipf:
+                        zipf.extractall(custom_modules_dir)
+
+                    utils.assert_dirs_match(
+                        os.path.join(custom_modules_dir, name),
+                        local_dir,  # TODO: this is incorrect
+                    )
+
+    @hypothesis.settings(deadline=None)
+    @hypothesis.given(name=strategies.python_module_name())  # pylint: disable=no-value-for-parameter
+    def test_module_and_local_pkg_have_same_name(self, name):
+        """A specific case of :meth:`test_module_and_local_dir_have_same_name`.
+
+        The local package is *not* directly ``import``able because it is
+        nested one level in, but the root directory still bears its name.
+
+        """
+        # avoid using an existing package name
+        hypothesis.assume(not CustomModules.is_importable(name))
+
+        with utils.chtempdir():
+            # create package in *current* directory and install
+            with contexts.installable_package(name, dir=".") as pkg_dir:
+                with contexts.installed_local_package(pkg_dir, name):
+                    # collect and extract custom modules
+                    custom_modules = _DeployableEntity._custom_modules_as_artifact([name])
+                    custom_modules_dir = os.path.abspath("custom_modules")
+                    with zipfile.ZipFile(custom_modules, "r") as zipf:
+                        zipf.extractall(custom_modules_dir)
+
+                    utils.assert_dirs_match(
+                        os.path.join(custom_modules_dir, name),
+                        pkg_dir,  # TODO: this is incorrect
+                    )

--- a/client/verta/tests/custom_modules/test_custom_modules.py
+++ b/client/verta/tests/custom_modules/test_custom_modules.py
@@ -57,7 +57,7 @@ class TestCollectPipInstalledModule:
                 "pytest modifies both import mechanisms and module objects,"
                 " which we can't handle right now"
             )
-        if six.Py2 and name == "pytest_forked":
+        if six.PY2 and name == "pytest_forked":
             pytest.skip(
                 "pytest_forked insists on having an empty __pycache__,"
                 " which custom modules ignores, which fails our match check"

--- a/client/verta/tests/custom_modules/test_custom_modules.py
+++ b/client/verta/tests/custom_modules/test_custom_modules.py
@@ -13,8 +13,6 @@ from verta._internal_utils.custom_modules import CustomModules
 from .. import strategies, utils
 from . import contexts
 
-# also deployable_entity/test_deployment.py::TestLogModel::test_custom_modules
-
 
 class TestCollection:
     @hypothesis.settings(deadline=None)

--- a/client/verta/tests/custom_modules/test_custom_modules.py
+++ b/client/verta/tests/custom_modules/test_custom_modules.py
@@ -46,6 +46,12 @@ class TestCollectPipInstalledModule:
         sorted(module[1] for module in pkgutil.iter_modules()),
     )
     def test_module(self, name):
+        if name == "tests" or name.startswith("test_"):
+            pytest.skip(
+                "pytest modifies both import mechanisms and module objects,"
+                " which we can't handle right now"
+            )
+
         custom_modules = _DeployableEntity._custom_modules_as_artifact([name])
         self.assert_in_custom_modules(custom_modules, name)
 

--- a/client/verta/tests/custom_modules/test_custom_modules.py
+++ b/client/verta/tests/custom_modules/test_custom_modules.py
@@ -42,13 +42,21 @@ class TestCollectPipInstalledModule:
                 utils.assert_dirs_match(module, retrieved_module)
 
     @pytest.mark.parametrize(
+        "name",
+        sorted(module[1] for module in pkgutil.iter_modules()),
+    )
+    def test_module(self, name):
+        custom_modules = _DeployableEntity._custom_modules_as_artifact([name])
+        self.assert_in_custom_modules(custom_modules, name)
+
+    @pytest.mark.parametrize(
         "names",
         [
-            ["cloudpickle"],
             ["cloudpickle", "hypothesis"],
+            ["cloudpickle", "hypothesis", "pytest"],
         ],
     )
-    def test_module(self, names):
+    def test_multiple_modules(self, names):
         custom_modules = _DeployableEntity._custom_modules_as_artifact(names)
         for name in names:
             self.assert_in_custom_modules(custom_modules, name)

--- a/client/verta/tests/custom_modules/test_custom_modules.py
+++ b/client/verta/tests/custom_modules/test_custom_modules.py
@@ -46,6 +46,7 @@ class TestCollectPipInstalledModule:
         sorted(module[1] for module in pkgutil.iter_modules()),
     )
     def test_module(self, name):
+        """pip-installed module can be collected."""
         if name == "tests" or name.startswith("test_"):
             pytest.skip(
                 "pytest modifies both import mechanisms and module objects,"
@@ -63,6 +64,7 @@ class TestCollectPipInstalledModule:
         ],
     )
     def test_multiple_modules(self, names):
+        """Multiple pip-installed modules can be collected at once."""
         custom_modules = _DeployableEntity._custom_modules_as_artifact(names)
         for name in names:
             self.assert_in_custom_modules(custom_modules, name)
@@ -70,6 +72,7 @@ class TestCollectPipInstalledModule:
     @hypothesis.settings(deadline=None)
     @hypothesis.given(name=strategies.python_module_name())  # pylint: disable=no-value-for-parameter
     def test_module_and_local_dir_have_same_name(self, name, testrun_uid):
+        """If a pip-installed module and a local directory share a name, the module is collected."""
         name += testrun_uid
 
         # avoid using an existing package name
@@ -97,8 +100,8 @@ class TestCollectPipInstalledModule:
 
         """A specific case of :meth:`test_module_and_local_dir_have_same_name`.
 
-        The local package is *not* directly ``import``able because it is
-        nested one level in, but the root directory still bears its name.
+        The local directory *is* a Python package repository
+        (but not directly importable without ``cd``ing one level into it).
 
         """
         # avoid using an existing package name

--- a/client/verta/tests/deployable_entity/test_deployment.py
+++ b/client/verta/tests/deployable_entity/test_deployment.py
@@ -48,7 +48,7 @@ class TestLogModel:
         custom_modules_dir = "."
 
         deployable_entity.log_model(
-            model_for_deployment['model'],
+            model_for_deployment["model"],
             custom_modules=["."],
         )
 
@@ -57,13 +57,19 @@ class TestLogModel:
             # skip venvs
             #     This logic is from _utils.find_filepaths().
             exec_path_glob = os.path.join(parent_dir, "{}", "bin", "python*")
-            dirnames[:] = [dirname for dirname in dirnames if not glob.glob(exec_path_glob.format(dirname))]
+            dirnames[:] = [
+                dirname
+                for dirname in dirnames
+                if not glob.glob(exec_path_glob.format(dirname))
+            ]
 
             custom_module_filenames.update(map(os.path.basename, filenames))
 
         custom_modules = deployable_entity.get_artifact(_artifact_utils.CUSTOM_MODULES_KEY)
-        with zipfile.ZipFile(custom_modules, 'r') as zipf:
-            assert custom_module_filenames == set(map(os.path.basename, zipf.namelist()))
+        with zipfile.ZipFile(custom_modules, "r") as zipf:
+            assert custom_module_filenames == set(
+                map(os.path.basename, zipf.namelist())
+            )
 
     def test_no_custom_modules(self, deployable_entity, model_for_deployment):
         deployable_entity.log_model(model_for_deployment['model'])
@@ -520,33 +526,6 @@ class TestDeployability:
             downloaded_model = pickle.load(f)
 
         assert downloaded_model.get_params() == model.get_params()
-
-    def test_log_model_with_custom_modules(self, deployable_entity, model_for_deployment):
-        custom_modules_dir = "."
-
-        deployable_entity.log_model(
-            model_for_deployment["model"],
-            custom_modules=["."],
-        )
-
-        custom_module_filenames = {"__init__.py", "_verta_config.py"}
-        for parent_dir, dirnames, filenames in os.walk(custom_modules_dir):
-            # skip venvs
-            #     This logic is from _utils.find_filepaths().
-            exec_path_glob = os.path.join(parent_dir, "{}", "bin", "python*")
-            dirnames[:] = [
-                dirname
-                for dirname in dirnames
-                if not glob.glob(exec_path_glob.format(dirname))
-            ]
-
-            custom_module_filenames.update(map(os.path.basename, filenames))
-
-        custom_modules = deployable_entity.get_artifact(_artifact_utils.CUSTOM_MODULES_KEY)
-        with zipfile.ZipFile(custom_modules, "r") as zipf:
-            assert custom_module_filenames == set(
-                map(os.path.basename, zipf.namelist())
-            )
 
     @pytest.mark.deployment
     def test_download_docker_context(

--- a/client/verta/tests/strategies.py
+++ b/client/verta/tests/strategies.py
@@ -6,6 +6,7 @@ import re
 import string
 import warnings
 
+import hypothesis
 import hypothesis.strategies as st
 from verta._internal_utils.time_utils import duration_millis
 
@@ -30,8 +31,13 @@ json_strategy = st.recursive(
 
 
 @st.composite
-def filepath(draw):
+def filepath(draw, allow_parent_dir_segments=False):
     """A valid filepath. Does **not** create the file.
+
+    Parameters
+    ----------
+    allow_parent_dir_segments : bool, default False
+        Whether to allow paths that contain `".."` segments.
 
     Returns
     -------
@@ -44,6 +50,9 @@ def filepath(draw):
     num_segments = draw(st.integers(min_value=1, max_value=6))
 
     segments = [draw(st.text(legal_chars, min_size=1)) for _ in range(num_segments)]
+    if not allow_parent_dir_segments:
+        hypothesis.assume(".." not in segments)
+
     return os.path.join(*segments)
 
 

--- a/client/verta/tests/strategies.py
+++ b/client/verta/tests/strategies.py
@@ -2,6 +2,7 @@
 
 from datetime import timedelta
 import os
+import re
 import string
 import warnings
 
@@ -44,6 +45,14 @@ def filepath(draw):
 
     segments = [draw(st.text(legal_chars, min_size=1)) for _ in range(num_segments)]
     return os.path.join(*segments)
+
+
+@st.composite
+def python_module_name(draw):
+    # intersection of package and module name requirements
+    pattern = r"[A-Z]|[A-Z][A-Z0-9_]*[A-Z0-9]"
+    regex = re.compile(pattern, flags=re.IGNORECASE)
+    return draw(st.from_regex(regex, fullmatch=True))
 
 
 @st.composite

--- a/client/verta/tests/strategies.py
+++ b/client/verta/tests/strategies.py
@@ -57,14 +57,6 @@ def filepath(draw, allow_parent_dir_segments=False):
 
 
 @st.composite
-def python_module_name(draw):
-    # intersection of package and module name requirements
-    pattern = r"[A-Z]|[A-Z][A-Z0-9_]*[A-Z0-9]"
-    regex = re.compile(pattern, flags=re.IGNORECASE)
-    return draw(st.from_regex(regex, fullmatch=True))
-
-
-@st.composite
 def env_vars(draw):
     """For use as Environment versioning's `env_var` parameter.
 

--- a/client/verta/tests/utils.py
+++ b/client/verta/tests/utils.py
@@ -112,6 +112,27 @@ def chdir(new_dir):
         os.chdir(old_dir)
 
 
+# TODO: move to client utils and use everywhere
+@contextlib.contextmanager
+def tempdir():
+    """Context manager for creating a temporary directory.
+
+    Similar to Python 3's :func:`tempfile.TemporaryDirectory`.
+
+    Yields
+    ------
+    str
+        Absolute path to the created directory.
+
+    """
+    dirpath = tempfile.mkdtemp(dir=TEMPDIR_ROOT)
+
+    try:
+        yield dirpath
+    finally:
+        shutil.rmtree(dirpath)
+
+
 @contextlib.contextmanager
 def chtempdir():
     """Context manager for safely changing into a temporary directory.
@@ -126,12 +147,9 @@ def chtempdir():
         Absolute path to the temporary working directory.
 
     """
-    dirpath = tempfile.mkdtemp(dir=TEMPDIR_ROOT)
-    try:
+    with tempdir() as dirpath:
         with chdir(dirpath):
             yield dirpath
-    finally:
-        shutil.rmtree(dirpath)
 
 
 @contextlib.contextmanager

--- a/client/verta/tests/utils.py
+++ b/client/verta/tests/utils.py
@@ -16,6 +16,9 @@ from verta._protos.public.uac import Organization_pb2 as _OrganizationService
 from hypothesis import strategies as st
 
 
+# Jenkins workers had been getting lost during artifact tests;
+# we added this env var to ensure files are written to disk
+# (and not, say, into RAM)
 TEMPDIR_ROOT = os.environ.get("TEMPDIR_ROOT")
 
 

--- a/client/verta/tests/utils.py
+++ b/client/verta/tests/utils.py
@@ -3,8 +3,10 @@ import copy
 import filecmp
 import random
 import os
+import shutil
 import sys
 from string import printable
+import tempfile
 
 import requests
 
@@ -12,6 +14,9 @@ from verta._internal_utils import _utils
 from verta._protos.public.uac import Organization_pb2 as _OrganizationService
 
 from hypothesis import strategies as st
+
+
+TEMPDIR_ROOT = os.environ.get("TEMPDIR_ROOT")
 
 
 def gen_none():
@@ -105,6 +110,28 @@ def chdir(new_dir):
         yield
     finally:
         os.chdir(old_dir)
+
+
+@contextlib.contextmanager
+def chtempdir():
+    """Context manager for safely changing into a temporary directory.
+
+    The :func:`in_tempdir` fixture should be preferred in general; this
+    context manager is for ``hypothesis`` tests because the fixture doesn't
+    reset between ``hypothesis`` examples.
+
+    Yields
+    ------
+    str
+        Absolute path to the temporary working directory.
+
+    """
+    dirpath = tempfile.mkdtemp(dir=TEMPDIR_ROOT)
+    try:
+        with chdir(dirpath):
+            yield dirpath
+    finally:
+        shutil.rmtree(dirpath)
 
 
 @contextlib.contextmanager

--- a/client/verta/verta/_internal_utils/custom_modules.py
+++ b/client/verta/verta/_internal_utils/custom_modules.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+
+import pkgutil
+
+
+class CustomModules(object):
+
+    @staticmethod
+    def is_importable(module_name):
+        """Return whether `module_name` can be imported.
+
+        Returns
+        -------
+        bool
+
+        """
+        return True if pkgutil.find_loader(module_name) else False

--- a/client/verta/verta/_internal_utils/custom_modules.py
+++ b/client/verta/verta/_internal_utils/custom_modules.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 
+import importlib
 import pkgutil
+
+from verta.external import six
 
 
 class CustomModules(object):
@@ -15,3 +18,24 @@ class CustomModules(object):
 
         """
         return True if pkgutil.find_loader(module_name) else False
+
+    @staticmethod
+    def get_module_path(module_name):
+        """Return root path to `module`.
+
+        Returns
+        -------
+        str
+
+        """
+        if six.PY2:
+            return pkgutil.find_loader(module_name).filename
+
+        module_spec = importlib.util.find_spec(module_name)  # pylint: disable=no-member
+
+        module_path = module_spec.submodule_search_locations  # module.__path__
+        if module_path:  # directory-based package
+            return module_path[0]  # root dir
+
+        # single-file module
+        return module_spec.origin  # module.__file__

--- a/client/verta/verta/tracking/entities/_deployable_entity.py
+++ b/client/verta/verta/tracking/entities/_deployable_entity.py
@@ -461,7 +461,8 @@ class _DeployableEntity(_ModelDBEntity):
 
         return artifacts
 
-    def _custom_modules_as_artifact(self, paths=None):
+    @staticmethod
+    def _custom_modules_as_artifact(paths=None):
         if isinstance(paths, six.string_types):
             paths = [paths]
 


### PR DESCRIPTION
<!-- Title of the PR must comply with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines. --> 
<!-- Title should include the JIRA ticket in square brackets after the conventional commit prefix. This will automatically link the PR in JIRA. -->
<!-- Example: "fix: [JIRA-123] Allow creation of groups with no members" -->

## Impact and Context
<!-- Brief description of why these changes are necessary. Don't rewrite the entire Jira ticket. -->

This PR adds test coverage for custom modules' ability to collect `pip`-installed modules by name.

The last two tests validate a scenario when the module shares a name with a local directory. These tests will fail until #2805 is merged.

## Risks and Area of Effect
<!--
  Describe both risk (how likely this is to break) and area of effect (how wide potential breakages could reach).
  These should be smaller scale than those documented in a design doc.
-->

Low risk: Most of this PR is new test code that won't break old things and is validated through testing.
- The Client's new `CustomModules` util class is a little bit risky as a new-for-us approach to module discovery, but it's validated in testing.
- The change to the Client's `_custom_modules_as_artifact` won't break anything (it's still called and used the same way)

Low AoE: Only impacts custom modules functionality and related tests.

## Testing
<!-- Explain how this contribution has been tested, e.g. what tests were added and where they have been run. -->

See #2805.

## How to Revert

Revert this PR.
