### PR TITLE
fix: fix build by reenabling skipTests

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -300,8 +300,6 @@
                     </includes>
                     <!-- Sets the VM argument line used when unit tests are run. -->
                     <argLine>${surefireArgLine}</argLine>
-                    <!-- Skips unit tests if the value of skip.unit.tests property is true -->
-                    <skipTests>${skip.unit.tests}</skipTests>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
<!-- Title of the PR must comply with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines. --> 
<!-- Title should include the JIRA ticket in square brackets after the conventional commit prefix. This will automatically link the PR in JIRA. -->
<!-- Example: "fix: [JIRA-123] Allow creation of groups with no members" -->

## Impact and Context
CI build was setting `-Dmaven.skip.test=true`, which would not only not run tests but would also not even build them. 
It was recently changed to use `-DskipTests`, however this pom.xml strangely overrides that setting. Applying the setting in the pom is unexpected.
This change removes the override returning to the previous state of not running tests in CI.  

## Risks and Area of Effect
Not running unit tests increases risk, but we weren't even compiling tests before.  We should look at enabling unit test execution CI.


## Testing
<!-- Explain how this contribution has been tested, e.g. what tests were added and where they have been run. -->

## How to Revert
<!-- List steps required to revert this change. For example, note if we'd need to revert liquibase changes. -->
