### PR TITLE
feat: Split out url property

### DIFF
--- a/client/verta/tests/registry/model_version/test_crud.py
+++ b/client/verta/tests/registry/model_version/test_crud.py
@@ -48,6 +48,7 @@ class TestCRUD:
         repr = str(model_version)
 
         assert model_version.name in repr
+        assert model_version.url in repr
         assert str(model_version.id) in repr
         assert str(model_version.registered_model_id) in repr
         assert str(model_version.get_labels()) in repr

--- a/client/verta/tests/registry/model_version/test_crud.py
+++ b/client/verta/tests/registry/model_version/test_crud.py
@@ -48,7 +48,6 @@ class TestCRUD:
         repr = str(model_version)
 
         assert model_version.name in repr
-        assert model_version.url in repr
         assert str(model_version.id) in repr
         assert str(model_version.registered_model_id) in repr
         assert str(model_version.get_labels()) in repr

--- a/client/verta/tests/registry/test_model.py
+++ b/client/verta/tests/registry/test_model.py
@@ -75,7 +75,6 @@ class TestModel:
         repr = str(registered_model)
 
         assert registered_model.name in repr
-        assert registered_model.url in repr
         assert str(registered_model.id) in repr
         assert str(registered_model.get_labels()) in repr
 

--- a/client/verta/tests/registry/test_model.py
+++ b/client/verta/tests/registry/test_model.py
@@ -75,6 +75,7 @@ class TestModel:
         repr = str(registered_model)
 
         assert registered_model.name in repr
+        assert registered_model.url in repr
         assert str(registered_model.id) in repr
         assert str(registered_model.get_labels()) in repr
 

--- a/client/verta/tests/test_dataset_versioning/test_dataset.py
+++ b/client/verta/tests/test_dataset_versioning/test_dataset.py
@@ -143,7 +143,6 @@ class TestCreateGet:
         str_repr = repr(dataset)
 
         assert "name: {}".format(dataset.name) in str_repr
-        assert dataset.url in str_repr
         assert "id: {}".format(dataset.id) in str_repr
         assert "time created" in str_repr
         assert "time updated" in str_repr

--- a/client/verta/tests/test_dataset_versioning/test_dataset.py
+++ b/client/verta/tests/test_dataset_versioning/test_dataset.py
@@ -143,6 +143,7 @@ class TestCreateGet:
         str_repr = repr(dataset)
 
         assert "name: {}".format(dataset.name) in str_repr
+        assert dataset.url in str_repr
         assert "id: {}".format(dataset.id) in str_repr
         assert "time created" in str_repr
         assert "time updated" in str_repr

--- a/client/verta/tests/test_endpoint/test_endpoint.py
+++ b/client/verta/tests/test_endpoint/test_endpoint.py
@@ -129,6 +129,7 @@ class TestEndpoint:
         str_repr = repr(endpoint)
 
         assert "path: {}".format(endpoint.path) in str_repr
+        assert endpoint.url in str_repr
         assert "url" in str_repr
         assert "id: {}".format(endpoint.id) in str_repr
         assert "curl: <endpoint not deployed>" in str_repr

--- a/client/verta/tests/test_endpoint/test_endpoint.py
+++ b/client/verta/tests/test_endpoint/test_endpoint.py
@@ -129,7 +129,6 @@ class TestEndpoint:
         str_repr = repr(endpoint)
 
         assert "path: {}".format(endpoint.path) in str_repr
-        assert endpoint.url in str_repr
         assert "url" in str_repr
         assert "id: {}".format(endpoint.id) in str_repr
         assert "curl: <endpoint not deployed>" in str_repr

--- a/client/verta/tests/test_entities.py
+++ b/client/verta/tests/test_entities.py
@@ -196,6 +196,14 @@ class TestProject:
         with pytest.raises(ValueError):
             client.set_project(id="nonexistent_id")
 
