### PR TITLE
fix: Include requirements.txt in source distribution

### DIFF
--- a/client/verta/MANIFEST.in
+++ b/client/verta/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt requirements-unit-tests.txt

--- a/client/verta/Makefile
+++ b/client/verta/Makefile
@@ -1,0 +1,11 @@
+# build wheel and source distributions
+build: clean
+	python setup.py sdist bdist_wheel --universal
+
+# clean previously-created builds
+clean:
+	rm -rf build dist verta.egg-info
+
+# upload distributions to PyPI
+upload: build
+	python -m twine upload dist/* -u \${PYPI_USERNAME} -p \${PYPI_PASSWORD}

--- a/client/verta/upload.sh
+++ b/client/verta/upload.sh
@@ -1,3 +1,0 @@
-python3 setup.py sdist bdist_wheel --universal
-python3 -m twine upload dist/*
-rm -rf build dist verta.egg-info


### PR DESCRIPTION
<!-- Title of the PR must comply with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines. --> 
<!-- Title should include the JIRA ticket in square brackets after the conventional commit prefix. This will automatically link the PR in JIRA. -->
<!-- Example: "fix: [JIRA-123] Allow creation of groups with no members" -->

## Impact and Context
<!-- Brief description of why these changes are necessary. Don't rewrite the entire Jira ticket. -->

We upload our client to PyPI as both a wheel as well as a source `.tar.gz` distribution. And since `0.19.3`, we [split out](https://github.com/VertaAI/modeldb/pull/2747) the list of our dependencies from within `setup.py` to a standalone `requirements.txt`.

This results in an issue: That `requirements.txt` is not included when `setuptools` [creates a source distribution](https://github.com/VertaAI/modeldb/blob/356cfc0e1050c3f261741ce7067a022638a04bb2/client/verta/upload.sh#L1), so anyone downloading and installing our package from source via PyPI won't be able to run `setup.py` since it tries to open a missing file. Specifically, this breaks our package's [conda-forge build](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=489118&view=logs&j=656edd35-690f-5c53-9ba3-09c10d0bea97&t=e5c8ab1d-8ff9-5cae-b332-e15ae582ed2d) which does precisely that.

This PR introduces a `MANIFEST.in` file, which is [the way](https://packaging.python.org/en/latest/guides/using-manifest-in/) to specify extra files to be included in a source distribution.

## Risks and Area of Effect
<!--
  Describe both risk (how likely this is to break) and area of effect (how wide potential breakages could reach).
  These should be smaller scale than those documented in a design doc.
-->

Low risk: An extra couple of files won't break anything.

Low AoE: This [only] benefits users installing our client from source.

## Testing
<!-- Explain how this contribution has been tested, e.g. what tests were added and where they have been run. -->

I built our library locally without then with this change, and installation from the source `tar.gz` failed then succeeded respectively.

This could probably be added to our CI 🤔 

## How to Revert
<!-- List steps required to revert this change. For example, note if we'd need to revert liquibase changes. -->

Revert this PR.