### PR TITLE
test: Stop deleting cache dir in tests

### DIFF
--- a/client/verta/tests/deployable_entity/test_deployment.py
+++ b/client/verta/tests/deployable_entity/test_deployment.py
@@ -224,44 +224,38 @@ class TestFetchArtifacts:
         for key, artifact in zip(strs, flat_dicts):
             deployable_entity.log_artifact(key, artifact)
 
-        try:
-            artifacts = deployable_entity.fetch_artifacts(strs)
+        artifacts = deployable_entity.fetch_artifacts(strs)
 
-            assert set(six.viewkeys(artifacts)) == set(strs)
-            assert all(
-                filepath.startswith(_CACHE_DIR)
-                for filepath in six.viewvalues(artifacts)
-            )
+        assert set(six.viewkeys(artifacts)) == set(strs)
+        assert all(
+            filepath.startswith(_CACHE_DIR)
+            for filepath in six.viewvalues(artifacts)
+        )
 
-            for key, filepath in six.viewitems(artifacts):
-                artifact_contents = deployable_entity._get_artifact(key)
-                if type(artifact_contents) is tuple:
-                    # ER returns (contents, path_only)
-                    # TODO: ER & RMV _get_artifact() should return the same thing
-                    artifact_contents, _ = artifact_contents
+        for key, filepath in six.viewitems(artifacts):
+            artifact_contents = deployable_entity._get_artifact(key)
+            if type(artifact_contents) is tuple:
+                # ER returns (contents, path_only)
+                # TODO: ER & RMV _get_artifact() should return the same thing
+                artifact_contents, _ = artifact_contents
 
-                with open(filepath, 'rb') as f:
-                    file_contents = f.read()
+            with open(filepath, 'rb') as f:
+                file_contents = f.read()
 
-                assert file_contents == artifact_contents
-        finally:
-            shutil.rmtree(_CACHE_DIR, ignore_errors=True)
+            assert file_contents == artifact_contents
 
     def test_cached_fetch_artifacts(self, deployable_entity, strs, flat_dicts):
         key = strs[0]
 
         deployable_entity.log_artifact(key, flat_dicts[0])
 
-        try:
-            filepath = deployable_entity.fetch_artifacts([key])[key]
-            last_modified = os.path.getmtime(filepath)
+        filepath = deployable_entity.fetch_artifacts([key])[key]
+        last_modified = os.path.getmtime(filepath)
 
-            time.sleep(3)
-            assert deployable_entity.fetch_artifacts([key])[key] == filepath
+        time.sleep(3)
+        assert deployable_entity.fetch_artifacts([key])[key] == filepath
 
-            assert os.path.getmtime(filepath) == last_modified
-        finally:
-            shutil.rmtree(_CACHE_DIR, ignore_errors=True)
+        assert os.path.getmtime(filepath) == last_modified
 
     def test_fetch_zip(self, deployable_entity, strs, dir_and_files):
         dirpath, filepaths = dir_and_files
@@ -269,21 +263,18 @@ class TestFetchArtifacts:
 
         deployable_entity.log_artifact(key, dirpath)
 
-        try:
-            dirpath = deployable_entity.fetch_artifacts([key])[key]
+        dirpath = deployable_entity.fetch_artifacts([key])[key]
 
-            assert dirpath.startswith(_CACHE_DIR)
+        assert dirpath.startswith(_CACHE_DIR)
 
-            retrieved_filepaths = set()
-            for root, _, files in os.walk(dirpath):
-                for filename in files:
-                    filepath = os.path.join(root, filename)
-                    filepath = os.path.relpath(filepath, dirpath)
-                    retrieved_filepaths.add(filepath)
+        retrieved_filepaths = set()
+        for root, _, files in os.walk(dirpath):
+            for filename in files:
+                filepath = os.path.join(root, filename)
+                filepath = os.path.relpath(filepath, dirpath)
+                retrieved_filepaths.add(filepath)
 
-            assert filepaths == retrieved_filepaths
-        finally:
-            shutil.rmtree(_CACHE_DIR, ignore_errors=True)
+        assert filepaths == retrieved_filepaths
 
     def test_cached_fetch_zip(self, deployable_entity, strs, dir_and_files):
         dirpath, _ = dir_and_files
@@ -291,16 +282,13 @@ class TestFetchArtifacts:
 
         deployable_entity.log_artifact(key, dirpath)
 
-        try:
-            dirpath = deployable_entity.fetch_artifacts([key])[key]
-            last_modified = os.path.getmtime(dirpath)
+        dirpath = deployable_entity.fetch_artifacts([key])[key]
+        last_modified = os.path.getmtime(dirpath)
 
-            time.sleep(3)
-            assert deployable_entity.fetch_artifacts([key])[key] == dirpath
+        time.sleep(3)
+        assert deployable_entity.fetch_artifacts([key])[key] == dirpath
 
