### PR TITLE
chore: allow detailed tracing of the InternalFuture via an env var

### DIFF
--- a/backend/common/src/main/java/ai/verta/modeldb/common/futures/FutureJdbi.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/futures/FutureJdbi.java
@@ -56,12 +56,7 @@ public class FutureJdbi {
           return InternalFuture.from(promise);
         },
         "jdbi.withHandle",
-        Map.of(
-            "caller",
-            String.format(
-                "%s:%d",
-                Thread.currentThread().getStackTrace()[2].getFileName(),
-                Thread.currentThread().getStackTrace()[2].getLineNumber())),
+        Map.of(),
         executor);
   }
 
@@ -100,12 +95,7 @@ public class FutureJdbi {
           return InternalFuture.from(promise);
         },
         "jdbi.useHandle",
-        Map.of(
-            "caller",
-            String.format(
-                "%s:%d",
-                Thread.currentThread().getStackTrace()[2].getFileName(),
-                Thread.currentThread().getStackTrace()[2].getLineNumber())),
+        Map.of(),
         executor);
   }
 }

--- a/backend/common/src/main/java/ai/verta/modeldb/common/futures/InternalFuture.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/futures/InternalFuture.java
@@ -1,7 +1,12 @@
 package ai.verta.modeldb.common.futures;
 
 import ai.verta.modeldb.common.exceptions.ModelDBException;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -11,30 +16,54 @@ import java.util.function.*;
 import java.util.stream.Collectors;
 
 public class InternalFuture<T> {
+  private static final boolean DEEP_TRACING_ENABLED;
+  public static final AttributeKey<String> STACK_ATTRIBUTE_KEY = AttributeKey.stringKey("stack");
+
+  static {
+    String internalFutureTracingEnabled = System.getenv("IFUTURE_TRACING_ENABLED");
+    if (internalFutureTracingEnabled == null) {
+      DEEP_TRACING_ENABLED = false;
+    } else {
+      DEEP_TRACING_ENABLED = Boolean.parseBoolean(internalFutureTracingEnabled);
+    }
+  }
+
+  private final Tracer futureTracer = GlobalOpenTelemetry.getTracer("futureTracer");
+  private final String formattedStack;
   private CompletionStage<T> stage;
 
   // keep the calling OpenTelemetry context, so we can use it to wrap the actual invocation of the
   // future's implementation
   private final Context callingContext = Context.current();
 
-  private InternalFuture() {}
+  private InternalFuture() {
+    if (!DEEP_TRACING_ENABLED) {
+      formattedStack = null;
+    } else {
+      StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
+      if (stackTrace.length > 10) {
+        stackTrace = Arrays.copyOf(stackTrace, 10);
+      }
+      this.formattedStack =
+              Arrays.stream(stackTrace)
+                      .map(StackTraceElement::toString)
+                      .collect(Collectors.joining("\nat "));
+    }
+  }
 
   public static <T> InternalFuture<T> trace(
-      Supplier<InternalFuture<T>> supplier,
-      String operationName,
-      Map<String, String> tags,
-      Executor executor) {
-    // todo: implement me
-    //    SpanBuilder spanBuilder =
-    // GlobalOpenTelemetry.getTracer("verta_java").spanBuilder(operationName);
-    //    tags.forEach(spanBuilder::setAttribute);
-
+          Supplier<InternalFuture<T>> supplier,
+          String operationName,
+          Map<String, String> tags,
+          Executor executor) {
+    // todo: remove me since tracing works in other ways now
     return supplier.get();
   }
 
   // Convert a list of futures to a future of a list
+  @SuppressWarnings("unchecked")
   public static <T> InternalFuture<List<T>> sequence(
-      final List<InternalFuture<T>> futures, Executor executor) {
+          final List<InternalFuture<T>> futures, Executor executor) {
     if (futures.isEmpty()) {
       return InternalFuture.completedInternalFuture(new LinkedList<>());
     }
@@ -42,33 +71,33 @@ public class InternalFuture<T> {
     final var promise = new CompletableFuture<List<T>>();
     final var values = new ArrayList<T>(futures.size());
     final CompletableFuture<T>[] futuresArray =
-        futures.stream()
-            .map(x -> x.toCompletionStage().toCompletableFuture())
-            .collect(Collectors.toList())
-            .toArray(new CompletableFuture[futures.size()]);
+            futures.stream()
+                    .map(x -> x.toCompletionStage().toCompletableFuture())
+                    .collect(Collectors.toList())
+                    .toArray(new CompletableFuture[futures.size()]);
 
     CompletableFuture.allOf(futuresArray)
-        .whenCompleteAsync(
-            (ignored, throwable) -> {
-              if (throwable != null) {
-                promise.completeExceptionally(throwable);
-                return;
-              }
+            .whenCompleteAsync(
+                    (ignored, throwable) -> {
+                      if (throwable != null) {
+                        promise.completeExceptionally(throwable);
+                        return;
+                      }
 
-              try {
-                for (final var future : futuresArray) {
-                  values.add(future.get());
-                }
-                promise.complete(values);
-              } catch (RuntimeException | InterruptedException | ExecutionException t) {
-                if (t instanceof InterruptedException) {
-                  // Restore interrupted state...
-                  Thread.currentThread().interrupt();
-                }
-                promise.completeExceptionally(t);
-              }
-            },
-            executor);
+                      try {
+                        for (final var future : futuresArray) {
+                          values.add(future.get());
+                        }
+                        promise.complete(values);
+                      } catch (RuntimeException | InterruptedException | ExecutionException t) {
+                        if (t instanceof InterruptedException) {
+                          // Restore interrupted state...
+                          Thread.currentThread().interrupt();
+                        }
+                        promise.completeExceptionally(t);
+                      }
+                    },
+                    executor);
 
     return InternalFuture.from(promise);
   }
@@ -86,40 +115,147 @@ public class InternalFuture<T> {
   }
 
   public <U> InternalFuture<U> thenCompose(
-      Function<? super T, InternalFuture<U>> fn, Executor executor) {
+          Function<? super T, InternalFuture<U>> fn, Executor executor) {
     return from(
-        stage.thenComposeAsync(
-            callingContext.wrapFunction(fn.andThen(internalFuture -> internalFuture.stage)),
-            executor));
+            stage.thenComposeAsync(
+                    traceFunction(
+                            callingContext.wrapFunction(
+                                    traceFunction(
+                                            fn.andThen(internalFuture -> internalFuture.stage), "futureThenCompose")),
+                            "futureThenApply"),
+                    executor));
   }
 
   public <U> InternalFuture<U> thenApply(Function<? super T, ? extends U> fn, Executor executor) {
-    return from(stage.thenApplyAsync(callingContext.wrapFunction(fn), executor));
+    return from(
+            stage.thenApplyAsync(
+                    traceFunction(callingContext.wrapFunction(fn), "futureThenApply"), executor));
+  }
+
+  private <U> Function<? super T, ? extends U> traceFunction(
+          Function<? super T, ? extends U> fn, String spanName) {
+    if (!DEEP_TRACING_ENABLED) {
+      return fn;
+    }
+    return t -> {
+      Span span = startSpan(spanName);
+      try (Scope ignored = span.makeCurrent()) {
+        return fn.apply(t);
+      } finally {
+        span.end();
+      }
+    };
+  }
+
+  private Span startSpan(String futureThenApply) {
+    return futureTracer
+            .spanBuilder(futureThenApply)
+            .setAttribute(STACK_ATTRIBUTE_KEY, formattedStack)
+            .startSpan();
   }
 
   public <U> InternalFuture<U> handle(
-      BiFunction<? super T, Throwable, ? extends U> fn, Executor executor) {
-    return from(stage.handleAsync(callingContext.wrapFunction(fn), executor));
+          BiFunction<? super T, Throwable, ? extends U> fn, Executor executor) {
+    return from(
+            stage.handleAsync(traceBiFunctionThrowable(callingContext.wrapFunction(fn)), executor));
+  }
+
+  private <U> BiFunction<? super T, Throwable, ? extends U> traceBiFunctionThrowable(
+          BiFunction<? super T, Throwable, ? extends U> fn) {
+    if (!DEEP_TRACING_ENABLED) {
+      return fn;
+    }
+    return (t, throwable) -> {
+      Span span = startSpan("futureHandle");
+      try (Scope ignored = span.makeCurrent()) {
+        return fn.apply(t, throwable);
+      } finally {
+        span.end();
+      }
+    };
   }
 
   public <U, V> InternalFuture<V> thenCombine(
-      InternalFuture<? extends U> other,
-      BiFunction<? super T, ? super U, ? extends V> fn,
-      Executor executor) {
-    return from(stage.thenCombineAsync(other.stage, callingContext.wrapFunction(fn), executor));
+          InternalFuture<? extends U> other,
+          BiFunction<? super T, ? super U, ? extends V> fn,
+          Executor executor) {
+    return from(
+            stage.thenCombineAsync(
+                    other.stage, callingContext.wrapFunction(traceBiFunction(fn)), executor));
+  }
+
+  private <U, V> BiFunction<? super T, ? super U, ? extends V> traceBiFunction(
+          BiFunction<? super T, ? super U, ? extends V> fn) {
+    if (!DEEP_TRACING_ENABLED) {
+      return fn;
+    }
+    return (t, u) -> {
+      Span span = startSpan("futureThenCombine");
+      try (Scope ignored = span.makeCurrent()) {
+        return fn.apply(t, u);
+      } finally {
+        span.end();
+      }
+    };
   }
 
   public InternalFuture<Void> thenAccept(Consumer<? super T> action, Executor executor) {
-    return from(stage.thenAcceptAsync(callingContext.wrapConsumer(action), executor));
+    return from(
+            stage.thenAcceptAsync(callingContext.wrapConsumer(traceConsumer(action)), executor));
+  }
+
+  private Consumer<? super T> traceConsumer(Consumer<? super T> action) {
+    if (!DEEP_TRACING_ENABLED) {
+      return action;
+    }
+    return t -> {
+      Span span = startSpan("futureThenAccept");
+      try (Scope ignored = span.makeCurrent()) {
+        action.accept(t);
+      } finally {
+        span.end();
+      }
+    };
   }
 
   public <U> InternalFuture<Void> thenRun(Runnable runnable, Executor executor) {
-    return from(stage.thenRunAsync(callingContext.wrap(runnable), executor));
+    return from(stage.thenRunAsync(callingContext.wrap(traceRunnable(runnable)), executor));
+  }
+
+  private Runnable traceRunnable(Runnable r) {
+    if (!DEEP_TRACING_ENABLED) {
+      return r;
+    }
+    return () -> {
+      Span span = startSpan("futureThenRun");
+      try (Scope ignored = span.makeCurrent()) {
+        r.run();
+      } finally {
+        span.end();
+      }
+    };
   }
 
   public InternalFuture<T> whenComplete(
-      BiConsumer<? super T, ? super Throwable> action, Executor executor) {
-    return from(stage.whenCompleteAsync(callingContext.wrapConsumer(action), executor));
+          BiConsumer<? super T, ? super Throwable> action, Executor executor) {
+    return from(
+            stage.whenCompleteAsync(callingContext.wrapConsumer(traceBiConsumer(action)), executor));
+  }
+
+  private BiConsumer<? super T, ? super Throwable> traceBiConsumer(
+          BiConsumer<? super T, ? super Throwable> action) {
+    if (!DEEP_TRACING_ENABLED) {
+      return action;
+    }
+
+    return (t, throwable) -> {
+      Span span = startSpan("futureWhenComplete");
+      try (Scope ignored = span.makeCurrent()) {
+        action.accept(t, throwable);
+      } finally {
+        span.end();
+      }
+    };
   }
 
   public static <U> InternalFuture<Void> runAsync(Runnable runnable, Executor executor) {
@@ -135,40 +271,40 @@ public class InternalFuture<T> {
   }
 
   public static <U> InternalFuture<U> retriableStage(
-      Supplier<InternalFuture<U>> supplier,
-      Function<Throwable, Boolean> retryChecker,
-      Executor executor) {
+          Supplier<InternalFuture<U>> supplier,
+          Function<Throwable, Boolean> retryChecker,
+          Executor executor) {
     final var promise = new CompletableFuture<U>();
 
     supplier
-        .get()
-        .whenComplete(
-            (value, throwable) -> {
-              boolean retryCheckerFlag = retryChecker.apply(throwable);
-              if (throwable == null) {
-                promise.complete(value);
-              } else if (retryCheckerFlag) {
-                // If we should retry, then perform the retry and map the result of the future to
-                // the current promise
-                // This build up a chain of promises, which can consume memory. I couldn't figure
-                // out how to do better
-                // with Java constraints of final vars in lambdas and not using uninitialized
-                // variables.
-                retriableStage(supplier, retryChecker, executor)
-                    .whenComplete(
-                        (v, t) -> {
-                          if (t == null) {
-                            promise.complete(v);
-                          } else {
-                            promise.completeExceptionally(t);
-                          }
-                        },
-                        executor);
-              } else {
-                promise.completeExceptionally(throwable);
-              }
-            },
-            executor);
+            .get()
+            .whenComplete(
+                    (value, throwable) -> {
+                      boolean retryCheckerFlag = retryChecker.apply(throwable);
+                      if (throwable == null) {
+                        promise.complete(value);
+                      } else if (retryCheckerFlag) {
+                        // If we should retry, then perform the retry and map the result of the future to
+                        // the current promise
+                        // This build up a chain of promises, which can consume memory. I couldn't figure
+                        // out how to do better
+                        // with Java constraints of final vars in lambdas and not using uninitialized
+                        // variables.
+                        retriableStage(supplier, retryChecker, executor)
+                                .whenComplete(
+                                        (v, t) -> {
+                                          if (t == null) {
+                                            promise.complete(v);
+                                          } else {
+                                            promise.completeExceptionally(t);
+                                          }
+                                        },
+                                        executor);
+                      } else {
+                        promise.completeExceptionally(throwable);
+                      }
+                    },
+                    executor);
 
     return InternalFuture.from(promise);
   }

--- a/backend/common/src/main/java/ai/verta/modeldb/common/futures/InternalFuture.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/futures/InternalFuture.java
@@ -21,11 +21,7 @@ public class InternalFuture<T> {
 
   static {
     String internalFutureTracingEnabled = System.getenv("IFUTURE_TRACING_ENABLED");
-    if (internalFutureTracingEnabled == null) {
-      DEEP_TRACING_ENABLED = false;
-    } else {
-      DEEP_TRACING_ENABLED = Boolean.parseBoolean(internalFutureTracingEnabled);
-    }
+    DEEP_TRACING_ENABLED = Boolean.parseBoolean(internalFutureTracingEnabled);
   }
 
   private final Tracer futureTracer = GlobalOpenTelemetry.getTracer("futureTracer");


### PR DESCRIPTION
This will allow enabling detailed tracing via an environment variable: `IFUTURE_TRACING_ENABLED=true`

<!-- Title of the PR must comply with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines. --> 
<!-- Title should include the JIRA ticket in square brackets after the conventional commit prefix. This will automatically link the PR in JIRA. -->
<!-- Example: "fix: [JIRA-123] Allow creation of groups with no members" -->

## Impact and Context
<!-- Brief description of why these changes are necessary. Don't rewrite the entire Jira ticket. -->

## Risks and Area of Effect
<!--
  Describe both risk (how likely this is to break) and area of effect (how wide potential breakages could reach).
  These should be smaller scale than those documented in a design doc.
-->

## Testing
<!-- Explain how this contribution has been tested, e.g. what tests were added and where they have been run. -->

## How to Revert
<!-- List steps required to revert this change. For example, note if we'd need to revert liquibase changes. -->
