### PR TITLE
fix: roll back to liquibase v4.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <log4j.version>2.17.1</log4j.version>
         <grpc.version>1.41.2</grpc.version>
         <postgres.version>42.2.25</postgres.version>
-        <liquibase.version>4.8.0</liquibase.version>
+        <liquibase.version>4.6.0</liquibase.version>
         <prometheus.version>0.15.0</prometheus.version>
         <protobuf.version>3.19.2</protobuf.version>
         <aws.version>1.12.174</aws.version>


### PR DESCRIPTION
Liquibase 4.7.0 introduced an issue where the check for FK existence stopped working.
https://github.com/liquibase/liquibase/issues/2389

We might be able to work around this, but we first need to get back to a non-broken state.

This is the most direct path to non-broken while we figure out a path forward.

<!-- Title of the PR must comply with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines. --> 
<!-- Title should include the JIRA ticket in square brackets after the conventional commit prefix. This will automatically link the PR in JIRA. -->
<!-- Example: "fix: [JIRA-123] Allow creation of groups with no members" -->

## Impact and Context
<!-- Brief description of why these changes are necessary. Don't rewrite the entire Jira ticket. -->

## Risks and Area of Effect
<!--
  Describe both risk (how likely this is to break) and area of effect (how wide potential breakages could reach).
  These should be smaller scale than those documented in a design doc.
-->

## Testing
<!-- Explain how this contribution has been tested, e.g. what tests were added and where they have been run. -->

## How to Revert
<!-- List steps required to revert this change. For example, note if we'd need to revert liquibase changes. -->