-            assert os.path.getmtime(dirpath) == last_modified
-        finally:
-            shutil.rmtree(_CACHE_DIR, ignore_errors=True)
+        assert os.path.getmtime(dirpath) == last_modified
 
     def test_fetch_tgz(self, deployable_entity, strs, dir_and_files):
         dirpath, filepaths = dir_and_files
@@ -316,21 +304,18 @@ class TestFetchArtifacts:
 
             deployable_entity.log_artifact(key, tempf.name)
 
-        try:
-            dirpath = deployable_entity.fetch_artifacts([key])[key]
+        dirpath = deployable_entity.fetch_artifacts([key])[key]
 
-            assert dirpath.startswith(_CACHE_DIR)
+        assert dirpath.startswith(_CACHE_DIR)
 
-            retrieved_filepaths = set()
-            for root, _, files in os.walk(dirpath):
-                for filename in files:
-                    filepath = os.path.join(root, filename)
-                    filepath = os.path.relpath(filepath, dirpath)
-                    retrieved_filepaths.add(filepath)
+        retrieved_filepaths = set()
+        for root, _, files in os.walk(dirpath):
+            for filename in files:
+                filepath = os.path.join(root, filename)
+                filepath = os.path.relpath(filepath, dirpath)
+                retrieved_filepaths.add(filepath)
 
-            assert filepaths == retrieved_filepaths
-        finally:
-            shutil.rmtree(_CACHE_DIR, ignore_errors=True)
+        assert filepaths == retrieved_filepaths
 
     def test_fetch_tar(self, deployable_entity, strs, dir_and_files):
         dirpath, filepaths = dir_and_files
@@ -346,21 +331,18 @@ class TestFetchArtifacts:
 
             deployable_entity.log_artifact(key, tempf.name)
 
-        try:
-            dirpath = deployable_entity.fetch_artifacts([key])[key]
+        dirpath = deployable_entity.fetch_artifacts([key])[key]
 
-            assert dirpath.startswith(_CACHE_DIR)
+        assert dirpath.startswith(_CACHE_DIR)
 
-            retrieved_filepaths = set()
-            for root, _, files in os.walk(dirpath):
-                for filename in files:
-                    filepath = os.path.join(root, filename)
-                    filepath = os.path.relpath(filepath, dirpath)
-                    retrieved_filepaths.add(filepath)
+        retrieved_filepaths = set()
+        for root, _, files in os.walk(dirpath):
+            for filename in files:
+                filepath = os.path.join(root, filename)
+                filepath = os.path.relpath(filepath, dirpath)
+                retrieved_filepaths.add(filepath)
 
-            assert filepaths == retrieved_filepaths
-        finally:
-            shutil.rmtree(_CACHE_DIR, ignore_errors=True)
+        assert filepaths == retrieved_filepaths
 
     def test_fetch_tar_gz(self, deployable_entity, strs, dir_and_files):
         dirpath, filepaths = dir_and_files
@@ -376,21 +358,18 @@ class TestFetchArtifacts:
 
             deployable_entity.log_artifact(key, tempf.name)
 
-        try:
-            dirpath = deployable_entity.fetch_artifacts([key])[key]
+        dirpath = deployable_entity.fetch_artifacts([key])[key]
 
-            assert dirpath.startswith(_CACHE_DIR)
+        assert dirpath.startswith(_CACHE_DIR)
 
-            retrieved_filepaths = set()
-            for root, _, files in os.walk(dirpath):
-                for filename in files:
-                    filepath = os.path.join(root, filename)
-                    filepath = os.path.relpath(filepath, dirpath)
-                    retrieved_filepaths.add(filepath)
+        retrieved_filepaths = set()
+        for root, _, files in os.walk(dirpath):
+            for filename in files:
+                filepath = os.path.join(root, filename)
+                filepath = os.path.relpath(filepath, dirpath)
+                retrieved_filepaths.add(filepath)
 
-            assert filepaths == retrieved_filepaths
-        finally:
-            shutil.rmtree(_CACHE_DIR, ignore_errors=True)
+        assert filepaths == retrieved_filepaths
 
     def test_wrong_type_artifacts_error(self, deployable_entity, all_values):
         # remove lists of strings and empty lists, because they're valid arguments
@@ -539,23 +518,20 @@ class TestDeployability:
         for key, artifact in zip(strs, flat_dicts):
             model_version.log_artifact(key, artifact)
 
-        try:
-            artifacts = model_version.fetch_artifacts(strs)
+        artifacts = model_version.fetch_artifacts(strs)
 
