### PR TITLE
fix!: [VRD-53] Collect installed custom module instead of local dir with same name

### DIFF
--- a/client/verta/verta/_internal_utils/custom_modules.py
+++ b/client/verta/verta/_internal_utils/custom_modules.py
@@ -17,7 +17,10 @@ class CustomModules(object):
         bool
 
         """
-        return True if pkgutil.find_loader(module_name) else False
+        try:
+            return True if pkgutil.find_loader(module_name) else False
+        except ImportError:
+            return False
 
     @staticmethod
     def get_module_path(module_name):

--- a/client/verta/verta/tracking/entities/_deployable_entity.py
+++ b/client/verta/verta/tracking/entities/_deployable_entity.py
@@ -20,6 +20,7 @@ from verta._internal_utils import (
     _histogram_utils,
     _utils,
 )
+from verta._internal_utils.custom_modules import CustomModules
 from verta._protos.public.common import CommonService_pb2 as _CommonCommonService
 from verta.environment import _Environment
 
@@ -473,16 +474,15 @@ class _DeployableEntity(_ModelDBEntity):
             new_paths = []
             for p in paths:
                 abspath = os.path.abspath(os.path.expanduser(p))
-                try:
-                    mod = importlib.import_module(p)
-                except ImportError:
+                if CustomModules.is_importable(p):
+                    mod_path = CustomModules.get_module_path(p)
+                    new_paths.append(mod_path)
+                    forced_local_sys_paths.append(os.path.dirname(mod_path))
+                else:
                     if os.path.exists(abspath):
                         new_paths.append(abspath)
                     else:
                         raise ValueError("custom module {} does not correspond to an existing folder or module".format(p))
-                else:
-                    new_paths.extend(mod.__path__)
-                    forced_local_sys_paths.extend(map(os.path.dirname, mod.__path__))
 
             paths = new_paths
 

--- a/client/verta/verta/tracking/entities/_deployable_entity.py
+++ b/client/verta/verta/tracking/entities/_deployable_entity.py
@@ -473,15 +473,16 @@ class _DeployableEntity(_ModelDBEntity):
             new_paths = []
             for p in paths:
                 abspath = os.path.abspath(os.path.expanduser(p))
-                if os.path.exists(abspath):
-                    new_paths.append(abspath)
-                else:
-                    try:
-                        mod = importlib.import_module(p)
-                        new_paths.extend(mod.__path__)
-                        forced_local_sys_paths.extend(map(os.path.dirname, mod.__path__))
-                    except ImportError:
+                try:
+                    mod = importlib.import_module(p)
+                except ImportError:
+                    if os.path.exists(abspath):
+                        new_paths.append(abspath)
+                    else:
                         raise ValueError("custom module {} does not correspond to an existing folder or module".format(p))
+                else:
+                    new_paths.extend(mod.__path__)
+                    forced_local_sys_paths.extend(map(os.path.dirname, mod.__path__))
 
             paths = new_paths
 


### PR DESCRIPTION
<!-- Title of the PR must comply with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines. --> 
<!-- Title should include the JIRA ticket in square brackets after the conventional commit prefix. This will automatically link the PR in JIRA. -->
<!-- Example: "fix: [JIRA-123] Allow creation of groups with no members" -->

## Impact and Context
<!-- Brief description of why these changes are necessary. Don't rewrite the entire Jira ticket. -->

This short PR incorporates 3 key improvements:

1. **This is a breaking user-facing behavior change.** When looking for a custom module by name, `_custom_modules_as_artifact()` will now prefer a pip-installed Python package over a local directory. A user may be able to force the local file by prepending `"./"`.
1. By using `pkgutil.find_loader()` instead of `importlib.import_module()`, we avoid any side effects of actually importing Python modules.
1. By using the new `CustomModules.get_module_path()` instead of `mod.__path__`, we now collect pip-installed Python packages that are a single `.py` file (such as [`six`](https://github.com/benjaminp/six/blob/master/six.py)); the `__path__` approach only worked for directory-based Python packages.

## Risks and Area of Effect
<!--
  Describe both risk (how likely this is to break) and area of effect (how wide potential breakages could reach).
  These should be smaller scale than those documented in a design doc.
-->

Moderate risk: While this change is quite small, and my use of `pkgutil` and `importlib.util` are corroborated by the std lib docs, some particulars of Python's import machinery are still unknown to me. This change could break custom module discovery; I've made an effort to counteract this risk through **Testing**.

Low AoE: This only impacts custom module functionality.

## Testing
<!-- Explain how this contribution has been tested, e.g. what tests were added and where they have been run. -->

To verify existing functionality has not broken, I ran /job/e2e-deployment/4 and saw that the custom modules and venv-related tests are still passing (`test_custom_modules`, `test_no_venv`, `test_fake_venv`, `test_pip_installed_custom_module_venv`).

I have also run the existing custom modules tests in the client suite:`deployable_entity/test_deployment.py::TestLogModel::test_custom_modules` (/job/pytest/20) and `custom_modules/test_utils.py` (/job/pytest/21).

Finally, I've run the new tests that specifically cover the collection of pip-installed custom modules introduced in #2799: `custom_modules/test_custom_modules.py` (/job/pytest/22).

## How to Revert
<!-- List steps required to revert this change. For example, note if we'd need to revert liquibase changes. -->

Revert this PR.

It may also be prudent to revert #2799; it has tests that would fail without this PR.