### PR TITLE
chore: add some syntactic sugar for future composition

### DIFF
--- a/backend/common/src/main/java/ai/verta/modeldb/common/futures/InternalFuture.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/futures/InternalFuture.java
@@ -245,6 +245,13 @@ public class InternalFuture<T> {
     };
   }
 
+  /**
+   * Syntactic sugar for {@link #thenCompose(Function, Executor)} with the function ignoring the input.
+   */
+  public <U> InternalFuture<U> thenSupply(Supplier<InternalFuture<U>> supplier, Executor executor) {
+    return thenCompose(ignored -> supplier.get(), executor);
+  }
+
   public static <U> InternalFuture<Void> runAsync(Runnable runnable, Executor executor) {
     return from(CompletableFuture.runAsync(runnable, executor));
   }

--- a/backend/common/src/test/java/ai/verta/modeldb/common/futures/InternalFutureTest.java
+++ b/backend/common/src/test/java/ai/verta/modeldb/common/futures/InternalFutureTest.java
@@ -1,9 +1,12 @@
 package ai.verta.modeldb.common.futures;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.util.concurrent.MoreExecutors;
 import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -26,5 +29,46 @@ class InternalFutureTest {
                 executor);
 
     assertThatThrownBy(testFuture::get).getRootCause().hasMessage("borken");
+  }
+
+  @Test
+  void thenSupply() {
+    AtomicBoolean firstWasCalled = new AtomicBoolean();
+    Executor executor = MoreExecutors.directExecutor();
+    InternalFuture<Void> testFuture =
+        InternalFuture.supplyAsync(
+            () -> {
+              firstWasCalled.set(true);
+              return null;
+            },
+            executor);
+    InternalFuture<String> result =
+        testFuture.thenSupply(() -> InternalFuture.completedInternalFuture("cheese"), executor);
+    assertThat(result.get()).isEqualTo("cheese");
+    assertThat(firstWasCalled).isTrue();
+  }
+
+  @Test
+  void thenSupply_exception() {
+    AtomicBoolean secondWasCalled = new AtomicBoolean();
+    Executor executor = MoreExecutors.directExecutor();
+    InternalFuture<Void> testFuture =
+        InternalFuture.supplyAsync(
+            () -> {
+              throw new IllegalStateException("failed");
+            },
+            executor);
+    InternalFuture<String> result =
+        testFuture.thenSupply(
+            () ->
+                InternalFuture.supplyAsync(
+                    () -> {
+                      secondWasCalled.set(true);
+                      return "cheese";
+                    },
+                    executor),
+            executor);
+    assertThatThrownBy(result::get).hasMessageContaining("failed");
+    assertThat(secondWasCalled).isFalse();
   }
 }


### PR DESCRIPTION
This is useful for cases of `InternalFuture<Void>` where you don't care about the null being returned.

<!-- Title of the PR must comply with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines. --> 
<!-- Title should include the JIRA ticket in square brackets after the conventional commit prefix. This will automatically link the PR in JIRA. -->
<!-- Example: "fix: [JIRA-123] Allow creation of groups with no members" -->

## Impact and Context
<!-- Brief description of why these changes are necessary. Don't rewrite the entire Jira ticket. -->

## Risks and Area of Effect
<!--
  Describe both risk (how likely this is to break) and area of effect (how wide potential breakages could reach).
  These should be smaller scale than those documented in a design doc.
-->

## Testing
<!-- Explain how this contribution has been tested, e.g. what tests were added and where they have been run. -->

## How to Revert
<!-- List steps required to revert this change. For example, note if we'd need to revert liquibase changes. -->