-            assert set(six.viewkeys(artifacts)) == set(strs)
-            assert all(
-                filepath.startswith(_CACHE_DIR)
-                for filepath in six.viewvalues(artifacts)
-            )
+        assert set(six.viewkeys(artifacts)) == set(strs)
+        assert all(
+            filepath.startswith(_CACHE_DIR)
+            for filepath in six.viewvalues(artifacts)
+        )
 
-            for key, filepath in six.viewitems(artifacts):
-                artifact_contents = model_version._get_artifact(key)
-                with open(filepath, "rb") as f:
-                    file_contents = f.read()
+        for key, filepath in six.viewitems(artifacts):
+            artifact_contents = model_version._get_artifact(key)
+            with open(filepath, "rb") as f:
+                file_contents = f.read()
 
-                assert file_contents == artifact_contents
-        finally:
-            shutil.rmtree(_CACHE_DIR, ignore_errors=True)
+            assert file_contents == artifact_contents
 
     @pytest.mark.deployment
     def test_model_artifacts(self, deployable_entity, endpoint, in_tempdir):

--- a/client/verta/tests/test_entities.py
+++ b/client/verta/tests/test_entities.py
@@ -122,16 +122,13 @@ class TestEntities:
             assert not os.path.isfile(filepath)
             assert not entity._get_cached_file(filename)
 
-            try:
-                assert entity._cache_file(filename, contents) == filepath
+            assert entity._cache_file(filename, contents) == filepath
 
-                assert os.path.isfile(filepath)
-                assert entity._get_cached_file(filename)
+            assert os.path.isfile(filepath)
+            assert entity._get_cached_file(filename)
 
-                with open(filepath, 'rb') as f:
-                    assert f.read() == contents
-            finally:
-                shutil.rmtree(_CACHE_DIR, ignore_errors=True)
+            with open(filepath, 'rb') as f:
+                assert f.read() == contents
 
     def test_context(self, client, strs):
         strs = iter(strs)


### PR DESCRIPTION
<!-- Title of the PR must comply with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines. --> 
<!-- Title should include the JIRA ticket in square brackets after the conventional commit prefix. This will automatically link the PR in JIRA. -->
<!-- Example: "fix: [JIRA-123] Allow creation of groups with no members" -->

## Impact and Context
<!-- Brief description of why these changes are necessary. Don't rewrite the entire Jira ticket. -->

When the client downloads artifacts in `fetch_artifacts()`, it caches them in `~/.verta/`. These tests have been clearing that cache directory at the end of their executions, which is causing all sorts of problems when running the tests in parallel.

Clearing the cache is also less necessary now than it used to be, since #2927 means that subsequent tests won't overwrite the files: artifact paths now include their entity IDs.

This PR removes the

```python
finally:
    shutil.rmtree(_CACHE_DIR, ignore_errors=True)
```

## Risks and Area of Effect
<!--
  Describe both risk (how likely this is to break) and area of effect (how wide potential breakages could reach).
  These should be smaller scale than those documented in a design doc.
-->

**Low risk**: The client doesn't provide any automatic cleaning of the cache, so running these tests (similar to running the client itself) would accumulate files on disk. But the Jenkins workers that run these tests don't persist for long so it should be fine, plus `fetch_artifacts()` isn't used all that much in the suite.

**Low AoE**: Only impacts test behavior.

## Testing
<!-- Explain how this contribution has been tested, e.g. what tests were added and where they have been run. -->

**Before**:

```sh
=========================== short test summary info ============================
FAILED deployable_entity/test_deployment.py::TestFetchArtifacts::test_fetch_artifacts[ExperimentRun]
FAILED deployable_entity/test_deployment.py::TestFetchArtifacts::test_cached_fetch_zip[ExperimentRun-foo]
FAILED deployable_entity/test_deployment.py::TestFetchArtifacts::test_cached_fetch_artifacts[ExperimentRun]
FAILED deployable_entity/test_deployment.py::TestFetchArtifacts::test_cached_fetch_artifacts[RegisteredModelVersion]
FAILED deployable_entity/test_deployment.py::TestFetchArtifacts::test_fetch_artifacts[RegisteredModelVersion]
FAILED deployable_entity/test_deployment.py::TestFetchArtifacts::test_cached_fetch_zip[ExperimentRun-foo.bar]
FAILED deployable_entity/test_deployment.py::TestFetchArtifacts::test_cached_fetch_zip[RegisteredModelVersion-foo]
FAILED deployable_entity/test_deployment.py::TestFetchArtifacts::test_cached_fetch_zip[RegisteredModelVersion-foo.bar]
================== 8 failed, 20 passed, 58 warnings in 34.42s ==================
```

**After**:

```sh
======================= 28 passed, 58 warnings in 36.70s =======================
```

## How to Revert
<!-- List steps required to revert this change. For example, note if we'd need to revert liquibase changes. -->

Revert this PR.