### PR TITLE
Revert "[VUMM-214] Modifed logic for untrusted artifacts"

### DIFF
--- a/backend/common/src/main/java/ai/verta/modeldb/common/config/NFSConfig.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/config/NFSConfig.java
@@ -5,7 +5,6 @@ public class NFSConfig {
   private String nfsRootPath;
   private String nfsServerHost = "";
   private NFSEndpointConfig artifactEndpoint;
-  private String nfsPathPrefix;
 
   public void Validate(String base) throws InvalidConfigException {
     if (nfsRootPath == null || nfsRootPath.isEmpty())
@@ -17,11 +16,7 @@ public class NFSConfig {
   }
 
   public String storeTypePathPrefix() {
-    var pathPrefix = String.format("nfs://%s/", nfsRootPath);
-    if (nfsPathPrefix != null && !nfsPathPrefix.isEmpty()) {
-      pathPrefix += nfsPathPrefix + "/";
-    }
-    return pathPrefix;
+    return String.format("nfs://%s/", nfsRootPath);
   }
 
   public String getNfsRootPath() {

--- a/backend/common/src/main/java/ai/verta/modeldb/common/config/S3Config.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/config/S3Config.java
@@ -3,7 +3,6 @@ package ai.verta.modeldb.common.config;
 @SuppressWarnings({"squid:S100"})
 public class S3Config {
   private String cloudBucketName;
-  private String cloudBucketPrefix;
   private String cloudAccessKey;
   private String cloudSecretKey;
   private String minioEndpoint;
@@ -16,11 +15,7 @@ public class S3Config {
   }
 
   public String storeTypePathPrefix() {
-    var pathPrefix = String.format("s3://%s/", cloudBucketName);
-    if (cloudBucketPrefix != null && !cloudBucketPrefix.isEmpty()) {
-      pathPrefix += cloudBucketPrefix + "/";
-    }
-    return pathPrefix;
+    return String.format("s3://%s/", cloudBucketName);
   }
 
   public String getCloudBucketName() {

--- a/backend/config.example.yaml
+++ b/backend/config.example.yaml
@@ -26,7 +26,6 @@ artifactStoreConfig:
     cloudAccessKey: #for s3 aws account access-key
     cloudSecretKey: #for s3 aws account secret-key
     cloudBucketName: # if nfs then root dir. Note: bucket needs to exist already
-    cloudBucketPrefix: # optional
     aws_region: us-east-1
     s3presignedURLEnabled: false
     minioEndpoint:
@@ -34,7 +33,6 @@ artifactStoreConfig:
     nfsServerHost: localhost #IF 'artifactStoreServerHost' found then this value will be ignore
     nfsUrlProtocol: https #IF 'artifactStoreUrlProtocol' found then this value will be ignore
     nfsRootPath:
-    nfsPathPrefix: # optional
     artifactEndpoint: #IF 'artifactEndpoint' found with parallel to 'artifactStoreType' then this value will be ignore
       getArtifact: "/v1/artifact1/getArtifact"
       storeArtifact: "/v1/artifact/storeArtifact"

--- a/backend/src/main/java/ai/verta/modeldb/entities/ArtifactEntity.java
+++ b/backend/src/main/java/ai/verta/modeldb/entities/ArtifactEntity.java
@@ -21,11 +21,14 @@ public class ArtifactEntity implements Serializable {
 
   public ArtifactEntity() {}
 
-  public ArtifactEntity(
-      Object entity, String fieldType, Artifact artifact, String entityName, String entityId) {
+  public ArtifactEntity(Object entity, String fieldType, Artifact artifact) {
     var app = App.getInstance();
     var artifactStoreConfig = app.mdbConfig.artifactStoreConfig;
     setKey(artifact.getKey());
+    setPath(artifact.getPath());
+    if (!artifact.getPathOnly()) {
+      setStore_type_path(artifactStoreConfig.storeTypePathPrefix() + artifact.getPath());
+    }
     setArtifact_type(artifact.getArtifactTypeValue());
     setPath_only(artifact.getPathOnly());
     setLinked_artifact_id(artifact.getLinkedArtifactId());
@@ -51,19 +54,6 @@ public class ArtifactEntity implements Serializable {
     var uploadCompleted = !artifactStoreConfig.getArtifactStoreType().equals(CommonConstants.S3);
     if (artifact.getUploadCompleted()) {
       uploadCompleted = true;
-    }
-
-    var path =
-        artifactStoreConfig.storeTypePathPrefix()
-            + entityName
-            + "/"
-            + entityId
-            + "/"
-            + artifact.getKey();
-
-    setPath(path);
-    if (!artifact.getPathOnly()) {
-      setStore_type_path(path);
     }
     setUploadCompleted(uploadCompleted);
   }

--- a/backend/src/main/java/ai/verta/modeldb/entities/CodeVersionEntity.java
+++ b/backend/src/main/java/ai/verta/modeldb/entities/CodeVersionEntity.java
@@ -4,7 +4,6 @@ import ai.verta.common.CodeVersion;
 import ai.verta.modeldb.ModelDBConstants;
 import ai.verta.modeldb.utils.RdbmsUtils;
 import java.io.Serializable;
-import java.util.UUID;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -31,11 +30,7 @@ public class CodeVersionEntity implements Serializable {
     } else if (codeVersion.hasCodeArchive()) {
       setCode_archive(
           RdbmsUtils.generateArtifactEntity(
-              this,
-              ModelDBConstants.CODE_ARCHIVE,
-              codeVersion.getCodeArchive(),
-              CodeVersionEntity.class.getSimpleName(),
-              "fake-" + UUID.randomUUID().toString()));
+              this, ModelDBConstants.CODE_ARCHIVE, codeVersion.getCodeArchive()));
     }
     this.field_type = fieldType;
   }

--- a/backend/src/main/java/ai/verta/modeldb/entities/ExperimentEntity.java
+++ b/backend/src/main/java/ai/verta/modeldb/entities/ExperimentEntity.java
@@ -40,11 +40,7 @@ public class ExperimentEntity implements Serializable {
     setTags(RdbmsUtils.convertTagListFromTagMappingList(this, experiment.getTagsList()));
     setArtifactMapping(
         RdbmsUtils.convertArtifactsFromArtifactEntityList(
-            this,
-            ModelDBConstants.ARTIFACTS,
-            experiment.getArtifactsList(),
-            ExperimentEntity.class.getSimpleName(),
-            experiment.getId()));
+            this, ModelDBConstants.ARTIFACTS, experiment.getArtifactsList()));
     setOwner(experiment.getOwner());
     if (experiment.getCodeVersionSnapshot().hasCodeArchive()
         || experiment.getCodeVersionSnapshot().hasGitSnapshot()) {

--- a/backend/src/main/java/ai/verta/modeldb/entities/ExperimentRunEntity.java
+++ b/backend/src/main/java/ai/verta/modeldb/entities/ExperimentRunEntity.java
@@ -58,18 +58,10 @@ public class ExperimentRunEntity implements Serializable {
             this, ModelDBConstants.HYPERPARAMETERS, experimentRun.getHyperparametersList()));
     setArtifactMapping(
         RdbmsUtils.convertArtifactsFromArtifactEntityList(
-            this,
-            ModelDBConstants.ARTIFACTS,
-            experimentRun.getArtifactsList(),
-            ExperimentRunEntity.class.getSimpleName(),
-            experimentRun.getId()));
+            this, ModelDBConstants.ARTIFACTS, experimentRun.getArtifactsList()));
     setArtifactMapping(
         RdbmsUtils.convertArtifactsFromArtifactEntityList(
-            this,
-            ModelDBConstants.DATASETS,
-            experimentRun.getDatasetsList(),
-            ExperimentRunEntity.class.getSimpleName(),
-            experimentRun.getId()));
+            this, ModelDBConstants.DATASETS, experimentRun.getDatasetsList()));
     setKeyValueMapping(
         RdbmsUtils.convertKeyValuesFromKeyValueEntityList(
             this, ModelDBConstants.METRICS, experimentRun.getMetricsList()));