+    def test_repr(self, client):
+        proj = client.create_project()
+        str_repr = str(proj)
+
+        assert proj.name in str_repr
+        assert proj.url in str_repr
+        assert proj.id in str_repr
+
     @pytest.mark.parametrize("tags", [TAG, [TAG]])
     def test_tags_is_list_of_str(self, client, tags):
         proj = client.set_project(tags=tags)
@@ -339,9 +347,12 @@ class TestExperimentRun:
         with pytest.raises(ValueError):
             client.set_experiment_run(id="nonexistent_id")
 
-    def test_no_experiment_error(self, client):
-        with pytest.raises(AttributeError):
-            client.set_experimennt_run()
+    def test_repr(self, experiment_run):
+        str_repr = str(experiment_run)
+
+        assert experiment_run.name in str_repr
+        assert experiment_run.url in str_repr
+        assert experiment_run.id in str_repr
 
     @pytest.mark.parametrize("tags", [TAG, [TAG]])
     def test_tags_is_list_of_str(self, client, tags):

--- a/client/verta/tests/test_entities.py
+++ b/client/verta/tests/test_entities.py
@@ -196,14 +196,6 @@ class TestProject:
         with pytest.raises(ValueError):
             client.set_project(id="nonexistent_id")
 
-    def test_repr(self, client):
-        proj = client.create_project()
-        str_repr = str(proj)
-
-        assert proj.name in str_repr
-        assert proj.url in str_repr
-        assert proj.id in str_repr
-
     @pytest.mark.parametrize("tags", [TAG, [TAG]])
     def test_tags_is_list_of_str(self, client, tags):
         proj = client.set_project(tags=tags)
@@ -347,12 +339,9 @@ class TestExperimentRun:
         with pytest.raises(ValueError):
             client.set_experiment_run(id="nonexistent_id")
 
-    def test_repr(self, experiment_run):
-        str_repr = str(experiment_run)
-
-        assert experiment_run.name in str_repr
-        assert experiment_run.url in str_repr
-        assert experiment_run.id in str_repr
+    def test_no_experiment_error(self, client):
+        with pytest.raises(AttributeError):
+            client.set_experimennt_run()
 
     @pytest.mark.parametrize("tags", [TAG, [TAG]])
     def test_tags_is_list_of_str(self, client, tags):

--- a/client/verta/verta/dataset/entities/_dataset.py
+++ b/client/verta/verta/dataset/entities/_dataset.py
@@ -37,6 +37,8 @@ class Dataset(_entity._ModelDBEntity):
         ID of this dataset.
     name : str
         Name of this dataset.
+    url : str
+        Verta web app URL.
     workspace : str
         Workspace containing this dataset.
     versions : :class:`~verta.dataset.entities.DatasetVersions`
