### PR TITLE
chore: make sure to close the tracing scope always

### DIFF
--- a/backend/common/src/main/java/ai/verta/modeldb/common/futures/FutureGrpc.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/futures/FutureGrpc.java
@@ -6,6 +6,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.GeneratedMessageV3;
 import io.grpc.Context;
 import io.grpc.stub.StreamObserver;
+import io.opentracing.Scope;
 import io.opentracing.util.GlobalTracer;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -87,8 +88,9 @@ public class FutureGrpc {
             Context.current()
                 .wrap(
                     () -> {
-                      tracer.scopeManager().activate(span);
-                      r.run();
+                      try (Scope s = tracer.scopeManager().activate(span)) {
+                        r.run();
+                      }
                     }));
       } else {
         other.execute(Context.current().wrap(r));


### PR DESCRIPTION
OTel uncovered this unclosed scope when I ran things with the `-Dio.opentelemetry.context.enableStrictContext=true` flag

In the logs: 
```
May 13, 2022 8:27:51 AM io.opentelemetry.context.StrictContextStorage$PendingScopes run
SEVERE: Scope garbage collected before being closed.
java.lang.AssertionError: Thread [ForkJoinPool-1-worker-229] opened a scope of {opentracing-shim-key=io.opentelemetry.opentracingshim.SpanShim@65fa797b, opentelemetry-trace-span-key=PropagatedSpan{ImmutableSpanContext{traceId=00000000000000000000000000000000, spanId=0000000000000000, traceFlags=00, traceState=ArrayBasedTraceState{entries=[]}, remote=false, valid=false}}} here:
	at io.opentelemetry.opentracingshim.ScopeManagerShim.activate(ScopeManagerShim.java:56)
	at ai.verta.modeldb.common.futures.FutureGrpc$ExecutorWrapper.lambda$execute$0(FutureGrpc.java:90)
	at io.grpc.Context$1.run(Context.java:566)
	at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1426)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
```


<!-- Title of the PR must comply with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines. --> 
<!-- Title should include the JIRA ticket in square brackets after the conventional commit prefix. This will automatically link the PR in JIRA. -->
<!-- Example: "fix: [JIRA-123] Allow creation of groups with no members" -->

## Impact and Context
<!-- Brief description of why these changes are necessary. Don't rewrite the entire Jira ticket. -->

## Risks and Area of Effect
<!--
  Describe both risk (how likely this is to break) and area of effect (how wide potential breakages could reach).
  These should be smaller scale than those documented in a design doc.
-->

## Testing
<!-- Explain how this contribution has been tested, e.g. what tests were added and where they have been run. -->

## How to Revert
<!-- List steps required to revert this change. For example, note if we'd need to revert liquibase changes. -->