--- a/backend/src/main/java/ai/verta/modeldb/entities/ObservationEntity.java
+++ b/backend/src/main/java/ai/verta/modeldb/entities/ObservationEntity.java
@@ -5,7 +5,6 @@ import ai.verta.modeldb.Observation;
 import ai.verta.modeldb.utils.RdbmsUtils;
 import com.google.protobuf.Value;
 import java.io.Serializable;
-import java.util.UUID;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -38,11 +37,7 @@ public class ObservationEntity implements Serializable {
     if (observation.getArtifact() != null && !observation.getArtifact().getKey().isEmpty()) {
       setArtifactMapping(
           RdbmsUtils.generateArtifactEntity(
-              this,
-              ModelDBConstants.ARTIFACTS,
-              observation.getArtifact(),
-              ObservationEntity.class.getSimpleName(),
-              "fake-" + UUID.randomUUID().toString()));
+              this, ModelDBConstants.ARTIFACTS, observation.getArtifact()));
     }
 
     if (entity instanceof ProjectEntity) {

--- a/backend/src/main/java/ai/verta/modeldb/entities/ProjectEntity.java
+++ b/backend/src/main/java/ai/verta/modeldb/entities/ProjectEntity.java
@@ -38,11 +38,7 @@ public class ProjectEntity implements Serializable {
     setTags(RdbmsUtils.convertTagListFromTagMappingList(this, project.getTagsList()));
     setArtifactMapping(
         RdbmsUtils.convertArtifactsFromArtifactEntityList(
-            this,
-            ModelDBConstants.ARTIFACTS,
-            project.getArtifactsList(),
-            ProjectEntity.class.getSimpleName(),
-            project.getId()));
+            this, ModelDBConstants.ARTIFACTS, project.getArtifactsList()));
     setOwner(project.getOwner());
     setReadme_text(project.getReadmeText());
     if (project.getCodeVersionSnapshot().hasCodeArchive()

--- a/backend/src/main/java/ai/verta/modeldb/experimentRun/ExperimentRunDAORdbImpl.java
+++ b/backend/src/main/java/ai/verta/modeldb/experimentRun/ExperimentRunDAORdbImpl.java
@@ -924,11 +924,7 @@ public class ExperimentRunDAORdbImpl implements ExperimentRunDAO {
 
       List<ArtifactEntity> newDatasetList =
           RdbmsUtils.convertArtifactsFromArtifactEntityList(
-              experimentRunEntityObj,
-              ModelDBConstants.DATASETS,
-              newDatasets,
-              ExperimentRunEntity.class.getSimpleName(),
-              experimentRunEntityObj.getId());
+              experimentRunEntityObj, ModelDBConstants.DATASETS, newDatasets);
       experimentRunEntityObj.setArtifactMapping(newDatasetList);
       long currentTimestamp = Calendar.getInstance().getTimeInMillis();
       experimentRunEntityObj.setDate_updated(currentTimestamp);
@@ -967,11 +963,7 @@ public class ExperimentRunDAORdbImpl implements ExperimentRunDAO {
 
       List<ArtifactEntity> newArtifactList =
           RdbmsUtils.convertArtifactsFromArtifactEntityList(
-              experimentRunEntityObj,
-              ModelDBConstants.ARTIFACTS,
-              newArtifacts,
-              ExperimentRunEntity.class.getSimpleName(),
-              experimentRunEntityObj.getId());
+              experimentRunEntityObj, ModelDBConstants.ARTIFACTS, newArtifacts);
       experimentRunEntityObj.setArtifactMapping(newArtifactList);
       long currentTimestamp = Calendar.getInstance().getTimeInMillis();
       experimentRunEntityObj.setDate_updated(currentTimestamp);

--- a/backend/src/main/java/ai/verta/modeldb/experimentRun/subtypes/ArtifactHandlerBase.java
+++ b/backend/src/main/java/ai/verta/modeldb/experimentRun/subtypes/ArtifactHandlerBase.java
@@ -26,6 +26,7 @@ public abstract class ArtifactHandlerBase extends CommonArtifactHandler<String> 
 
   private static final String FIELD_TYPE_QUERY_PARAM = "field_type";
   private static final String ENTITY_NAME_QUERY_PARAM = "entity_name";
+  protected final String entityName;
   protected final String fieldType;
   protected String entityIdReferenceColumn;
 
@@ -35,8 +36,9 @@ public abstract class ArtifactHandlerBase extends CommonArtifactHandler<String> 
       String fieldType,
       String entityName,
       ArtifactStoreConfig artifactStoreConfig) {
-    super(executor, jdbi, artifactStoreConfig, entityName);
+    super(executor, jdbi, artifactStoreConfig);
     this.fieldType = fieldType;
+    this.entityName = entityName;
 
     switch (entityName) {
       case "ProjectEntity":

--- a/backend/src/main/java/ai/verta/modeldb/utils/RdbmsUtils.java
+++ b/backend/src/main/java/ai/verta/modeldb/utils/RdbmsUtils.java
@@ -172,21 +172,16 @@ public class RdbmsUtils {
   }
 
   public static ArtifactEntity generateArtifactEntity(
-      Object entity, String fieldType, Artifact artifact, String entityName, String entityId) {
-    return new ArtifactEntity(entity, fieldType, artifact, entityName, entityId);
+      Object entity, String fieldType, Artifact artifact) {
+    return new ArtifactEntity(entity, fieldType, artifact);
   }
 
   public static List<ArtifactEntity> convertArtifactsFromArtifactEntityList(
-      Object entity,
-      String fieldType,
-      List<Artifact> artifactList,
-      String entityName,
-      String entityId) {
+      Object entity, String fieldType, List<Artifact> artifactList) {
     List<ArtifactEntity> artifactEntityList = new ArrayList<>();
     if (artifactList != null) {
       return artifactList.stream()
-          .map(
-              artifact -> generateArtifactEntity(entity, fieldType, artifact, entityName, entityId))
+          .map(artifact -> generateArtifactEntity(entity, fieldType, artifact))
           .collect(Collectors.toList());
     }
     return artifactEntityList;

--- a/backend/src/test/java/ai/verta/modeldb/ExperimentRunTest.java
+++ b/backend/src/test/java/ai/verta/modeldb/ExperimentRunTest.java
@@ -48,7 +48,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.After;
@@ -593,8 +592,8 @@ public class ExperimentRunTest extends TestsInit {
       for (ExperimentRun experimentRun1 : experimentRunResponse.getExperimentRunsList()) {
         assertEquals(
             "ExperimentRun not match with expected experimentRun",
-            experimentRunMap.get(experimentRun1.getId()).getId(),
-            experimentRun1.getId());
+            experimentRunMap.get(experimentRun1.getId()),
+            experimentRun1);
       }
     } else {
       LOGGER.warn("More ExperimentRun not found in database");
@@ -635,8 +634,8 @@ public class ExperimentRunTest extends TestsInit {
         for (ExperimentRun experimentRun : experimentRunResponse.getExperimentRunsList()) {
           assertEquals(
               "ExperimentRun not match with expected experimentRun",
-              experimentRunMap.get(experimentRun.getId()).getId(),
-              experimentRun.getId());
+              experimentRunMap.get(experimentRun.getId()),
+              experimentRun);
         }
       } else {
         if (isExpectedResultFound) {
@@ -670,8 +669,8 @@ public class ExperimentRunTest extends TestsInit {
         experimentRunResponse.getExperimentRunsCount());
     assertEquals(
         "ExperimentRun not match with expected experimentRun",
-        experimentRun2.getId(),
-        experimentRunResponse.getExperimentRuns(0).getId());
+        experimentRun2,
+        experimentRunResponse.getExperimentRuns(0));
 
     getExperiment =
         GetExperimentRunsInProject.newBuilder()
@@ -689,8 +688,8 @@ public class ExperimentRunTest extends TestsInit {
         experimentRunResponse.getExperimentRunsCount());
     assertEquals(
         "ExperimentRun not match with expected experimentRun",
-        experimentRun.getId(),
-        experimentRunResponse.getExperimentRuns(0).getId());
+        experimentRun,
+        experimentRunResponse.getExperimentRuns(0));
 
     getExperiment =
         GetExperimentRunsInProject.newBuilder()
@@ -756,8 +755,8 @@ public class ExperimentRunTest extends TestsInit {
       for (ExperimentRun experimentRun1 : experimentRunResponse.getExperimentRunsList()) {
         assertEquals(
             "ExperimentRun not match with expected experimentRun",
-            experimentRunMap.get(experimentRun1.getId()).getId(),
-            experimentRun1.getId());
+            experimentRunMap.get(experimentRun1.getId()),
+            experimentRun1);
       }
     } else {
       LOGGER.warn("More ExperimentRun not found in database");
@@ -796,8 +795,8 @@ public class ExperimentRunTest extends TestsInit {
         for (ExperimentRun experimentRun : experimentRunResponse.getExperimentRunsList()) {
           assertEquals(
               "ExperimentRun not match with expected experimentRun",
-              experimentRunMap.get(experimentRun.getId()).getId(),
-              experimentRun.getId());
+              experimentRunMap.get(experimentRun.getId()),
+              experimentRun);
         }
       } else {
         if (isExpectedResultFound) {
@@ -831,8 +830,8 @@ public class ExperimentRunTest extends TestsInit {
         experimentRunResponse.getExperimentRunsCount());
     assertEquals(
         "ExperimentRun not match with expected experimentRun",
-        experimentRun2.getId(),
-        experimentRunResponse.getExperimentRuns(0).getId());
+        experimentRun2,
+        experimentRunResponse.getExperimentRuns(0));
 
     getExperimentRunsInExperiment =
         GetExperimentRunsInExperiment.newBuilder()
@@ -851,8 +850,8 @@ public class ExperimentRunTest extends TestsInit {
         experimentRunResponse.getExperimentRunsCount());
     assertEquals(
         "ExperimentRun not match with expected experimentRun",
-        experimentRun.getId(),
-        experimentRunResponse.getExperimentRuns(0).getId());
+        experimentRun,
+        experimentRunResponse.getExperimentRuns(0));
     assertEquals(
         "Total records count not matched with expected records count",
         2,
@@ -922,8 +921,8 @@ public class ExperimentRunTest extends TestsInit {
     LOGGER.info("getExperimentRunById Response : \n" + response.getExperimentRun());
     assertEquals(
         "ExperimentRun not match with expected experimentRun",
-        experimentRun.getId(),
-        response.getExperimentRun().getId());
+        experimentRun,
+        response.getExperimentRun());
 
     LOGGER.info("Get ExperimentRunById test stop................................");
   }
@@ -2774,8 +2773,8 @@ public class ExperimentRunTest extends TestsInit {
     LOGGER.info("GetDatasets Response : " + response.getDatasetsCount());
     assertEquals(
         "Experiment datasets not match with expected datasets",
-        experimentRun.getDatasetsList().stream().map(Artifact::getKey).collect(Collectors.toList()),
-        response.getDatasetsList().stream().map(Artifact::getKey).collect(Collectors.toList()));
+        experimentRun.getDatasetsList(),
+        response.getDatasetsList());
 
     LOGGER.info("Get Datasets from ExperimentRun tags test stop................................");
   }
