### PR TITLE
fix: set valid checksum

### DIFF
--- a/backend/src/main/resources/liquibase/create-versioning-tables-changelog.xml
+++ b/backend/src/main/resources/liquibase/create-versioning-tables-changelog.xml
@@ -158,6 +158,7 @@
         </createTable>
     </changeSet>
     <changeSet author="anand" id="create-commit_parent">
+        <validCheckSum>8:7984b0df7fdb4c5b97a1a0b2209eac73</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="commit_parent"/>


### PR DESCRIPTION
<!-- Title of the PR must comply with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines. --> 
<!-- Title should include the JIRA ticket in square brackets after the conventional commit prefix. This will automatically link the PR in JIRA. -->
<!-- Example: "fix: [JIRA-123] Allow creation of groups with no members" -->

## Impact and Context
<!-- Brief description of why these changes are necessary. Don't rewrite the entire Jira ticket. -->

## Risks and Area of Effect
<!--
  Describe both risk (how likely this is to break) and area of effect (how wide potential breakages could reach).
  These should be smaller scale than those documented in a design doc.
-->

## Testing
Created a cluster based on last commit before any liquibase changes (https://github.com/VertaAI/modeldb/commit/2a8b9d5f930c3729ab28c880cb7a603ffaf17ec4). 
Saw working cluster. 
Updated cluster-setup with this branch and applied.  Successful pod update.  Didn't any meaningful output in the logs, but that maybe expected.  All information I have points to this being the correct fix.  

<!-- Explain how this contribution has been tested, e.g. what tests were added and where they have been run. -->

## How to Revert
<!-- List steps required to revert this change. For example, note if we'd need to revert liquibase changes. -->
