### PR TITLE
Fix AWS credentials

### DIFF
--- a/backend/src/main/java/ai/verta/modeldb/artifactStore/storageservice/s3/S3Client.java
+++ b/backend/src/main/java/ai/verta/modeldb/artifactStore/storageservice/s3/S3Client.java
@@ -113,14 +113,14 @@ public class S3Client {
     AmazonS3 newS3Client = null;
     try {
       final var stsClientBuilder =
-              AWSSecurityTokenServiceClientBuilder.standard().withRegion(awsRegion);
+          AWSSecurityTokenServiceClientBuilder.standard().withRegion(awsRegion);
       if (!CommonUtils.appendOptionalTelepresencePath("foo").equals("foo")) {
         stsClientBuilder.setCredentials(
-                WebIdentityTokenCredentialsProvider.builder()
-                        .webIdentityTokenFile(
-                                CommonUtils.appendOptionalTelepresencePath(
-                                        System.getenv(ModelDBConstants.AWS_WEB_IDENTITY_TOKEN_FILE)))
-                        .build());
+            WebIdentityTokenCredentialsProvider.builder()
+                .webIdentityTokenFile(
+                    CommonUtils.appendOptionalTelepresencePath(
+                        System.getenv(ModelDBConstants.AWS_WEB_IDENTITY_TOKEN_FILE)))
+                .build());
       }
       stsClient = stsClientBuilder.build();
 

--- a/backend/src/main/java/ai/verta/modeldb/artifactStore/storageservice/s3/S3Client.java
+++ b/backend/src/main/java/ai/verta/modeldb/artifactStore/storageservice/s3/S3Client.java
@@ -112,7 +112,17 @@ public class S3Client {
     AWSSecurityTokenService stsClient = null;
     AmazonS3 newS3Client = null;
     try {
-      stsClient = AWSSecurityTokenServiceClientBuilder.standard().withRegion(awsRegion).build();
+      final var stsClientBuilder =
+              AWSSecurityTokenServiceClientBuilder.standard().withRegion(awsRegion);
+      if (!CommonUtils.appendOptionalTelepresencePath("foo").equals("foo")) {
+        stsClientBuilder.setCredentials(
+                WebIdentityTokenCredentialsProvider.builder()
+                        .webIdentityTokenFile(
+                                CommonUtils.appendOptionalTelepresencePath(
+                                        System.getenv(ModelDBConstants.AWS_WEB_IDENTITY_TOKEN_FILE)))
+                        .build());
+      }
+      stsClient = stsClientBuilder.build();
 
       String roleArn = System.getenv(ModelDBConstants.AWS_ROLE_ARN);
 


### PR DESCRIPTION
Modeldb fails to come up when using Telepresence with this error:
```
com.amazonaws.SdkClientException: Unable to load AWS credentials from any provider in the chain: 
[EnvironmentVariableCredentialsProvider: Unable to load AWS credentials from environment variables (AWS_ACCESS_KEY_ID (or AWS_ACCESS_KEY) and AWS_SECRET_KEY (or AWS_SECRET_ACCESS_KEY)), 
SystemPropertiesCredentialsProvider: Unable to load AWS credentials from Java system properties (aws.accessKeyId and aws.secretKey), 
WebIdentityTokenCredentialsProvider: Unable to locate specified web identity token file: /var/run/secrets/eks.amazonaws.com/serviceaccount/token, 
com.amazonaws.auth.profile.ProfileCredentialsProvider@53dad875: Unable to load credentials into profile [default]: AWS Access Key ID is not specified., 
com.amazonaws.auth.EC2ContainerCredentialsProviderWrapper@2a32fb6: Failed to connect to service endpoint: ]
```
This fix duplicates the fix in Registry: https://github.com/VertaAI/registry/pull/1003