@@ -5012,7 +5011,7 @@ public class ExperimentRunTest extends TestsInit {
     GetExperimentRunById.Response response =
         experimentRunServiceStub.getExperimentRunById(getExperimentRunById);
     CodeVersion codeVersion = response.getExperimentRun().getCodeVersionSnapshot();
-    assertNotEquals(
+    assertEquals(
         "ExperimentRun codeVersion not match with expected ExperimentRun codeVersion",
         logExperimentRunCodeVersionRequest.getCodeVersion(),
         codeVersion);
@@ -5049,7 +5048,7 @@ public class ExperimentRunTest extends TestsInit {
 
     response = experimentRunServiceStub.getExperimentRunById(getExperimentRunById);
     codeVersion = response.getExperimentRun().getCodeVersionSnapshot();
-    assertNotEquals(
+    assertEquals(
         "ExperimentRun codeVersion not match with expected ExperimentRun codeVersion",
         logExperimentRunCodeVersionRequest.getCodeVersion(),
         codeVersion);
@@ -5113,7 +5112,7 @@ public class ExperimentRunTest extends TestsInit {
     GetExperimentRunById.Response response =
         experimentRunServiceStub.getExperimentRunById(getExperimentRunById);
     CodeVersion codeVersion = response.getExperimentRun().getCodeVersionSnapshot();
-    assertNotEquals(
+    assertEquals(
         "ExperimentRun codeVersion not match with expected ExperimentRun codeVersion",
         logExperimentRunCodeVersionRequest.getCodeVersion(),
         codeVersion);
@@ -7696,8 +7695,8 @@ public class ExperimentRunTest extends TestsInit {
           getExperimentRunByIdResponse.getExperimentRun().getDatasetsList()) {
         assertEquals(
             "Experiment datasets not match with expected datasets",
-            artifactMap.get(datasetArtifact.getKey()).getKey(),
-            datasetArtifact.getKey());
+            artifactMap.get(datasetArtifact.getKey()),
+            datasetArtifact);
       }
       experimentRun11 = getExperimentRunByIdResponse.getExperimentRun();
 
@@ -8104,8 +8103,8 @@ public class ExperimentRunTest extends TestsInit {
               .build();
       assertEquals(
           "Clone experimentRun can not match with expected experimentRun",
-          srcExperimentRun.getId(),
-          cloneResponse.getRun().getId());
+          srcExperimentRun,
+          cloneResponse.getRun());
 
       cloneExperimentRun =
           CloneExperimentRun.newBuilder()
@@ -8132,8 +8131,8 @@ public class ExperimentRunTest extends TestsInit {
               .build();
       assertEquals(
           "Clone experimentRun can not match with expected experimentRun",
-          srcExperimentRun.getId(),
-          cloneResponse.getRun().getId());
+          srcExperimentRun,
+          cloneResponse.getRun());
 
       try {
         cloneExperimentRun =

--- a/backend/src/test/java/ai/verta/modeldb/ExperimentTest.java
+++ b/backend/src/test/java/ai/verta/modeldb/ExperimentTest.java
@@ -1437,7 +1437,7 @@ public class ExperimentTest extends TestsInit {
         experimentServiceStub.logExperimentCodeVersion(logExperimentCodeVersionRequest);
     CodeVersion codeVersion =
         logExperimentCodeVersionResponse.getExperiment().getCodeVersionSnapshot();
-    assertNotEquals(
+    assertEquals(
         "Experiment codeVersion not match with expected experiment codeVersion",
         logExperimentCodeVersionRequest.getCodeVersion(),
         codeVersion);
@@ -1494,8 +1494,7 @@ public class ExperimentTest extends TestsInit {
         experimentServiceStub.logExperimentCodeVersion(logExperimentCodeVersionRequest);
     CodeVersion codeVersion =
         logExperimentCodeVersionResponse.getExperiment().getCodeVersionSnapshot();
-
-    assertNotEquals(
+    assertEquals(
         "Experiment codeVersion not match with expected experiment codeVersion",
         logExperimentCodeVersionRequest.getCodeVersion(),
         codeVersion);

--- a/backend/src/test/java/ai/verta/modeldb/ProjectTest.java
+++ b/backend/src/test/java/ai/verta/modeldb/ProjectTest.java
@@ -1645,8 +1645,8 @@ public class ProjectTest extends TestsInit {
 
       assertEquals(
           "ExperimentRun does not match with expected experimentRun",
-          lastModifiedExperimentRun.getId(),
-          experimentRun.getId());
+          lastModifiedExperimentRun,
+          experimentRun);
 
       assertTrue(
           "last modified experimentRun summary does not match",
@@ -2565,11 +2565,10 @@ public class ProjectTest extends TestsInit {
       LogProjectCodeVersion.Response logProjectCodeVersionResponse =
           projectServiceStub.logProjectCodeVersion(logProjectCodeVersionRequest);
       CodeVersion codeVersion = logProjectCodeVersionResponse.getProject().getCodeVersionSnapshot();
-      assertNotEquals(
+      assertEquals(
           "Project codeVersion not match with expected project codeVersion",
           logProjectCodeVersionRequest.getCodeVersion(),
           codeVersion);
-
       project = logProjectCodeVersionResponse.getProject();
 
       try {
@@ -2633,11 +2632,10 @@ public class ProjectTest extends TestsInit {
     LogProjectCodeVersion.Response logProjectCodeVersionResponse =
         projectServiceStub.logProjectCodeVersion(logProjectCodeVersionRequest);
     project = logProjectCodeVersionResponse.getProject();
-    assertNotEquals(
+    assertEquals(
         "Project codeVersion not match with expected project codeVersion",
         logProjectCodeVersionRequest.getCodeVersion(),
         project.getCodeVersionSnapshot());
-
     project = logProjectCodeVersionResponse.getProject();
     projectMap.put(project.getId(), project);
 


### PR DESCRIPTION
Reverts VertaAI/modeldb#2862

The change to `Artifact.path` breaks artifact downloads in deployment-api.
https://vertaai.slack.com/archives/CJ2MM54Q3/p1646686496240899?thread_ts=1646678523.290519&cid=CJ2MM54Q3