### PR TITLE
test: Add deployment test for custom modules fix

### DIFF
--- a/client/verta/tests/conftest.py
+++ b/client/verta/tests/conftest.py
@@ -20,6 +20,9 @@ import verta
 from verta import Client
 from verta._internal_utils import _utils, _pip_requirements_utils
 from verta.environment import Python
+from verta.tracking.entities._deployable_entity import _DeployableEntity
+from verta.tracking.entities import ExperimentRun
+from verta.registry.entities import RegisteredModelVersion
 
 import hypothesis
 import pytest
@@ -465,6 +468,26 @@ def registered_model(client, created_entities):
 @pytest.fixture(scope="class")
 def class_registered_model(class_client, class_created_entities):
     return registered_model_factory(class_client, class_created_entities)
+
+
+@pytest.fixture(params=utils.sorted_subclasses(_DeployableEntity))
+def deployable_entity(request, client, created_entities):
+    cls = request.param
+    if cls is ExperimentRun:
+        proj = client.create_project()
+        created_entities.append(proj)
+        entity = client.create_experiment_run()
+    elif cls is RegisteredModelVersion:
+        reg_model = client.create_registered_model()
+        created_entities.append(reg_model)
+        entity = reg_model.create_version()
+    else:
+        raise RuntimeError(
+            "_DeployableEntity appears to have a subclass {} that is not"
+            " accounted for in this fixture".format(cls)
+        )
+
+    return entity
 
 
 @pytest.fixture

--- a/client/verta/tests/custom_modules/integration/test_deploy_custom_modules.py
+++ b/client/verta/tests/custom_modules/integration/test_deploy_custom_modules.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+
+import importlib
+
+import hypothesis
+import pytest
+
+from verta.environment import Python
+from verta._internal_utils.custom_modules import CustomModules
+
+from ... import utils
+from .. import contexts, models
+
+
+pytestmark = [pytest.mark.integration]
+
+
+class TestPipInstalledModule:
+    @pytest.mark.deployment
+    def test_deploy_module_and_local_pkg_have_same_name(
+        self,
+        deployable_entity,
+        endpoint,
+        worker_id,
+    ):
+        """Deployment analogue to ``custom_modules/test_custom_modules.py::TestPipInstalledModule::test_module_and_local_pkg_have_same_name``.
+
+        A success means that custom modules successfully collected the
+        pip-installed module, and the deployed model could import it.
+
+        """
+        name = worker_id
+
+        # avoid using an existing package name
+        hypothesis.assume(not CustomModules.is_importable(name))
+
+        with utils.chtempdir():
+            # create package in *current* directory and install
+            with contexts.installable_package(name, dir=".") as pkg_dir:
+                with contexts.installed_local_package(pkg_dir, name):
+                    Model = models.create_custom_module_model(name)
+                    assert Model().predict("") == name  # sanity check
+
+                    deployable_entity.log_model(Model, custom_modules=[name])
+                    deployable_entity.log_environment(Python([]))
+
+                    endpoint.update(deployable_entity, wait=True)
+
+                    assert endpoint.get_deployed_model().predict("") == name

--- a/client/verta/tests/custom_modules/integration/test_deploy_custom_modules.py
+++ b/client/verta/tests/custom_modules/integration/test_deploy_custom_modules.py
@@ -42,8 +42,8 @@ class TestPipInstalledModule:
                     assert Model().predict("") == name  # sanity check
 
                     deployable_entity.log_model(Model, custom_modules=[name])
-                    deployable_entity.log_environment(Python([]))
+        deployable_entity.log_environment(Python([]))
 
-                    endpoint.update(deployable_entity, wait=True)
+        endpoint.update(deployable_entity, wait=True)
 
-                    assert endpoint.get_deployed_model().predict("") == name
+        assert endpoint.get_deployed_model().predict("") == name

--- a/client/verta/tests/custom_modules/models.py
+++ b/client/verta/tests/custom_modules/models.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+
+# NOTE: Don't import pytest, or anything other than std lib and verta;
+#       otherwise unpickling will try to find them and probably fail.
+import importlib
+
+from verta.registry import VertaModelBase, verify_io
+
+
+def create_custom_module_model(module_name):
+    """Return a model that imports `module_name` and predicts back its name.
+
+    Parameters
+    ----------
+    module_name : str
+        Name of a pip-installable module.
+
+    Returns
+    -------
+    cls
+
+    """
+    class Model(VertaModelBase):
+        def __init__(self, artifacts=None):
+            exec("import {}".format(module_name), {})
+
+        @verify_io
+        def predict(self, input):
+            return importlib.import_module(module_name).__name__
+
+    return Model

--- a/client/verta/tests/custom_modules/test_custom_modules.py
+++ b/client/verta/tests/custom_modules/test_custom_modules.py
@@ -80,7 +80,14 @@ class TestPipInstalledModule:
             self.assert_in_custom_modules(custom_modules, name)
 
     def test_module_and_local_dir_have_same_name(self, worker_id):
-        """If a pip-installed module and a local directory share a name, the module is collected."""
+        """If a pip-installed module and a local directory share a name, the module is collected.
+
+        If a user can import a package "foo" in their environment, and uses
+        custom modules to find "foo", we will prefer that package over a
+        directory/file "foo" in the cwd. Otherwise, it is very difficult or
+        impossible to force the installed package.
+
+        """
         name = worker_id
 
         # avoid using an existing package name
@@ -106,8 +113,12 @@ class TestPipInstalledModule:
     def test_module_and_local_pkg_have_same_name(self, worker_id):
         """A specific case of :meth:`test_module_and_local_dir_have_same_name`.
 
-        The local directory *is* a Python package repository
-        (but not directly importable without ``cd``ing one level into it).
+        The local directory *is* a Python package repository (but not directly
+        importable without ``cd``ing one level into it).
+
+        A user may have a monolithic project with model management scripts
+        alongside Python package directories (that may *also* be installed
+        into the environment).
 
         """
         name = worker_id

