### PR TITLE
chore: Add the capability of processing futures synchronously

### DIFF
--- a/backend/common/src/main/java/ai/verta/modeldb/common/futures/InternalFuture.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/futures/InternalFuture.java
@@ -47,15 +47,6 @@ public class InternalFuture<T> {
     }
   }
 
-  public static <T> InternalFuture<T> trace(
-      Supplier<InternalFuture<T>> supplier,
-      String operationName,
-      Map<String, String> tags,
-      Executor executor) {
-    // todo: remove me since tracing works in other ways now
-    return supplier.get();
-  }
-
   // Convert a list of futures to a future of a list
   @SuppressWarnings("unchecked")
   public static <T> InternalFuture<List<T>> sequence(
@@ -122,10 +113,24 @@ public class InternalFuture<T> {
             executor));
   }
 
+  public <U> InternalFuture<U> thenComposeSync(Function<? super T, InternalFuture<U>> fn) {
+    return from(
+        stage.thenCompose(
+            traceFunction(
+                callingContext.wrapFunction(
+                    traceFunction(
+                        fn.andThen(internalFuture -> internalFuture.stage), "futureThenCompose")),
+                "futureThenApply")));
+  }
+
   public <U> InternalFuture<U> thenApply(Function<? super T, ? extends U> fn, Executor executor) {
     return from(
         stage.thenApplyAsync(
             traceFunction(callingContext.wrapFunction(fn), "futureThenApply"), executor));
+  }
+
+  public <U> InternalFuture<U> thenApplySync(Function<? super T, ? extends U> fn) {
+    return from(stage.thenApply(traceFunction(callingContext.wrapFunction(fn), "futureThenApply")));
   }
 
   private <U> Function<? super T, ? extends U> traceFunction(
@@ -156,6 +161,10 @@ public class InternalFuture<T> {
         stage.handleAsync(traceBiFunctionThrowable(callingContext.wrapFunction(fn)), executor));
   }
 
+  public <U> InternalFuture<U> handleSync(BiFunction<? super T, Throwable, ? extends U> fn) {
+    return from(stage.handle(traceBiFunctionThrowable(callingContext.wrapFunction(fn))));
+  }
+
   private <U> BiFunction<? super T, Throwable, ? extends U> traceBiFunctionThrowable(
       BiFunction<? super T, Throwable, ? extends U> fn) {
     if (!DEEP_TRACING_ENABLED) {
@@ -180,6 +189,11 @@ public class InternalFuture<T> {
             other.stage, callingContext.wrapFunction(traceBiFunction(fn)), executor));
   }
 
+  public <U, V> InternalFuture<V> thenCombineSync(
+      InternalFuture<? extends U> other, BiFunction<? super T, ? super U, ? extends V> fn) {
+    return from(stage.thenCombine(other.stage, callingContext.wrapFunction(traceBiFunction(fn))));
+  }
+
   private <U, V> BiFunction<? super T, ? super U, ? extends V> traceBiFunction(
       BiFunction<? super T, ? super U, ? extends V> fn) {
     if (!DEEP_TRACING_ENABLED) {
@@ -200,6 +214,10 @@ public class InternalFuture<T> {
         stage.thenAcceptAsync(callingContext.wrapConsumer(traceConsumer(action)), executor));
   }
 
+  public InternalFuture<Void> thenAcceptSync(Consumer<? super T> action) {
+    return from(stage.thenAccept(callingContext.wrapConsumer(traceConsumer(action))));
+  }
+
   private Consumer<? super T> traceConsumer(Consumer<? super T> action) {
     if (!DEEP_TRACING_ENABLED) {
       return action;
@@ -216,6 +234,10 @@ public class InternalFuture<T> {
 
   public <U> InternalFuture<Void> thenRun(Runnable runnable, Executor executor) {
     return from(stage.thenRunAsync(callingContext.wrap(traceRunnable(runnable)), executor));
+  }
+
+  public <U> InternalFuture<Void> thenRunSync(Runnable runnable) {
+    return from(stage.thenRun(callingContext.wrap(traceRunnable(runnable))));
   }
 
   private Runnable traceRunnable(Runnable r) {
@@ -236,6 +258,10 @@ public class InternalFuture<T> {
       BiConsumer<? super T, ? super Throwable> action, Executor executor) {
     return from(
         stage.whenCompleteAsync(callingContext.wrapConsumer(traceBiConsumer(action)), executor));
+  }
+
+  public InternalFuture<T> whenCompleteSync(BiConsumer<? super T, ? super Throwable> action) {
+    return from(stage.whenComplete(callingContext.wrapConsumer(traceBiConsumer(action))));
   }
 
   private BiConsumer<? super T, ? super Throwable> traceBiConsumer(

--- a/backend/common/src/test/java/ai/verta/modeldb/common/futures/InternalFutureTest.java
+++ b/backend/common/src/test/java/ai/verta/modeldb/common/futures/InternalFutureTest.java
@@ -27,4 +27,21 @@ class InternalFutureTest {
 
     assertThatThrownBy(testFuture::get).getRootCause().hasMessage("borken");
   }
+
+  @Test
+  void composition_syncFailsFast() {
+    InternalFuture<String> testFuture =
+        InternalFuture.completedInternalFuture("cheese")
+            .thenApplySync(
+                s1 -> {
+                  throw new RuntimeException("borken");
+                })
+            .thenComposeSync(
+                s -> {
+                  Assertions.fail("should never execute the next stage");
+                  return InternalFuture.failedStage(new RuntimeException("broken"));
+                });
+
+    assertThatThrownBy(testFuture::get).getRootCause().hasMessage("borken");
+  }
 }


### PR DESCRIPTION
Also: fixed a broken http client tracing test
Also: removed un-needed no-op tracing method in the InternalFuture class

<!-- Title of the PR must comply with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines. --> 
<!-- Title should include the JIRA ticket in square brackets after the conventional commit prefix. This will automatically link the PR in JIRA. -->
<!-- Example: "fix: [JIRA-123] Allow creation of groups with no members" -->

## Impact and Context
In many places in our code, we use asynchronous processing where it is not actually needed, including some very simple input validation. By forcing asynchronous execution, we can introduce a considerable amount of unneeded thread jumping, which is a relatively expensive operation. 

This PR will enable processing future responses synchronously, but only if explicitly requested via the new `*Sync` methods. 

## Risks and Area of Effect
Since this is only additive to the InternalFuture API, it has very low immediate risk.
