### PR TITLE
test: Uncache module after deletion

### DIFF
--- a/client/verta/tests/custom_modules/contexts.py
+++ b/client/verta/tests/custom_modules/contexts.py
@@ -133,3 +133,7 @@ def installed_local_package(pkg_dir, name):
                 name,
             ],
         )
+
+        # delete cached module to disallow subsequent imports
+        if name in sys.modules:
+            del sys.modules[name]

--- a/client/verta/tests/custom_modules/test_custom_modules.py
+++ b/client/verta/tests/custom_modules/test_custom_modules.py
@@ -13,11 +13,11 @@ import six
 from verta.tracking.entities._deployable_entity import _DeployableEntity
 from verta._internal_utils.custom_modules import CustomModules
 
-from .. import strategies, utils
+from .. import utils
 from . import contexts
 
 
-class TestCollectPipInstalledModule:
+class TestPipInstalledModule:
     @staticmethod
     def assert_in_custom_modules(custom_modules, module_name):
         module = CustomModules.get_module_path(module_name)
@@ -82,7 +82,6 @@ class TestCollectPipInstalledModule:
     def test_module_and_local_dir_have_same_name(self, worker_id):
         """If a pip-installed module and a local directory share a name, the module is collected."""
         name = worker_id
-        del worker_id
 
         # avoid using an existing package name
         hypothesis.assume(not CustomModules.is_importable(name))
@@ -112,7 +111,6 @@ class TestCollectPipInstalledModule:
 
         """
         name = worker_id
-        del worker_id
 
         # avoid using an existing package name
         hypothesis.assume(not CustomModules.is_importable(name))


### PR DESCRIPTION
<!-- Title of the PR must comply with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines. --> 
<!-- Title should include the JIRA ticket in square brackets after the conventional commit prefix. This will automatically link the PR in JIRA. -->
<!-- Example: "fix: [JIRA-123] Allow creation of groups with no members" -->

## Impact and Context
<!-- Brief description of why these changes are necessary. Don't rewrite the entire Jira ticket. -->

Python 3 caches modules when they're imported, so even a `pip uninstall` doesn't clean it from the system. This PR augments the context manager to remove the module from the cache right after the `pip uninstall`.

This is specifically a problem for these tests because they use the `pytest-xdist` worker ID as the package name, so if the tests run sequentially on the same worker (e.g. when not run in parallel), the same package name gets re-used.

Also while I'm at it, I'm removing the `del worker_id`s because they were preventing pytest from introspecting their values in test failure reports.

## Risks and Area of Effect
<!--
  Describe both risk (how likely this is to break) and area of effect (how wide potential breakages could reach).
  These should be smaller scale than those documented in a design doc.
-->

Low risk: The `installed_local_package()` context isn't thread-safe to begin with, and removing a cached module is safer than all the pip things it does anyway.

Low AoE: Only affects the two tests that use this context manager.

## Testing
<!-- Explain how this contribution has been tested, e.g. what tests were added and where they have been run. -->

Ran `custom_modules/test_custom_modules.py` locally both with and without parallelism (our CI jobs currently can only run our tests in parallel).

## How to Revert
<!-- List steps required to revert this change. For example, note if we'd need to revert liquibase changes. -->

Revert this PR.