### PR TITLE
fix: [VUMM-194] Don't log database parameters

### DIFF
--- a/backend/common/src/main/java/ai/verta/modeldb/common/futures/FutureJdbi.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/futures/FutureJdbi.java
@@ -6,6 +6,7 @@ import java.util.concurrent.Executor;
 import org.jdbi.v3.core.HandleCallback;
 import org.jdbi.v3.core.HandleConsumer;
 import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.statement.StatementExceptions;
 import org.jdbi.v3.core.transaction.TransactionIsolationLevel;
 
 public class FutureJdbi {
@@ -15,6 +16,8 @@ public class FutureJdbi {
   public FutureJdbi(Jdbi jdbi, Executor executor) {
     this.executor = executor;
     this.jdbi = jdbi;
+      // Ensure that we do not log any sensitive/private data when exceptions are logged
+      this.jdbi.getConfig(StatementExceptions.class).setMessageRendering(StatementExceptions.MessageRendering.NONE);
   }
 
   @FunctionalInterface

--- a/backend/common/src/main/java/ai/verta/modeldb/common/futures/FutureJdbi.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/futures/FutureJdbi.java
@@ -16,8 +16,10 @@ public class FutureJdbi {
   public FutureJdbi(Jdbi jdbi, Executor executor) {
     this.executor = executor;
     this.jdbi = jdbi;
-      // Ensure that we do not log any sensitive/private data when exceptions are logged
-      this.jdbi.getConfig(StatementExceptions.class).setMessageRendering(StatementExceptions.MessageRendering.NONE);
+    // Ensure that we do not log any sensitive/private data when exceptions are logged
+    this.jdbi
+        .getConfig(StatementExceptions.class)
+        .setMessageRendering(StatementExceptions.MessageRendering.NONE);
   }
 
   @FunctionalInterface

--- a/backend/src/main/java/ai/verta/modeldb/artifactStore/storageservice/s3/S3Client.java
+++ b/backend/src/main/java/ai/verta/modeldb/artifactStore/storageservice/s3/S3Client.java
@@ -113,14 +113,14 @@ public class S3Client {
     AmazonS3 newS3Client = null;
     try {
       final var stsClientBuilder =
-              AWSSecurityTokenServiceClientBuilder.standard().withRegion(awsRegion);
+          AWSSecurityTokenServiceClientBuilder.standard().withRegion(awsRegion);
       if (!CommonUtils.appendOptionalTelepresencePath("foo").equals("foo")) {
         stsClientBuilder.setCredentials(
-                WebIdentityTokenCredentialsProvider.builder()
-                        .webIdentityTokenFile(
-                                CommonUtils.appendOptionalTelepresencePath(
-                                        System.getenv(ModelDBConstants.AWS_WEB_IDENTITY_TOKEN_FILE)))
-                        .build());
+            WebIdentityTokenCredentialsProvider.builder()
+                .webIdentityTokenFile(
+                    CommonUtils.appendOptionalTelepresencePath(
+                        System.getenv(ModelDBConstants.AWS_WEB_IDENTITY_TOKEN_FILE)))
+                .build());
       }
       stsClient = stsClientBuilder.build();
 

--- a/backend/src/main/java/ai/verta/modeldb/artifactStore/storageservice/s3/S3Client.java
+++ b/backend/src/main/java/ai/verta/modeldb/artifactStore/storageservice/s3/S3Client.java
@@ -112,7 +112,17 @@ public class S3Client {
     AWSSecurityTokenService stsClient = null;
     AmazonS3 newS3Client = null;
     try {
-      stsClient = AWSSecurityTokenServiceClientBuilder.standard().withRegion(awsRegion).build();
+      final var stsClientBuilder =
+              AWSSecurityTokenServiceClientBuilder.standard().withRegion(awsRegion);
+      if (!CommonUtils.appendOptionalTelepresencePath("foo").equals("foo")) {
+        stsClientBuilder.setCredentials(
+                WebIdentityTokenCredentialsProvider.builder()
+                        .webIdentityTokenFile(
+                                CommonUtils.appendOptionalTelepresencePath(
+                                        System.getenv(ModelDBConstants.AWS_WEB_IDENTITY_TOKEN_FILE)))
+                        .build());
+      }
+      stsClient = stsClientBuilder.build();
 
       String roleArn = System.getenv(ModelDBConstants.AWS_ROLE_ARN);
 


### PR DESCRIPTION

## Impact and Context
SQL errors should not expose sensitive data in the logs

## Testing

To test this I did the following:
Added code line at line 128 of `TagsHandlerBase`:
```java
    for (final var tag : tagsSet) {
      batch
          .bind("tag", tag)
          .bind(ENTITY_ID_QUERY_PARAM, entityId + "0123456789".repeat(100)) // <-- The repeated string at the end ensures an error
          .bind(ENTITY_NAME_QUERY_PARAM, entityName)
          .add();
    }
```
2) Attempt to add tag to a project
