### PR TITLE
fix: [VUMM-268] Upgrade to Liquibase 4.9.1

### DIFF
--- a/backend/src/main/resources/liquibase/create-index-changelog.xml
+++ b/backend/src/main/resources/liquibase/create-index-changelog.xml
@@ -2,7 +2,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-                        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd"
+                        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd"
         logicalFilePath="src/main/resources/liquibase/create-index-changelog.xml">
 
     <changeSet author="anandJ" id="1-create-text-indexes-postgres" failOnError="false">

--- a/backend/src/main/resources/liquibase/create-tables-changelog-1.0.xml
+++ b/backend/src/main/resources/liquibase/create-tables-changelog-1.0.xml
@@ -2,7 +2,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-                        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd"
+                        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd"
         logicalFilePath="src/main/resources/liquibase/create-tables-changelog-1.0.xml">
 
     <changeSet author="anandJ" id="createTable-1" failOnError="false">

--- a/backend/src/main/resources/liquibase/create-versioning-tables-changelog.xml
+++ b/backend/src/main/resources/liquibase/create-versioning-tables-changelog.xml
@@ -2,7 +2,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-                        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd"
+                        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd"
         logicalFilePath="src/main/resources/liquibase/create-tables-changelog-1.0.xml">
     <changeSet author="anand" id="create-commit">
         <preConditions onFail="MARK_RAN">

--- a/backend/src/main/resources/liquibase/create-versioning-tables-changelog2.xml
+++ b/backend/src/main/resources/liquibase/create-versioning-tables-changelog2.xml
@@ -2,7 +2,7 @@
 	xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-                        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd"
+                        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd"
 	logicalFilePath="src/main/resources/liquibase/create-tables-changelog-1.0.xml">
 
 	<changeSet author="raviS" id="create-git_code_blob">

--- a/backend/src/main/resources/liquibase/db-changelog-1.0.xml
+++ b/backend/src/main/resources/liquibase/db-changelog-1.0.xml
@@ -2,7 +2,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-                        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd"
+                        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd"
         logicalFilePath="src/main/resources/liquibase/db-changelog-1.0.xml">
 
     <include file="src/main/resources/liquibase/create-tables-changelog-1.0.xml"/>

--- a/backend/src/main/resources/liquibase/db-changelog-2.0.xml
+++ b/backend/src/main/resources/liquibase/db-changelog-2.0.xml
@@ -2,7 +2,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-                        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd"
+                        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd"
         logicalFilePath="src/main/resources/liquibase/db-changelog-2.0.xml">
 
     <changeSet id="db_version_2.0.pre" author="raviS">

--- a/backend/src/main/resources/liquibase/db-changelog-master.xml
+++ b/backend/src/main/resources/liquibase/db-changelog-master.xml
@@ -1,7 +1,7 @@
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-                        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+                        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd">
 
     <include file="src/main/resources/liquibase/db-changelog-1.0.xml"/>
     <include file="src/main/resources/liquibase/db-changelog-2.0.xml"/>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <log4j.version>2.17.1</log4j.version>
         <grpc.version>1.41.2</grpc.version>
         <postgres.version>42.3.3</postgres.version>
-        <liquibase.version>4.6.0</liquibase.version>
+        <liquibase.version>4.9.1</liquibase.version>
         <prometheus.version>0.15.0</prometheus.version>
         <protobuf.version>3.19.2</protobuf.version>
         <aws.version>1.12.187</aws.version>


### PR DESCRIPTION
<!-- Title of the PR must comply with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines. --> 
<!-- Title should include the JIRA ticket in square brackets after the conventional commit prefix. This will automatically link the PR in JIRA. -->
<!-- Example: "fix: [JIRA-123] Allow creation of groups with no members" -->

## Impact and Context
Fixes security vulnerability in Liquibase. 

## Risks and Area of Effect
Previous attempt to upgrade encountered issues due to a bug in the newer version of Liquibase.  Later changes to our code appear to have worked around that bug.  

## Testing
Clean installed this change with mysql. 
Clean installed this change with SQL Server. 
Migrated to this change from a cluster running mysql and using Liquibase 3.8. 

## How to Revert
<!-- List steps required to revert this change. For example, note if we'd need to revert liquibase changes. -->
