### PR TITLE
fix: deployable_entity.test_artifacts.TestModels.test_keras

### DIFF
--- a/client/verta/verta/_internal_utils/_artifact_utils.py
+++ b/client/verta/verta/_internal_utils/_artifact_utils.py
@@ -329,7 +329,7 @@ def serialize_model(model):
             model_type = "xgboost"
             bytestream, method = ensure_bytestream(model)
             break
-        elif module_name.startswith("tensorflow.python.keras"):
+        elif module_name.startswith("tensorflow.python.keras") or module_name.startswith("keras"):
             model_type = "tensorflow"
             tempf = tempfile.NamedTemporaryFile()
             try:


### PR DESCRIPTION
<!-- Title of the PR must comply with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines. --> 
<!-- Title should include the JIRA ticket in square brackets after the conventional commit prefix. This will automatically link the PR in JIRA. -->
<!-- Example: "fix: [JIRA-123] Allow creation of groups with no members" -->

## Impact and Context
<!-- Brief description of why these changes are necessary. Don't rewrite the entire Jira ticket. -->

Fixes [VR-13463]

## Risks and Area of Effect
<!--
  Describe both risk (how likely this is to break) and area of effect (how wide potential breakages could reach).
  These should be smaller scale than those documented in a design doc.
-->

## Testing
<!-- Explain how this contribution has been tested, e.g. what tests were added and where they have been run. -->

Test now passes, except in the Python 3.5 pipeline where `gcc` is completely borked.

- https://jenkins.dev.verta.ai/job/client/job/python/job/pytest/48/console
- https://jenkins.dev.verta.ai/job/client/job/python/job/pytest-3.8/47/console

## How to Revert
<!-- List steps required to revert this change. For example, note if we'd need to revert liquibase changes. -->


[VR-13463]: https://vertaai.atlassian.net/browse/VR-13463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