@@ -52,7 +54,7 @@ class Dataset(_entity._ModelDBEntity):
 
         return '\n'.join((
             "name: {}".format(msg.name),
-            "url: {}://{}/{}/datasets/{}/summary".format(self._conn.scheme, self._conn.socket, self.workspace, self.id),
+            "url: {}".format(self.url),
             "time created: {}".format(_utils.timestamp_to_str(int(msg.time_created))),
             "time updated: {}".format(_utils.timestamp_to_str(int(msg.time_updated))),
             "description: {}".format(msg.description),
@@ -65,6 +67,15 @@ class Dataset(_entity._ModelDBEntity):
     def name(self):
         self._refresh_cache()
         return self._msg.name
+
+    @property
+    def url(self):
+        return "{}://{}/{}/datasets/{}/summary".format(
+            self._conn.scheme,
+            self._conn.socket,
+            self.workspace,
+            self.id,
+        )
 
     @property
     def workspace(self):

--- a/client/verta/verta/endpoint/_endpoint.py
+++ b/client/verta/verta/endpoint/_endpoint.py
@@ -47,6 +47,8 @@ class Endpoint(object):
         Kafka settings on this endpoint.
     path : str
         Path of this endpoint.
+    url : str
+        Verta web app URL.
 
     """
 
@@ -68,9 +70,7 @@ class Endpoint(object):
         return "\n".join(
             (
                 "path: {}".format(data["creator_request"]["path"]),
-                "url: {}://{}/{}/endpoints/{}/summary".format(
-                    self._conn.scheme, self._conn.socket, self.workspace, self.id
-                ),
+                "url: {}".format(self.url),
                 "id: {}".format(self.id),
                 "curl: {}".format(curl),
                 "status: {}".format(status["status"]),
@@ -93,6 +93,15 @@ class Endpoint(object):
     def path(self):
         """Get the HTTP path of this endpoint."""
         return self._path(Endpoint._get_json_by_id(self._conn, self.workspace, self.id))
+
+    @property
+    def url(self):
+        return "{}://{}/{}/endpoints/{}/summary".format(
+            self._conn.scheme,
+            self._conn.socket,
+            self.workspace,
+            self.id,
+        )
 
     def get_current_build(self):
         """Retrieve the currently deployed build for this endpoint.

--- a/client/verta/verta/registry/entities/_model.py
+++ b/client/verta/verta/registry/entities/_model.py
@@ -29,6 +29,8 @@ class RegisteredModel(_entity._ModelDBEntity):
         ID of this Registered Model.
     name : str
         Name of this Registered Model.
+    url : str
+        Verta web app URL.
     versions : iterable of :class:`~verta.registry.entities.RegisteredModelVersion`
         Versions of this RegisteredModel.
 
@@ -42,7 +44,7 @@ class RegisteredModel(_entity._ModelDBEntity):
 
         return '\n'.join((
             "name: {}".format(msg.name),
-            "url: {}://{}/{}/registry/{}".format(self._conn.scheme, self._conn.socket, self.workspace, self.id),
+            "url: {}".format(self.url),
             "time created: {}".format(_utils.timestamp_to_str(int(msg.time_created))),
             "time updated: {}".format(_utils.timestamp_to_str(int(msg.time_updated))),
             "description: {}".format(msg.description),
@@ -54,6 +56,15 @@ class RegisteredModel(_entity._ModelDBEntity):
     def name(self):
         self._refresh_cache()
         return self._msg.name
+
+    @property
+    def url(self):
+        return "{}://{}/{}/registry/{}".format(
+            self._conn.scheme,
+            self._conn.socket,
+            self.workspace,
+            self.id,
+        )
 
     @property
     def workspace(self):

--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -66,6 +66,8 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
         ID of this version's Registered Model.
     stage : str
         Model version stage.
+    url : str
+        Verta web app URL.
 
     """
 
@@ -92,13 +94,7 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
                         msg.lock_level
                     ).lower()
                 ),
-                "url: {}://{}/{}/registry/{}/versions/{}".format(
-                    self._conn.scheme,
-                    self._conn.socket,
-                    self.workspace,
-                    self.registered_model_id,
-                    self.id,
-                ),
+                "url: {}".format(self.url),
                 "time created: {}".format(
                     _utils.timestamp_to_str(int(msg.time_created))
                 ),
@@ -151,6 +147,16 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
     # def is_archived(self):
     #     self._refresh_cache()
     #     return self._msg.archived == _CommonCommonService.TernaryEnum.TRUE
+
+    @property
+    def url(self):
+        return "{}://{}/{}/registry/{}/versions/{}".format(
+            self._conn.scheme,
+            self._conn.socket,
+            self.workspace,
+            self.registered_model_id,
+            self.id,
+        )
 
     @property
     def workspace(self):

--- a/client/verta/verta/tracking/entities/_experimentrun.py
+++ b/client/verta/verta/tracking/entities/_experimentrun.py
@@ -59,6 +59,8 @@ class ExperimentRun(_DeployableEntity):
         Name of this Experiment Run.
     has_environment : bool
         Whether there is an environment associated with this Experiment Run.
+    url : str
+        Verta web app URL.
 
     """
 
@@ -71,8 +73,7 @@ class ExperimentRun(_DeployableEntity):
         run_msg = self._msg
         return '\n'.join((
             "name: {}".format(run_msg.name),
-            "url: {}://{}/{}/projects/{}/exp-runs/{}".format(
-                self._conn.scheme, self._conn.socket, self.workspace, run_msg.project_id, self.id),
+            "url: {}".format(self.url),
             "date created: {}".format(
                 _utils.timestamp_to_str(int(run_msg.date_created))),
             "date updated: {}".format(
@@ -129,6 +130,16 @@ class ExperimentRun(_DeployableEntity):
     def name(self):
         self._refresh_cache()
         return self._msg.name
+
+    @property
+    def url(self):
+        return "{}://{}/{}/projects/{}/exp-runs/{}".format(
+            self._conn.scheme,
+            self._conn.socket,
+            self.workspace,
+            self._msg.project_id,
+            self.id,
+        )
 
     @classmethod
     def _generate_default_name(cls):

--- a/client/verta/verta/tracking/entities/_project.py
+++ b/client/verta/verta/tracking/entities/_project.py
@@ -35,6 +35,8 @@ class Project(_ModelDBEntity):
         Name of this Project.
     expt_runs : :class:`~verta.tracking.entities.ExperimentRuns`
         Experiment Runs under this Project.
+    url : str
+        Verta web app URL.
 
     """
     def __init__(self, conn, conf, msg):
@@ -46,7 +48,7 @@ class Project(_ModelDBEntity):
 
         return '\n'.join((
             "name: {}".format(msg.name),
-            "url: {}://{}/{}/projects/{}/summary".format(self._conn.scheme, self._conn.socket, self.workspace, self.id),
+            "url: {}".format(self.url),
         ))
 
     @property
@@ -62,6 +64,15 @@ class Project(_ModelDBEntity):
     def expt_runs(self):
         # get runs in this Project
         return ExperimentRuns(self._conn, self._conf).with_project(self)
+
+    @property
+    def url(self):
+        return "{}://{}/{}/projects/{}/summary".format(
+            self._conn.scheme,
+            self._conn.socket,
+            self.workspace,
+            self.id,
+        )
 
     @property
     def workspace(self):


### PR DESCRIPTION
<!-- Title of the PR must comply with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines. --> 
<!-- Title should include the JIRA ticket in square brackets after the conventional commit prefix. This will automatically link the PR in JIRA. -->
<!-- Example: "fix: [JIRA-123] Allow creation of groups with no members" -->

## Impact and Context
<!-- Brief description of why these changes are necessary. Don't rewrite the entire Jira ticket. -->

Occasionally-requested and low-cost!

Exposes `experiment_run.url` and such.

## Risks and Area of Effect
<!--
  Describe both risk (how likely this is to break) and area of effect (how wide potential breakages could reach).
  These should be smaller scale than those documented in a design doc.
-->

Low risk: Straightforward copy-and-paste.

The URL was a hack I did years ago for the novelty, and this cements it in our public API, but technically having it in the `__repr__()` already made it public anyway.

## Testing
<!-- Explain how this contribution has been tested, e.g. what tests were added and where they have been run. -->

I ran this snippet and verified that the URLs are correct:

```python
from verta import Client

client = Client()

reg_model = client.create_registered_model()
for entity in [
    client.create_dataset(),
    client.get_or_create_endpoint("banana"),
    reg_model,
    reg_model.create_version(),
    client.create_experiment_run(),
    client.proj,
]:
    print(entity.url)
```

I also ran all of our `test_repr` tests in all supported Python versions, and there are no related failures.

## How to Revert
<!-- List steps required to revert this change. For example, note if we'd need to revert liquibase changes. -->

Revert this PR.