--- a/client/verta/tests/deployable_entity/conftest.py
+++ b/client/verta/tests/deployable_entity/conftest.py
@@ -2,9 +2,6 @@
 
 import pytest
 
-from verta.tracking.entities._deployable_entity import _DeployableEntity
-from verta.tracking.entities import ExperimentRun
-from verta.registry.entities import RegisteredModelVersion
 from verta.environment import (
     _Environment,
     Docker,
@@ -12,26 +9,6 @@ from verta.environment import (
 )
 
 from .. import utils
-
-
-@pytest.fixture(params=utils.sorted_subclasses(_DeployableEntity))
-def deployable_entity(request, client, created_entities):
-    cls = request.param
-    if cls is ExperimentRun:
-        proj = client.create_project()
-        created_entities.append(proj)
-        entity = client.create_experiment_run()
-    elif cls is RegisteredModelVersion:
-        reg_model = client.create_registered_model()
-        created_entities.append(reg_model)
-        entity = reg_model.create_version()
-    else:
-        raise RuntimeError(
-            "_DeployableEntity appears to have a subclass {} that is not"
-            " accounted for in this fixture".format(cls)
-        )
-
-    return entity
 
 
 @pytest.fixture(params=utils.sorted_subclasses(_Environment))

--- a/client/verta/tests/pytest.ini
+++ b/client/verta/tests/pytest.ini
@@ -2,6 +2,7 @@
 markers =
     oss: mark the given test function as only applicable to OSS.
     not_oss: mark the given test function not available in OSS.
+    integration: mark the given test function as an integration test.
     deployment: mark the given test function as covering Verta model deployment.
     tensorflow: mark the given test function as covering TensorFlow--useful for comparing 1.X vs 2.X.
 filterwarnings =

--- a/client/verta/verta/_internal_utils/custom_modules.py
+++ b/client/verta/verta/_internal_utils/custom_modules.py
@@ -17,10 +17,7 @@ class CustomModules(object):
         bool
 
         """
-        try:
-            return True if pkgutil.find_loader(module_name) else False
-        except ImportError:
-            return False
+        return True if pkgutil.find_loader(module_name) else False
 
     @staticmethod
     def get_module_path(module_name):

--- a/client/verta/verta/_internal_utils/custom_modules.py
+++ b/client/verta/verta/_internal_utils/custom_modules.py
@@ -17,7 +17,10 @@ class CustomModules(object):
         bool
 
         """
-        return True if pkgutil.find_loader(module_name) else False
+        try:
+            return True if pkgutil.find_loader(module_name) else False
+        except ImportError:
+            return False
 
     @staticmethod
     def get_module_path(module_name):

--- a/client/verta/verta/tracking/entities/_deployable_entity.py
+++ b/client/verta/verta/tracking/entities/_deployable_entity.py
@@ -20,6 +20,7 @@ from verta._internal_utils import (
     _histogram_utils,
     _utils,
 )
+from verta._internal_utils.custom_modules import CustomModules
 from verta._protos.public.common import CommonService_pb2 as _CommonCommonService
 from verta.environment import _Environment
 
@@ -473,14 +474,14 @@ class _DeployableEntity(_ModelDBEntity):
             new_paths = []
             for p in paths:
                 abspath = os.path.abspath(os.path.expanduser(p))
-                if os.path.exists(abspath):
-                    new_paths.append(abspath)
+                if CustomModules.is_importable(p):
+                    mod_path = CustomModules.get_module_path(p)
+                    new_paths.append(mod_path)
+                    forced_local_sys_paths.append(os.path.dirname(mod_path))
                 else:
-                    try:
-                        mod = importlib.import_module(p)
-                        new_paths.extend(mod.__path__)
-                        forced_local_sys_paths.extend(map(os.path.dirname, mod.__path__))
-                    except ImportError:
+                    if os.path.exists(abspath):
+                        new_paths.append(abspath)
+                    else:
                         raise ValueError("custom module {} does not correspond to an existing folder or module".format(p))
 
             paths = new_paths


### PR DESCRIPTION
<!-- Title of the PR must comply with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines. --> 
<!-- Title should include the JIRA ticket in square brackets after the conventional commit prefix. This will automatically link the PR in JIRA. -->
<!-- Example: "fix: [JIRA-123] Allow creation of groups with no members" -->

## Impact and Context
<!-- Brief description of why these changes are necessary. Don't rewrite the entire Jira ticket. -->

#2799 and #2805 didn't include a test that actually deploys the model to verify that the custom module can be imported! This PR does just that.

Also adds more thorough descriptions to the custom modules tests, as requested in [this review comment](https://github.com/VertaAI/modeldb/pull/2799/files#r788281319).

## Risks and Area of Effect
<!--
  Describe both risk (how likely this is to break) and area of effect (how wide potential breakages could reach).
  These should be smaller scale than those documented in a design doc.
-->

Low risk and AoE: A new test oughtn't break anything. This PR does move the `deployable_entity` fixture to the root conftest, but that shouldn't break anything either (widens its accessibility).

## Testing
<!-- Explain how this contribution has been tested, e.g. what tests were added and where they have been run. -->

Locally in Python 2.7 and 3.7, I momentarily reverted the custom modules fix (#2805) then ran this test to verify that it fails.

Then I ran all our custom modules tests in CI (/job/pytest/34) to verify that they pass with the fix.

## How to Revert
<!-- List steps required to revert this change. For example, note if we'd need to revert liquibase changes. -->

Revert this PR.