### PR TITLE
feat: [CAT-49] Modify python CLI to accept new attributes

### DIFF
--- a/client/verta/tests/registry/test_model.py
+++ b/client/verta/tests/registry/test_model.py
@@ -2,10 +2,6 @@ import pytest
 import requests
 
 import verta
-from verta.registry import action_type as action_type_module
-from verta.registry import data_type as data_type_module
-
-from ..utils import sorted_subclasses
 
 pytestmark = pytest.mark.not_oss  # skip if run in oss setup. Applied to entire module
 
@@ -131,55 +127,3 @@ class TestModel:
         created_entities.append(registered_model)
         registered_model.set_description(desc)
         assert desc == registered_model.get_description()
-
-
-class TestActionTypes:
-    @pytest.mark.parametrize("action_type_cls", sorted_subclasses(action_type_module._ActionType))
-    def test_creation(self, client, created_entities, action_type_cls):
-        if action_type_cls is action_type_module.Unknown:
-            pytest.skip("unsupported action type")
-
-        action_type = action_type_cls()
-
-        registered_model = client.create_registered_model(action_type=action_type)
-        created_entities.append(registered_model)
-
-        registered_model = client.get_registered_model(id=registered_model.id)
-        assert registered_model.get_action_type() == action_type
-
-    @pytest.mark.parametrize("action_type_cls", sorted_subclasses(action_type_module._ActionType))
-    def test_set(self, registered_model, action_type_cls):
-        if action_type_cls is action_type_module.Unknown:
-            pytest.skip("unsupported action type")
-
-        action_type = action_type_cls()
-
-        registered_model.set_action_type(action_type)
-
-        assert registered_model.get_action_type() == action_type
-
-
-class TestDataTypes:
-    @pytest.mark.parametrize("data_type_cls", sorted_subclasses(data_type_module._DataType))
-    def test_creation(self, client, created_entities, data_type_cls):
-        if data_type_cls is data_type_module.Unknown:
-            pytest.skip("unsupported data type")
-
-        data_type = data_type_cls()
-
-        registered_model = client.create_registered_model(data_type=data_type)
-        created_entities.append(registered_model)
-
-        registered_model = client.get_registered_model(id=registered_model.id)
-        assert registered_model.get_data_type() == data_type
-
-    @pytest.mark.parametrize("data_type_cls", sorted_subclasses(data_type_module._DataType))
-    def test_set(self, registered_model, data_type_cls):
-        if data_type_cls is data_type_module.Unknown:
-            pytest.skip("unsupported data type")
-
-        data_type = data_type_cls()
-
-        registered_model.set_data_type(data_type)
-
-        assert registered_model.get_data_type() == data_type

--- a/client/verta/tests/registry/test_model.py
+++ b/client/verta/tests/registry/test_model.py
@@ -2,6 +2,10 @@ import pytest
 import requests
 
 import verta
+from verta.registry.action_type import _ActionType
+from verta.registry.data_type import _DataType
+
+from .. import utils
 
 pytestmark = pytest.mark.not_oss  # skip if run in oss setup. Applied to entire module
 
@@ -127,3 +131,41 @@ class TestModel:
         created_entities.append(registered_model)
         registered_model.set_description(desc)
         assert desc == registered_model.get_description()
+
+
+class TestActionTypes:
+    @pytest.mark.parametrize("action_type_cls", utils.sorted_subclasses(_ActionType))
+    def test_creation(self, client, created_entities, action_type_cls):
+        action_type = action_type_cls()
+
+        registered_model = client.create_registered_model(action_type=action_type)
+        created_entities.append(registered_model)
+
+        assert registered_model.get_action_type() == action_type
+
+    @pytest.mark.parametrize("action_type_cls", utils.sorted_subclasses(_ActionType))
+    def test_set(self, registered_model, action_type_cls):
+        action_type = action_type_cls()
+
+        registered_model.set_action_type(action_type)
+
+        assert registered_model.get_action_type() == action_type
+
+
+class TestDataTypes:
+    @pytest.mark.parametrize("data_type_cls", utils.sorted_subclasses(_DataType))
+    def test_creation(self, client, created_entities, data_type_cls):
+        data_type = data_type_cls()
+
+        registered_model = client.create_registered_model(data_type=data_type)
+        created_entities.append(registered_model)
+
+        assert registered_model.get_data_type() == data_type
+
+    @pytest.mark.parametrize("data_type_cls", utils.sorted_subclasses(_DataType))
+    def test_set(self, registered_model, data_type_cls):
+        data_type = data_type_cls()
+
+        registered_model.set_data_type(data_type)
+
+        assert registered_model.get_data_type() == data_type

--- a/client/verta/tests/registry/test_model.py
+++ b/client/verta/tests/registry/test_model.py
@@ -2,10 +2,10 @@ import pytest
 import requests
 
 import verta
-from verta.registry.action_type import _ActionType
-from verta.registry.data_type import _DataType
+from verta.registry import action_type as action_type_module
+from verta.registry import data_type as data_type_module
 
-from .. import utils
+from ..utils import sorted_subclasses
 
 pytestmark = pytest.mark.not_oss  # skip if run in oss setup. Applied to entire module
 
@@ -134,17 +134,24 @@ class TestModel:
 
 
 class TestActionTypes:
-    @pytest.mark.parametrize("action_type_cls", utils.sorted_subclasses(_ActionType))
+    @pytest.mark.parametrize("action_type_cls", sorted_subclasses(action_type_module._ActionType))
     def test_creation(self, client, created_entities, action_type_cls):
+        if action_type_cls is action_type_module.Unknown:
+            pytest.skip("unsupported action type")
+
         action_type = action_type_cls()
 
         registered_model = client.create_registered_model(action_type=action_type)
         created_entities.append(registered_model)
 
+        registered_model = client.get_registered_model(id=registered_model.id)
         assert registered_model.get_action_type() == action_type
 
-    @pytest.mark.parametrize("action_type_cls", utils.sorted_subclasses(_ActionType))
+    @pytest.mark.parametrize("action_type_cls", sorted_subclasses(action_type_module._ActionType))
     def test_set(self, registered_model, action_type_cls):
+        if action_type_cls is action_type_module.Unknown:
+            pytest.skip("unsupported action type")
+
         action_type = action_type_cls()
 
         registered_model.set_action_type(action_type)
@@ -153,17 +160,24 @@ class TestActionTypes:
 
 
 class TestDataTypes:
-    @pytest.mark.parametrize("data_type_cls", utils.sorted_subclasses(_DataType))
+    @pytest.mark.parametrize("data_type_cls", sorted_subclasses(data_type_module._DataType))
     def test_creation(self, client, created_entities, data_type_cls):
+        if data_type_cls is data_type_module.Unknown:
+            pytest.skip("unsupported data type")
+
         data_type = data_type_cls()
 
         registered_model = client.create_registered_model(data_type=data_type)
         created_entities.append(registered_model)
 
+        registered_model = client.get_registered_model(id=registered_model.id)
         assert registered_model.get_data_type() == data_type
 
-    @pytest.mark.parametrize("data_type_cls", utils.sorted_subclasses(_DataType))
+    @pytest.mark.parametrize("data_type_cls", sorted_subclasses(data_type_module._DataType))
     def test_set(self, registered_model, data_type_cls):
+        if data_type_cls is data_type_module.Unknown:
+            pytest.skip("unsupported data type")
+
         data_type = data_type_cls()
 
         registered_model.set_data_type(data_type)

--- a/client/verta/tests/registry/test_model.py
+++ b/client/verta/tests/registry/test_model.py
@@ -2,6 +2,10 @@ import pytest
 import requests
 
 import verta
+from verta.registry import action_type as action_type_module
+from verta.registry import data_type as data_type_module
+
+from ..utils import sorted_subclasses
 
 pytestmark = pytest.mark.not_oss  # skip if run in oss setup. Applied to entire module
 
@@ -127,3 +131,54 @@ class TestModel:
         created_entities.append(registered_model)
         registered_model.set_description(desc)
         assert desc == registered_model.get_description()
+
+class TestActionTypes:
+    @pytest.mark.parametrize("action_type_cls", sorted_subclasses(action_type_module._ActionType))
+    def test_creation(self, client, created_entities, action_type_cls):
+        if action_type_cls is action_type_module._Unknown:
+            pytest.skip("unsupported action type")
+
+        action_type = action_type_cls()
+
+        registered_model = client.create_registered_model(action_type=action_type)
+        created_entities.append(registered_model)
+
+        registered_model = client.get_registered_model(id=registered_model.id)
+        assert registered_model.get_action_type() == action_type
+
+    @pytest.mark.parametrize("action_type_cls", sorted_subclasses(action_type_module._ActionType))
+    def test_set(self, registered_model, action_type_cls):
+        if action_type_cls is action_type_module._Unknown:
+            pytest.skip("unsupported action type")
+
+        action_type = action_type_cls()
+
+        registered_model.set_action_type(action_type)
+
+        assert registered_model.get_action_type() == action_type
+
+
+class TestDataTypes:
+    @pytest.mark.parametrize("data_type_cls", sorted_subclasses(data_type_module._DataType))
+    def test_creation(self, client, created_entities, data_type_cls):
+        if data_type_cls is data_type_module._Unknown:
+            pytest.skip("unsupported data type")
+
+        data_type = data_type_cls()
+
+        registered_model = client.create_registered_model(data_type=data_type)
+        created_entities.append(registered_model)
+
+        registered_model = client.get_registered_model(id=registered_model.id)
+        assert registered_model.get_data_type() == data_type
+
+    @pytest.mark.parametrize("data_type_cls", sorted_subclasses(data_type_module._DataType))
+    def test_set(self, registered_model, data_type_cls):
+        if data_type_cls is data_type_module._Unknown:
+            pytest.skip("unsupported data type")
+
+        data_type = data_type_cls()
+
+        registered_model.set_data_type(data_type)
+
+        assert registered_model.get_data_type() == data_type

--- a/client/verta/tests/test_cli/test_registry.py
+++ b/client/verta/tests/test_cli/test_registry.py
@@ -674,7 +674,7 @@ def test_multiple_attributes():
 class TestActionTypes:
     @pytest.mark.parametrize("action_type_cls", sorted_subclasses(action_type_module._ActionType))
     def test_creation(self, client, created_entities, action_type_cls):
-        if action_type_cls is action_type_module.Unknown:
+        if action_type_cls is action_type_module._Unknown:
             pytest.skip("unsupported action type")
 
         action_type = action_type_cls()
@@ -698,7 +698,7 @@ class TestActionTypes:
 class TestDataTypes:
     @pytest.mark.parametrize("data_type_cls", sorted_subclasses(data_type_module._DataType))
     def test_creation(self, client, created_entities, data_type_cls):
-        if data_type_cls is data_type_module.Unknown:
+        if data_type_cls is data_type_module._Unknown:
             pytest.skip("unsupported data type")
 
         data_type = data_type_cls()

--- a/client/verta/verta/_cli/registry/create.py
+++ b/client/verta/verta/_cli/registry/create.py
@@ -28,14 +28,16 @@ def create():
 @click.option("--label", "-l", multiple=True, help="Labels to be associated with the object.")
 @click.option("--visibility", "-v", default="private", show_default=True, type=click.Choice(["private", "org"], case_sensitive=False), help="Visibility level of the object.")
 @click.option("--workspace", "-w", help="Workspace to use.")
-def create_model(model_name, label, visibility, workspace, description):
+@click.option("--actionType", "-a", default="OTHER", show_default=True, type=click.Choice(["OTHER", "CLASSIFICATION", "CLUSTERING", "DETECTION", "REGRESSION", "TRANSCRIPTION", "TRANSLATION"], case_sensitive=True), help="Action type.")
+@click.option("--dataType", "-d", default="OTHER", show_default=True, type=click.Choice(["OTHER", "AUDIO", "IMAGE", "TABULAR", "TEXT", "VIDEO"], case_sensitive=True), help="Data type.")
+def create_model(model_name, label, visibility, workspace, description, actionType, dataType):
     """Create a new registeredmodel entry.
     """
     public_within_org = visibility == "org"
     client = Client()
 
     model = client.create_registered_model(model_name, workspace=workspace, public_within_org=public_within_org,
-                                           desc=description)
+                                           desc=description, actionType=actionType, dataType=dataType)
     for l in label:
         model.add_label(l)
 

--- a/client/verta/verta/_cli/registry/create.py
+++ b/client/verta/verta/_cli/registry/create.py
@@ -30,8 +30,8 @@ def create():
 @click.option("--label", "-l", multiple=True, help="Labels to be associated with the object.")
 @click.option("--visibility", "-v", default="private", show_default=True, type=click.Choice(["private", "org"], case_sensitive=False), help="Visibility level of the object.")
 @click.option("--workspace", "-w", help="Workspace to use.")
-@click.option("--action_type", "-a", default="other", show_default=True, type=click.Choice(["other", "classification", "clustering", "detection", "regression", "transcription", "translation"], case_sensitive=False), help="Action type.")
-@click.option("--data_type", "-d", default="other", show_default=True, type=click.Choice(["other", "audio", "image", "tabular", "text", "video"], case_sensitive=False), help="Data type.")
+@click.option("--action-type", default="other", show_default=True, type=click.Choice(["other", "classification", "clustering", "detection", "regression", "transcription", "translation"], case_sensitive=False), help="Action type.")
+@click.option("--data-type", default="other", show_default=True, type=click.Choice(["other", "audio", "image", "tabular", "text", "video"], case_sensitive=False), help="Data type.")
 def create_model(model_name, label, visibility, workspace, description, action_type, data_type):
     """Create a new registeredmodel entry.
     """

--- a/client/verta/verta/_cli/registry/create.py
+++ b/client/verta/verta/_cli/registry/create.py
@@ -5,8 +5,8 @@ import click
 from .registry import registry
 from ... import Client
 from .update import update_model_version
-from verta.registry import action_type as action
-from verta.registry import data_type as data
+from verta.registry import action_type as action_type_module
+from verta.registry import data_type as data_type_module
 
 
 @registry.group(name="create")

--- a/client/verta/verta/_cli/registry/create.py
+++ b/client/verta/verta/_cli/registry/create.py
@@ -40,13 +40,13 @@ def create_model(model_name, label, visibility, workspace, description, action_t
 
     if (action_type is not None):
         try:
-            action_type = action._ActionType._from_str(action_type)
+            action_type = action_type_module._ActionType._from_str(action_type)
         except ValueError:
             raise click.BadParameter("action type {} does not exist".format(action_type))
 
     if (data_type is not None):
         try:
-            data_type = data._DataType._from_str(data_type)
+            data_type = data_type_module._DataType._from_str(data_type)
         except ValueError:
             raise click.BadParameter("data type {} does not exist".format(data_type))
 

--- a/client/verta/verta/_cli/registry/create.py
+++ b/client/verta/verta/_cli/registry/create.py
@@ -5,6 +5,8 @@ import click
 from .registry import registry
 from ... import Client
 from .update import update_model_version
+from verta.registry import action_type as action
+from verta.registry import data_type as data
 
 
 @registry.group(name="create")
@@ -28,16 +30,28 @@ def create():
 @click.option("--label", "-l", multiple=True, help="Labels to be associated with the object.")
 @click.option("--visibility", "-v", default="private", show_default=True, type=click.Choice(["private", "org"], case_sensitive=False), help="Visibility level of the object.")
 @click.option("--workspace", "-w", help="Workspace to use.")
-@click.option("--actionType", "-a", default="OTHER", show_default=True, type=click.Choice(["OTHER", "CLASSIFICATION", "CLUSTERING", "DETECTION", "REGRESSION", "TRANSCRIPTION", "TRANSLATION"], case_sensitive=True), help="Action type.")
-@click.option("--dataType", "-d", default="OTHER", show_default=True, type=click.Choice(["OTHER", "AUDIO", "IMAGE", "TABULAR", "TEXT", "VIDEO"], case_sensitive=True), help="Data type.")
-def create_model(model_name, label, visibility, workspace, description, actionType, dataType):
+@click.option("--action_type", "-a", default="other", show_default=True, type=click.Choice(["other", "classification", "clustering", "detection", "regression", "transcription", "translation"], case_sensitive=False), help="Action type.")
+@click.option("--data_type", "-d", default="other", show_default=True, type=click.Choice(["other", "audio", "image", "tabular", "text", "video"], case_sensitive=False), help="Data type.")
+def create_model(model_name, label, visibility, workspace, description, action_type, data_type):
     """Create a new registeredmodel entry.
     """
     public_within_org = visibility == "org"
     client = Client()
 
+    if (action_type is not None):
+        try:
+            action_type = action._ActionType._from_str(action_type)
+        except ValueError:
+            raise click.BadParameter("action type {} does not exist".format(action_type))
+
+    if (data_type is not None):
+        try:
+            data_type = data._DataType._from_str(data_type)
+        except ValueError:
+            raise click.BadParameter("data type {} does not exist".format(data_type))
+
     model = client.create_registered_model(model_name, workspace=workspace, public_within_org=public_within_org,
-                                           desc=description, actionType=actionType, dataType=dataType)
+                                           desc=description, action_type=action_type, data_type=data_type)
     for l in label:
         model.add_label(l)
 

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -671,9 +671,9 @@ class Client(object):
         id : str, optional
             ID of the registered_model. This parameter cannot be provided alongside `name`, and other
             parameters will be ignored.
-        action_type : :mod:`~verta.registry.action_type`, default :class:`~verta.registry.action_type.Unknown`, optional
+        action_type : :mod:`~verta.registry.action_type`, optional
             Action type of the registered_model.
-        data_type : :mod:`~verta.registry.data_type`, default :class:`~verta.registry.data_type.Unknown`, optional
+        data_type : :mod:`~verta.registry.data_type`, optional
             Data type of the registered_model.
 
         Returns

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -640,7 +640,7 @@ class Client(object):
         """
         return self.set_experiment_run(*args, **kwargs)
 
-    def get_or_create_registered_model(self, name=None, desc=None, labels=None, workspace=None, public_within_org=None, visibility=None, id=None, actionType=None, dataType=None):
+    def get_or_create_registered_model(self, name=None, desc=None, labels=None, workspace=None, public_within_org=None, visibility=None, id=None, action_type=None, data_type=None):
         """
         Attaches a registered_model to this Client.
 
@@ -671,12 +671,11 @@ class Client(object):
         id : str, optional
             ID of the registered_model. This parameter cannot be provided alongside `name`, and other
             parameters will be ignored.
-        actionType : str, optional
+        action_type : :mod:`~verta.registry.action_type`, default :class:`~verta.registry.action_type.Unknown`, optional
             Action type of the registered_model.
-            OTHER, CLASSIFICATION, CLUSTERING, DETECTION, REGRESSION, TRANSCRIPTION, TRANSLATION
-        dataType : str, optional
+        data_type : :mod:`~verta.registry.data_type`, default :class:`~verta.registry.data_type.Unknown`, optional
             Data type of the registered_model.
-            OTHER, AUDIO, IMAGE, TABULAR, TEXT, VIDEO
+
         Returns
         -------
         :class:`~verta.registry.entities.RegisteredModel`
@@ -708,7 +707,7 @@ class Client(object):
         else:
             registered_model = RegisteredModel._get_or_create_by_name(self._conn, name,
                                                                   lambda name: RegisteredModel._get_by_name(self._conn, self._conf, name, ctx.workspace_name),
-                                                                  lambda name: RegisteredModel._create(self._conn, self._conf, ctx, name=name, desc=desc, tags=labels, public_within_org=public_within_org, visibility=visibility, actionType=actionType, dataType=dataType),
+                                                                  lambda name: RegisteredModel._create(self._conn, self._conf, ctx, name=name, desc=desc, tags=labels, public_within_org=public_within_org, visibility=visibility, action_type=action_type, data_type=data_type),
                                                                   lambda: check_unnecessary_params_warning(
                                                                       resource_name,
                                                                       "name {}".format(name),
@@ -1019,7 +1018,7 @@ class Client(object):
         return self._ctx.expt_run
 
 
-    def create_registered_model(self, name=None, desc=None, labels=None, workspace=None, public_within_org=None, visibility=None, actionType=None, dataType=None):
+    def create_registered_model(self, name=None, desc=None, labels=None, workspace=None, public_within_org=None, visibility=None, action_type=None, data_type=None):
         """
         Creates a new Registered Model.
 
@@ -1045,12 +1044,10 @@ class Client(object):
             Visibility to set when creating this registered model. If not
             provided, an appropriate default will be used. This parameter
             should be preferred over `public_within_org`.
-        actionType : str, optional
+        action_type : :mod:`~verta.registry.action_type`, default :class:`~verta.registry.action_type.Unknown`, optional
             Action type of the registered_model.
-            OTHER, CLASSIFICATION, CLUSTERING, DETECTION, REGRESSION, TRANSCRIPTION, TRANSLATION
-        dataType : str, optional
+        data_type : :mod:`~verta.registry.data_type`, default :class:`~verta.registry.data_type.Unknown`, optional
             Data type of the registered_model.
-            OTHER, AUDIO, IMAGE, TABULAR, TEXT, VIDEO
 
         Returns
         -------
@@ -1076,7 +1073,7 @@ class Client(object):
             self._conn, self._conf, ctx,
             name=name, desc=desc, tags=labels,
             public_within_org=public_within_org, visibility=visibility,
-            actionType=actionType, dataType=dataType,
+            action_type=action_type, data_type=data_type,
         )
 
 

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -640,7 +640,7 @@ class Client(object):
         """
         return self.set_experiment_run(*args, **kwargs)
 
-    def get_or_create_registered_model(self, name=None, desc=None, labels=None, workspace=None, public_within_org=None, visibility=None, id=None):
+    def get_or_create_registered_model(self, name=None, desc=None, labels=None, workspace=None, public_within_org=None, visibility=None, id=None, actionType=None, dataType=None):
         """
         Attaches a registered_model to this Client.
 
@@ -671,7 +671,12 @@ class Client(object):
         id : str, optional
             ID of the registered_model. This parameter cannot be provided alongside `name`, and other
             parameters will be ignored.
-
+        actionType : str, optional
+            Action type of the registered_model.
+            OTHER, CLASSIFICATION, CLUSTERING, DETECTION, REGRESSION, TRANSCRIPTION, TRANSLATION
+        dataType : str, optional
+            Data type of the registered_model.
+            OTHER, AUDIO, IMAGE, TABULAR, TEXT, VIDEO
         Returns
         -------
         :class:`~verta.registry.entities.RegisteredModel`
@@ -703,7 +708,7 @@ class Client(object):
         else:
             registered_model = RegisteredModel._get_or_create_by_name(self._conn, name,
                                                                   lambda name: RegisteredModel._get_by_name(self._conn, self._conf, name, ctx.workspace_name),
-                                                                  lambda name: RegisteredModel._create(self._conn, self._conf, ctx, name=name, desc=desc, tags=labels, public_within_org=public_within_org, visibility=visibility),
+                                                                  lambda name: RegisteredModel._create(self._conn, self._conf, ctx, name=name, desc=desc, tags=labels, public_within_org=public_within_org, visibility=visibility, actionType=actionType, dataType=dataType),
                                                                   lambda: check_unnecessary_params_warning(
                                                                       resource_name,
                                                                       "name {}".format(name),
@@ -1014,7 +1019,7 @@ class Client(object):
         return self._ctx.expt_run
 
 
-    def create_registered_model(self, name=None, desc=None, labels=None, workspace=None, public_within_org=None, visibility=None):
+    def create_registered_model(self, name=None, desc=None, labels=None, workspace=None, public_within_org=None, visibility=None, actionType=None, dataType=None):
         """
         Creates a new Registered Model.
 
@@ -1040,6 +1045,12 @@ class Client(object):
             Visibility to set when creating this registered model. If not
             provided, an appropriate default will be used. This parameter
             should be preferred over `public_within_org`.
+        actionType : str, optional
+            Action type of the registered_model.
+            OTHER, CLASSIFICATION, CLUSTERING, DETECTION, REGRESSION, TRANSCRIPTION, TRANSLATION
+        dataType : str, optional
+            Data type of the registered_model.
+            OTHER, AUDIO, IMAGE, TABULAR, TEXT, VIDEO
 
         Returns
         -------
@@ -1065,6 +1076,7 @@ class Client(object):
             self._conn, self._conf, ctx,
             name=name, desc=desc, tags=labels,
             public_within_org=public_within_org, visibility=visibility,
+            actionType=actionType, dataType=dataType,
         )
 
 

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -1044,9 +1044,9 @@ class Client(object):
             Visibility to set when creating this registered model. If not
             provided, an appropriate default will be used. This parameter
             should be preferred over `public_within_org`.
-        action_type : :mod:`~verta.registry.action_type`, default :class:`~verta.registry.action_type.Unknown`, optional
+        action_type : :mod:`~verta.registry.action_type`, optional
             Action type of the registered_model.
-        data_type : :mod:`~verta.registry.data_type`, default :class:`~verta.registry.data_type.Unknown`, optional
+        data_type : :mod:`~verta.registry.data_type`, optional
             Data type of the registered_model.
 
         Returns

--- a/client/verta/verta/registry/action_type/__init__.py
+++ b/client/verta/verta/registry/action_type/__init__.py
@@ -11,6 +11,7 @@ from ._detection import Detection
 from ._regression import Regression
 from ._transcription import Transcription
 from ._translation import Translation
+from ._unknown import Unknown
 
 documentation.reassign_module(
     [
@@ -21,6 +22,7 @@ documentation.reassign_module(
         Regression,
         Transcription,
         Translation,
+        Unknown,
     ],
     module_name=__name__,
 )
@@ -32,3 +34,4 @@ detection = Detection()
 regression = Regression()
 transcription = Transcription()
 translation = Translation()
+unknown = Unknown()

--- a/client/verta/verta/registry/action_type/__init__.py
+++ b/client/verta/verta/registry/action_type/__init__.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+"""Action type for registered models."""
+
+from verta._internal_utils import documentation
+
+from ._action_type import _ActionType
+from ._other import Other
+from ._classification import Classification
+from ._clustering import Clustering
+from ._detection import Detection
+from ._regression import Regression
+from ._transcription import Transcription
+from ._translation import Translation
+
+documentation.reassign_module(
+    [
+        Other,
+        Classification,
+        Clustering,
+        Detection,
+        Regression,
+        Transcription,
+        Translation,
+    ],
+    module_name=__name__,
+)
+
+other = Other()
+classification = Classification()
+clustering = Clustering()
+detection = Detection()
+regression = Regression()
+transcription = Transcription()
+translation = Translation()

--- a/client/verta/verta/registry/action_type/__init__.py
+++ b/client/verta/verta/registry/action_type/__init__.py
@@ -11,7 +11,7 @@ from ._detection import Detection
 from ._regression import Regression
 from ._transcription import Transcription
 from ._translation import Translation
-from ._unknown import Unknown
+from ._unknown import _Unknown
 
 documentation.reassign_module(
     [
@@ -22,7 +22,7 @@ documentation.reassign_module(
         Regression,
         Transcription,
         Translation,
-        Unknown,
+        _Unknown,
     ],
     module_name=__name__,
 )
@@ -34,4 +34,4 @@ detection = Detection()
 regression = Regression()
 transcription = Transcription()
 translation = Translation()
-unknown = Unknown()
+unknown = _Unknown()

--- a/client/verta/verta/registry/action_type/_action_type.py
+++ b/client/verta/verta/registry/action_type/_action_type.py
@@ -1,0 +1,50 @@
+import abc
+
+from ...external import six
+
+
+@six.add_metaclass(abc.ABCMeta)
+class _ActionType(object):
+    """
+    Base class for action type. Not for external use.
+
+    """
+
+    _ACTION_TYPE = None
+
+    def __repr__(self):
+        return "<{} action type>".format(self.__class__.__name__)
+
+    def _as_proto(self):
+        return self._ACTION_TYPE
+
+    @staticmethod
+    def _from_proto(action_type):
+        """
+        Parameters
+        ----------
+        action_type : ``RegistryService_pb2.ActionTypeEnum.ActionType``
+
+        Returns
+        -------
+        :class:`_ActionType`
+
+        """
+        # imports here to avoid circular import in Python 2
+        from . import (
+            Other,
+            Classification,
+            Clustering,
+            Detection,
+            Regression,
+            Transcription,
+            Translation,
+        )
+
+        for action_type_cls in (Other, Classification, Clustering, Detection, Regression, Transcription, Translation):
+            if action_type == action_type_cls._ACTION_TYPE:
+                return action_type_cls()
+        else:
+            raise ValueError(
+                "unrecognized action type {}".format(action_type)
+            )

--- a/client/verta/verta/registry/action_type/_action_type.py
+++ b/client/verta/verta/registry/action_type/_action_type.py
@@ -49,3 +49,35 @@ class _ActionType(object):
             raise ValueError(
                 "unrecognized action type {}".format(action_type)
             )
+
+    @staticmethod
+    def _from_str(action_type_str):
+        """
+        Parameters
+        ----------
+        action_type : Action type name.
+
+        Returns
+        -------
+        :class:`_ActionType`
+
+        """
+        # imports here to avoid circular import in Python 2
+        from . import (
+            Other,
+            Classification,
+            Clustering,
+            Detection,
+            Regression,
+            Transcription,
+            Translation,
+            Unknown,
+        )
+        
+        for action_type_cls in (Other, Classification, Clustering, Detection, Regression, Transcription, Translation, Unknown):            
+            if action_type_str.lower() == action_type_cls.__qualname__.lower():
+                return action_type_cls()
+        else:
+            raise ValueError(
+                "unrecognized action type {}".format(action_type_str)
+            )

--- a/client/verta/verta/registry/action_type/_action_type.py
+++ b/client/verta/verta/registry/action_type/_action_type.py
@@ -75,7 +75,7 @@ class _ActionType(object):
         )
         
         for action_type_cls in (Other, Classification, Clustering, Detection, Regression, Transcription, Translation, Unknown):            
-            if action_type_str.lower() == action_type_cls.__qualname__.lower():
+            if action_type_str.lower() == action_type_cls.__name__.lower():
                 return action_type_cls()
         else:
             raise ValueError(

--- a/client/verta/verta/registry/action_type/_action_type.py
+++ b/client/verta/verta/registry/action_type/_action_type.py
@@ -44,10 +44,10 @@ class _ActionType(object):
             Regression,
             Transcription,
             Translation,
-            Unknown,
+            _Unknown,
         )
 
-        for action_type_cls in (Other, Classification, Clustering, Detection, Regression, Transcription, Translation, Unknown):
+        for action_type_cls in (Other, Classification, Clustering, Detection, Regression, Transcription, Translation, _Unknown):
             if action_type == action_type_cls._ACTION_TYPE:
                 return action_type_cls()
         else:
@@ -76,10 +76,9 @@ class _ActionType(object):
             Regression,
             Transcription,
             Translation,
-            Unknown,
         )
         
-        for action_type_cls in (Other, Classification, Clustering, Detection, Regression, Transcription, Translation, Unknown):            
+        for action_type_cls in (Other, Classification, Clustering, Detection, Regression, Transcription, Translation):            
             if action_type_str.lower() == action_type_cls.__name__.lower():
                 return action_type_cls()
         else:

--- a/client/verta/verta/registry/action_type/_action_type.py
+++ b/client/verta/verta/registry/action_type/_action_type.py
@@ -12,6 +12,11 @@ class _ActionType(object):
 
     _ACTION_TYPE = None
 
+    def __eq__(self, other):
+        if type(self) is not type(other):
+            return NotImplemented
+        return self._as_proto() == other._as_proto()
+
     def __repr__(self):
         return "<{} action type>".format(self.__class__.__name__)
 

--- a/client/verta/verta/registry/action_type/_action_type.py
+++ b/client/verta/verta/registry/action_type/_action_type.py
@@ -76,9 +76,10 @@ class _ActionType(object):
             Regression,
             Transcription,
             Translation,
+            _Unknown,
         )
         
-        for action_type_cls in (Other, Classification, Clustering, Detection, Regression, Transcription, Translation):            
+        for action_type_cls in (Other, Classification, Clustering, Detection, Regression, Transcription, Translation, _Unknown):            
             if action_type_str.lower() == action_type_cls.__name__.lower():
                 return action_type_cls()
         else:

--- a/client/verta/verta/registry/action_type/_action_type.py
+++ b/client/verta/verta/registry/action_type/_action_type.py
@@ -39,9 +39,10 @@ class _ActionType(object):
             Regression,
             Transcription,
             Translation,
+            Unknown,
         )
 
-        for action_type_cls in (Other, Classification, Clustering, Detection, Regression, Transcription, Translation):
+        for action_type_cls in (Other, Classification, Clustering, Detection, Regression, Transcription, Translation, Unknown):
             if action_type == action_type_cls._ACTION_TYPE:
                 return action_type_cls()
         else:

--- a/client/verta/verta/registry/action_type/_classification.py
+++ b/client/verta/verta/registry/action_type/_classification.py
@@ -1,0 +1,19 @@
+from ..._protos.public.registry import RegistryService_pb2
+
+from . import _ActionType
+
+
+class Classification(_ActionType):
+    """
+    Classification action of the registered model.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        from verta.registry import action_type
+        reg_model = client.create_registered_model("My Model", workspace="my-org", action_type=action_type.Classification())
+
+    """
+
+    _ACTION_TYPE = RegistryService_pb2.ActionTypeEnum.ActionType.CLASSIFICATION

--- a/client/verta/verta/registry/action_type/_clustering.py
+++ b/client/verta/verta/registry/action_type/_clustering.py
@@ -1,0 +1,19 @@
+from ..._protos.public.registry import RegistryService_pb2
+
+from . import _ActionType
+
+
+class Clustering(_ActionType):
+    """
+    Clustering action of the registered model.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        from verta.registry import action_type
+        reg_model = client.create_registered_model("My Model", workspace="my-org", action_type=action_type.Clustering())
+
+    """
+
+    _ACTION_TYPE = RegistryService_pb2.ActionTypeEnum.ActionType.CLUSTERING

--- a/client/verta/verta/registry/action_type/_detection.py
+++ b/client/verta/verta/registry/action_type/_detection.py
@@ -1,0 +1,19 @@
+from ..._protos.public.registry import RegistryService_pb2
+
+from . import _ActionType
+
+
+class Detection(_ActionType):
+    """
+    Detection action of the registered model.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        from verta.registry import action_type
+        reg_model = client.create_registered_model("My Model", workspace="my-org", action_type=action_type.Detection())
+
+    """
+
+    _ACTION_TYPE = RegistryService_pb2.ActionTypeEnum.ActionType.DETECTION

--- a/client/verta/verta/registry/action_type/_other.py
+++ b/client/verta/verta/registry/action_type/_other.py
@@ -1,0 +1,19 @@
+from ..._protos.public.registry import RegistryService_pb2
+
+from . import _ActionType
+
+
+class Other(_ActionType):
+    """
+    Other action of the registered model.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        from verta.registry import action_type
+        reg_model = client.create_registered_model("My Model", workspace="my-org", action_type=action_type.Other())
+
+    """
+
+    _ACTION_TYPE = RegistryService_pb2.ActionTypeEnum.ActionType.OTHER

--- a/client/verta/verta/registry/action_type/_regression.py
+++ b/client/verta/verta/registry/action_type/_regression.py
@@ -1,0 +1,19 @@
+from ..._protos.public.registry import RegistryService_pb2
+
+from . import _ActionType
+
+
+class Regression(_ActionType):
+    """
+    Regression action of the registered model.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        from verta.registry import action_type
+        reg_model = client.create_registered_model("My Model", workspace="my-org", action_type=action_type.Regression())
+
+    """
+
+    _ACTION_TYPE = RegistryService_pb2.ActionTypeEnum.ActionType.REGRESSION

--- a/client/verta/verta/registry/action_type/_transcription.py
+++ b/client/verta/verta/registry/action_type/_transcription.py
@@ -1,0 +1,19 @@
+from ..._protos.public.registry import RegistryService_pb2
+
+from . import _ActionType
+
+
+class Transcription(_ActionType):
+    """
+    Transcription action of the registered model.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        from verta.registry import action_type
+        reg_model = client.create_registered_model("My Model", workspace="my-org", action_type=action_type.Transcription())
+
+    """
+
+    _ACTION_TYPE = RegistryService_pb2.ActionTypeEnum.ActionType.TRANSCRIPTION

--- a/client/verta/verta/registry/action_type/_translation.py
+++ b/client/verta/verta/registry/action_type/_translation.py
@@ -1,0 +1,19 @@
+from ..._protos.public.registry import RegistryService_pb2
+
+from . import _ActionType
+
+
+class Translation(_ActionType):
+    """
+    Translation action of the registered model.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        from verta.registry import action_type
+        reg_model = client.create_registered_model("My Model", workspace="my-org", action_type=action_type.Translation())
+
+    """
+
+    _ACTION_TYPE = RegistryService_pb2.ActionTypeEnum.ActionType.TRANSLATION

--- a/client/verta/verta/registry/action_type/_unknown.py
+++ b/client/verta/verta/registry/action_type/_unknown.py
@@ -1,0 +1,19 @@
+from ..._protos.public.registry import RegistryService_pb2
+
+from . import _ActionType
+
+
+class Unknown(_ActionType):
+    """
+    Unknown action of the registered model.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        from verta.registry import action_type
+        reg_model = client.create_registered_model("My Model", workspace="my-org", action_type=action_type.Unknown())
+
+    """
+
+    _ACTION_TYPE = RegistryService_pb2.ActionTypeEnum.ActionType.UNKNOWN

--- a/client/verta/verta/registry/action_type/_unknown.py
+++ b/client/verta/verta/registry/action_type/_unknown.py
@@ -3,16 +3,9 @@ from ..._protos.public.registry import RegistryService_pb2
 from . import _ActionType
 
 
-class Unknown(_ActionType):
+class _Unknown(_ActionType):
     """
-    Unknown action of the registered model.
-
-    Examples
-    --------
-    .. code-block:: python
-
-        from verta.registry import action_type
-        reg_model = client.create_registered_model("My Model", workspace="my-org", action_type=action_type.Unknown())
+    Unknown action of the registered model. Not for external use.
 
     """
 

--- a/client/verta/verta/registry/data_type/__init__.py
+++ b/client/verta/verta/registry/data_type/__init__.py
@@ -11,7 +11,7 @@ from ._image import Image
 from ._tabular import Tabular
 from ._text import Text
 from ._video import Video
-from ._unknown import Unknown
+from ._unknown import _Unknown
 
 documentation.reassign_module(
     [
@@ -21,7 +21,7 @@ documentation.reassign_module(
         Tabular,
         Text,
         Video,
-        Unknown,
+        _Unknown,
     ],
     module_name=__name__,
 )
@@ -32,4 +32,4 @@ image = Image()
 tabular = Tabular()
 text = Text()
 video = Video()
-unknown = Unknown()
+unknown = _Unknown()

--- a/client/verta/verta/registry/data_type/__init__.py
+++ b/client/verta/verta/registry/data_type/__init__.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+"""Data type for registered models."""
+
+import imp
+from verta._internal_utils import documentation
+
+from ._data_type import _DataType
+from ._other import Other
+from ._audio import Audio
+from ._image import Image
+from ._tabular import Tabular
+from ._text import Text
+from ._video import Video
+from ._unknown import Unknown
+
+documentation.reassign_module(
+    [
+        Other,
+        Audio,
+        Image,
+        Tabular,
+        Text,
+        Video,
+        Unknown,
+    ],
+    module_name=__name__,
+)
+
+other = Other()
+audio = Audio()
+image = Image()
+tabular = Tabular()
+text = Text()
+video = Video()
+unknown = Unknown()

--- a/client/verta/verta/registry/data_type/_audio.py
+++ b/client/verta/verta/registry/data_type/_audio.py
@@ -1,0 +1,19 @@
+from ..._protos.public.registry import RegistryService_pb2
+
+from . import _DataType
+
+
+class Audio(_DataType):
+    """
+    Audio data of the registered model.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        from verta.registry import data_type
+        reg_model = client.create_registered_model("My Model", workspace="my-org", data_type=data_type.Audio())
+
+    """
+
+    _DATA_TYPE = RegistryService_pb2.DataTypeEnum.DataType.AUDIO

--- a/client/verta/verta/registry/data_type/_data_type.py
+++ b/client/verta/verta/registry/data_type/_data_type.py
@@ -43,10 +43,10 @@ class _DataType(object):
             Tabular,
             Text,
             Video,
-            Unknown,
+            _Unknown,
         )
 
-        for data_type_cls in (Other, Audio, Image, Tabular, Text, Video, Unknown):
+        for data_type_cls in (Other, Audio, Image, Tabular, Text, Video, _Unknown):
             if data_type == data_type_cls._DATA_TYPE:
                 return data_type_cls()
         else:
@@ -74,10 +74,9 @@ class _DataType(object):
             Tabular,
             Text,
             Video,
-            Unknown,
         )
 
-        for data_type_cls in (Other, Audio, Image, Tabular, Text, Video, Unknown):
+        for data_type_cls in (Other, Audio, Image, Tabular, Text, Video):
             if data_type_str.lower() == data_type_cls.__qualname__.lower():
                 return data_type_cls()
         else:

--- a/client/verta/verta/registry/data_type/_data_type.py
+++ b/client/verta/verta/registry/data_type/_data_type.py
@@ -1,0 +1,81 @@
+import abc
+
+from ...external import six
+
+
+@six.add_metaclass(abc.ABCMeta)
+class _DataType(object):
+    """
+    Base class for data type. Not for external use.
+
+    """
+
+    _DATA_TYPE = None
+
+    def __repr__(self):
+        return "<{} data type>".format(self.__class__.__name__)
+
+    def _as_proto(self):
+        return self._DATA_TYPE
+
+    @staticmethod
+    def _from_proto(data_type):
+        """
+        Parameters
+        ----------
+        data_type : ``RegistryService_pb2.DataTypeEnum.DataType.OTHER``
+
+        Returns
+        -------
+        :class:`_DataType`
+
+        """
+        # imports here to avoid circular import in Python 2
+        from . import (
+            Other,
+            Audio,
+            Image,
+            Tabular,
+            Text,
+            Video,
+            Unknown,
+        )
+
+        for data_type_cls in (Other, Audio, Image, Tabular, Text, Video, Unknown):
+            if data_type == data_type_cls._DATA_TYPE:
+                return data_type_cls()
+        else:
+            raise ValueError(
+                "unrecognized data type {}".format(data_type)
+            )
+
+    @staticmethod
+    def _from_str(data_type_str):
+        """
+        Parameters
+        ----------
+        data_type : Data type name.
+
+        Returns
+        -------
+        :class:`_DataType`
+
+        """
+        # imports here to avoid circular import in Python 2
+        from . import (
+            Other,
+            Audio,
+            Image,
+            Tabular,
+            Text,
+            Video,
+            Unknown,
+        )
+        
+        for data_type_cls in (Other, Audio, Image, Tabular, Text, Video, Unknown):
+            if data_type_str.lower() == data_type_cls.__qualname__.lower():
+                return data_type_cls()
+        else:
+            raise ValueError(
+                "unrecognized data type {}".format(data_type_str)
+            )

--- a/client/verta/verta/registry/data_type/_data_type.py
+++ b/client/verta/verta/registry/data_type/_data_type.py
@@ -23,7 +23,7 @@ class _DataType(object):
         """
         Parameters
         ----------
-        data_type : ``RegistryService_pb2.DataTypeEnum.DataType.OTHER``
+        data_type : ``RegistryService_pb2.DataTypeEnum.DataType``
 
         Returns
         -------

--- a/client/verta/verta/registry/data_type/_data_type.py
+++ b/client/verta/verta/registry/data_type/_data_type.py
@@ -74,10 +74,11 @@ class _DataType(object):
             Tabular,
             Text,
             Video,
+            _Unknown
         )
 
-        for data_type_cls in (Other, Audio, Image, Tabular, Text, Video):
-            if data_type_str.lower() == data_type_cls.__qualname__.lower():
+        for data_type_cls in (Other, Audio, Image, Tabular, Text, Video, _Unknown):
+            if data_type_str.lower() == data_type_cls.__name__.lower():
                 return data_type_cls()
         else:
             raise ValueError(

--- a/client/verta/verta/registry/data_type/_data_type.py
+++ b/client/verta/verta/registry/data_type/_data_type.py
@@ -12,6 +12,11 @@ class _DataType(object):
 
     _DATA_TYPE = None
 
+    def __eq__(self, other):
+        if type(self) is not type(other):
+            return NotImplemented
+        return self._as_proto() == other._as_proto()
+
     def __repr__(self):
         return "<{} data type>".format(self.__class__.__name__)
 
@@ -71,7 +76,7 @@ class _DataType(object):
             Video,
             Unknown,
         )
-        
+
         for data_type_cls in (Other, Audio, Image, Tabular, Text, Video, Unknown):
             if data_type_str.lower() == data_type_cls.__qualname__.lower():
                 return data_type_cls()

--- a/client/verta/verta/registry/data_type/_image.py
+++ b/client/verta/verta/registry/data_type/_image.py
@@ -1,0 +1,19 @@
+from ..._protos.public.registry import RegistryService_pb2
+
+from . import _DataType
+
+
+class Image(_DataType):
+    """
+    Image data of the registered model.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        from verta.registry import data_type
+        reg_model = client.create_registered_model("My Model", workspace="my-org", data_type=data_type.Image())
+
+    """
+
+    _DATA_TYPE = RegistryService_pb2.DataTypeEnum.DataType.IMAGE

--- a/client/verta/verta/registry/data_type/_other.py
+++ b/client/verta/verta/registry/data_type/_other.py
@@ -1,0 +1,19 @@
+from ..._protos.public.registry import RegistryService_pb2
+
+from . import _DataType
+
+
+class Other(_DataType):
+    """
+    Other data of the registered model.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        from verta.registry import data_type
+        reg_model = client.create_registered_model("My Model", workspace="my-org", data_type=data_type.Other())
+
+    """
+
+    _DATA_TYPE = RegistryService_pb2.DataTypeEnum.DataType.OTHER

--- a/client/verta/verta/registry/data_type/_tabular.py
+++ b/client/verta/verta/registry/data_type/_tabular.py
@@ -1,0 +1,19 @@
+from ..._protos.public.registry import RegistryService_pb2
+
+from . import _DataType
+
+
+class Tabular(_DataType):
+    """
+    Tabular data of the registered model.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        from verta.registry import data_type
+        reg_model = client.create_registered_model("My Model", workspace="my-org", data_type=data_type.Tabular())
+
+    """
+
+    _DATA_TYPE = RegistryService_pb2.DataTypeEnum.DataType.TABULAR

--- a/client/verta/verta/registry/data_type/_text.py
+++ b/client/verta/verta/registry/data_type/_text.py
@@ -1,0 +1,19 @@
+from ..._protos.public.registry import RegistryService_pb2
+
+from . import _DataType
+
+
+class Text(_DataType):
+    """
+    Text data of the registered model.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        from verta.registry import data_type
+        reg_model = client.create_registered_model("My Model", workspace="my-org", data_type=data_type.Text())
+
+    """
+
+    _DATA_TYPE = RegistryService_pb2.DataTypeEnum.DataType.TEXT

--- a/client/verta/verta/registry/data_type/_unknown.py
+++ b/client/verta/verta/registry/data_type/_unknown.py
@@ -1,0 +1,19 @@
+from ..._protos.public.registry import RegistryService_pb2
+
+from . import _DataType
+
+
+class Unknown(_DataType):
+    """
+    Unknown data of the registered model.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        from verta.registry import data_type
+        reg_model = client.create_registered_model("My Model", workspace="my-org", data_type=data_type.Unknown())
+
+    """
+
+    _DATA_TYPE = RegistryService_pb2.DataTypeEnum.DataType.UNKNOWN

--- a/client/verta/verta/registry/data_type/_unknown.py
+++ b/client/verta/verta/registry/data_type/_unknown.py
@@ -3,16 +3,9 @@ from ..._protos.public.registry import RegistryService_pb2
 from . import _DataType
 
 
-class Unknown(_DataType):
+class _Unknown(_DataType):
     """
-    Unknown data of the registered model.
-
-    Examples
-    --------
-    .. code-block:: python
-
-        from verta.registry import data_type
-        reg_model = client.create_registered_model("My Model", workspace="my-org", data_type=data_type.Unknown())
+    Unknown data of the registered model. Not for external use.
 
     """
 

--- a/client/verta/verta/registry/data_type/_video.py
+++ b/client/verta/verta/registry/data_type/_video.py
@@ -1,0 +1,19 @@
+from ..._protos.public.registry import RegistryService_pb2
+
+from . import _DataType
+
+
+class Video(_DataType):
+    """
+    Video data of the registered model.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        from verta.registry import data_type
+        reg_model = client.create_registered_model("My Model", workspace="my-org", data_type=data_type.Video())
+
+    """
+
+    _DATA_TYPE = RegistryService_pb2.DataTypeEnum.DataType.VIDEO

--- a/client/verta/verta/registry/entities/_model.py
+++ b/client/verta/verta/registry/entities/_model.py
@@ -921,7 +921,7 @@ class RegisteredModel(_entity._ModelDBEntity):
                 " not {}".format(type(action_type))
             )
 
-        self._update(self.RegisteredModelMessage(action_type=action_type))
+        self._update(self.RegisteredModelMessage(action_type=action_type._as_proto()))
 
     def get_action_type(self):
         self._refresh_cache()

--- a/client/verta/verta/registry/entities/_model.py
+++ b/client/verta/verta/registry/entities/_model.py
@@ -915,7 +915,7 @@ class RegisteredModel(_entity._ModelDBEntity):
         _utils.raise_for_http_error(response)
 
     def set_action_type(self, action_type):
-        if not isinstance(action_type, action):
+        if not isinstance(action_type, action._ActionType):
             raise ValueError(
                 "`action_type` must be an object from verta.registry.action_type,"
                 " not {}".format(type(action_type))

--- a/client/verta/verta/registry/entities/_model.py
+++ b/client/verta/verta/registry/entities/_model.py
@@ -929,7 +929,10 @@ class RegisteredModel(_entity._ModelDBEntity):
 
     def set_data_type(self, data_type):
         if not isinstance(data_type, data):
-            raise ValueError("data_type is not specified")
+            raise ValueError(
+                "`data_type` must be an object from verta.registry.data_type,"
+                " not {}".format(type(data_type))
+            )
 
         self._update(self.RegisteredModelMessage(data_type=data_type._as_proto()))
 

--- a/client/verta/verta/registry/entities/_model.py
+++ b/client/verta/verta/registry/entities/_model.py
@@ -801,9 +801,9 @@ class RegisteredModel(_entity._ModelDBEntity):
     @classmethod
     def _create_proto_internal(cls, conn, ctx, name, desc=None, tags=None, attrs=None, date_created=None, public_within_org=None, visibility=None, action_type=None, data_type=None):
         if action_type is None:
-            action_type = action.Unknown()
+            action_type = action_type_module._Unknown()
         if data_type is None:
-            data_type = data.Unknown()
+            data_type = data_type_module._Unknown()
         Message = _RegistryService.RegisteredModel
         msg = Message(name=name, description=desc, labels=tags, time_created=date_created, time_updated=date_created, action_type=action_type._as_proto(), data_type=data_type._as_proto())
         if (public_within_org
@@ -915,7 +915,16 @@ class RegisteredModel(_entity._ModelDBEntity):
         _utils.raise_for_http_error(response)
 
     def set_action_type(self, action_type):
-        if not isinstance(action_type, action._ActionType):
+        """
+        Sets this registered model action type
+
+        Parameters
+        ----------
+        action_type : :mod:`~verta.registry.action_type`
+            Action type to set.
+
+        """
+        if not isinstance(action_type, action_type_module._ActionType):
             raise ValueError(
                 "`action_type` must be an object from verta.registry.action_type,"
                 " not {}".format(type(action_type))
@@ -924,11 +933,29 @@ class RegisteredModel(_entity._ModelDBEntity):
         self._update(self.RegisteredModelMessage(action_type=action_type._as_proto()))
 
     def get_action_type(self):
+        """
+        Gets this registered model action type
+
+        Returns
+        -------
+        action_type : :mod:`~verta.registry.action_type`
+            This registered model action type.
+
+        """
         self._refresh_cache()
-        return action._ActionType._from_proto(self._msg.action_type)
+        return action_type_module._ActionType._from_proto(self._msg.action_type)
 
     def set_data_type(self, data_type):
-        if not isinstance(data_type, data):
+        """
+        Sets this registered model data type
+
+        Parameters
+        ----------
+        data_type : :mod:`~verta.registry.data_type`
+            Data type to set.
+
+        """
+        if not isinstance(data_type, data_type_module._DataType):
             raise ValueError(
                 "`data_type` must be an object from verta.registry.data_type,"
                 " not {}".format(type(data_type))
@@ -937,5 +964,14 @@ class RegisteredModel(_entity._ModelDBEntity):
         self._update(self.RegisteredModelMessage(data_type=data_type._as_proto()))
 
     def get_data_type(self):
+        """
+        Gets this registered model data type
+
+        Returns
+        -------
+        data_type : :mod:`~verta.registry.data_type`
+            This registered model data type.
+
+        """
         self._refresh_cache()
-        return data._DataType._from_proto(self._msg.data_type)
+        return data_type_module._DataType._from_proto(self._msg.data_type)

--- a/client/verta/verta/registry/entities/_model.py
+++ b/client/verta/verta/registry/entities/_model.py
@@ -797,9 +797,9 @@ class RegisteredModel(_entity._ModelDBEntity):
         return conn.maybe_proto_response(response, Message.Response).registered_model
 
     @classmethod
-    def _create_proto_internal(cls, conn, ctx, name, desc=None, tags=None, attrs=None, date_created=None, public_within_org=None, visibility=None):
+    def _create_proto_internal(cls, conn, ctx, name, desc=None, tags=None, attrs=None, date_created=None, public_within_org=None, visibility=None, actionType=None, dataType=None):
         Message = _RegistryService.RegisteredModel
-        msg = Message(name=name, description=desc, labels=tags, time_created=date_created, time_updated=date_created)
+        msg = Message(name=name, description=desc, labels=tags, time_created=date_created, time_updated=date_created, action_type=actionType, data_type=dataType)
         if (public_within_org
                 and ctx.workspace_name is not None  # not user's personal workspace
                 and _utils.is_org(ctx.workspace_name, conn)):  # not anyone's personal workspace
@@ -907,3 +907,21 @@ class RegisteredModel(_entity._ModelDBEntity):
         request_url = "{}://{}/api/v1/registry/registered_models/{}".format(self._conn.scheme, self._conn.socket, self.id)
         response = _utils.make_request("DELETE", request_url, self._conn)
         _utils.raise_for_http_error(response)
+
+    def set_actionType(self, actionType):
+        if not actionType:
+            raise ValueError("actionType is not specified")
+        self._update(self.RegisteredModelMessage(action_type=actionType))
+
+    def get_actionType(self):
+        self._refresh_cache()
+        return self._msg.action_type
+
+    def set_dataType(self, dataType):
+        if not dataType:
+            raise ValueError("dataType is not specified")
+        self._update(self.RegisteredModelMessage(data_type=dataType))
+
+    def get_dataType(self):
+        self._refresh_cache()
+        return self._msg.data_type

--- a/client/verta/verta/registry/entities/_model.py
+++ b/client/verta/verta/registry/entities/_model.py
@@ -13,8 +13,8 @@ from verta._protos.public.registry import RegistryService_pb2 as _RegistryServic
 from .. import _constants, VertaModelBase
 from ._modelversion import RegisteredModelVersion
 from ._modelversions import RegisteredModelVersions
-from .. import action_type as action
-from .. import data_type as data
+from .. import action_type as action_type_module
+from .. import data_type as data_type_module
 
 
 class RegisteredModel(_entity._ModelDBEntity):

--- a/client/verta/verta/registry/entities/_model.py
+++ b/client/verta/verta/registry/entities/_model.py
@@ -916,7 +916,10 @@ class RegisteredModel(_entity._ModelDBEntity):
 
     def set_action_type(self, action_type):
         if not isinstance(action_type, action):
-            raise ValueError("action_type is not specified")
+            raise ValueError(
+                "`action_type` must be an object from verta.registry.action_type,"
+                " not {}".format(type(action_type))
+            )
 
         self._update(self.RegisteredModelMessage(action_type=action_type))
 

--- a/client/verta/verta/registry/entities/_model.py
+++ b/client/verta/verta/registry/entities/_model.py
@@ -931,7 +931,7 @@ class RegisteredModel(_entity._ModelDBEntity):
         if not isinstance(data_type, data):
             raise ValueError("data_type is not specified")
 
-        self._update(self.RegisteredModelMessage(data_type=data_type))
+        self._update(self.RegisteredModelMessage(data_type=data_type._as_proto()))
 
     def get_data_type(self):
         self._refresh_cache()

--- a/client/verta/verta/tracking/entities/_entity.py
+++ b/client/verta/verta/tracking/entities/_entity.py
@@ -200,7 +200,7 @@ class _ModelDBEntity(object):
         return cls._create_proto_internal(conn, *args, **kwargs)
 
     @classmethod
-    def _create_proto_internal(cls, conn, ctx, name, desc=None, tags=None, attrs=None, date_created=None, **kwargs):  # recommended params
+    def _create_proto_internal(cls, conn, ctx, name, desc=None, tags=None, attrs=None, date_created=None, actionType=None, dataType=None, **kwargs):  # recommended params
         raise NotImplementedError
 
     def log_code(self, exec_path=None, repo_url=None, commit_hash=None, overwrite=False, is_dirty=None, autocapture=True):

--- a/client/verta/verta/tracking/entities/_entity.py
+++ b/client/verta/verta/tracking/entities/_entity.py
@@ -200,7 +200,7 @@ class _ModelDBEntity(object):
         return cls._create_proto_internal(conn, *args, **kwargs)
 
     @classmethod
-    def _create_proto_internal(cls, conn, ctx, name, desc=None, tags=None, attrs=None, date_created=None, action_type=None, data_type=None, **kwargs):  # recommended params
+    def _create_proto_internal(cls, conn, ctx, name, desc=None, tags=None, attrs=None, date_created=None, **kwargs):  # recommended params
         raise NotImplementedError
 
     def log_code(self, exec_path=None, repo_url=None, commit_hash=None, overwrite=False, is_dirty=None, autocapture=True):

--- a/client/verta/verta/tracking/entities/_entity.py
+++ b/client/verta/verta/tracking/entities/_entity.py
@@ -200,7 +200,7 @@ class _ModelDBEntity(object):
         return cls._create_proto_internal(conn, *args, **kwargs)
 
     @classmethod
-    def _create_proto_internal(cls, conn, ctx, name, desc=None, tags=None, attrs=None, date_created=None, actionType=None, dataType=None, **kwargs):  # recommended params
+    def _create_proto_internal(cls, conn, ctx, name, desc=None, tags=None, attrs=None, date_created=None, action_type=None, data_type=None, **kwargs):  # recommended params
         raise NotImplementedError
 
     def log_code(self, exec_path=None, repo_url=None, commit_hash=None, overwrite=False, is_dirty=None, autocapture=True):


### PR DESCRIPTION
# Summary

Modify python CLI to accept new attributes

# References

https://vertaai.atlassian.net/browse/CAT-49?atlOrigin=eyJpIjoiNmFkZWJhZTQzOTljNDk0ZmFkZmY3NTNmNTlkNDFmYWYiLCJwIjoiaiJ9

# Test Result (2022-08-18)
```
export VERTA_HOST="https://modelcatalog.dev.verta.ai/"
export VERTA_EMAIL="marcelo@verta.ai"
export VERTA_DEV_KEY="7ae98d72-d0dd-4034-9fb1-e2f79e894fd9"
pytest-3 -k "TestActionTypes or TestDataTypes" -vvra
================================================================================== test session starts ===================================================================================
platform linux -- Python 3.8.10, pytest-4.6.9, py-1.8.1, pluggy-0.13.0 -- /usr/bin/python3
cachedir: .pytest_cache
hypothesis profile 'default' -> suppress_health_check=[HealthCheck.too_slow], database=DirectoryBasedExampleDatabase('/opt/repositorio-git/verta/modeldb/client/verta/tests/.hypothesis/examples')
rootdir: /opt/repositorio-git/verta/modeldb/client/verta/tests, inifile: pytest.ini
plugins: hypothesis-4.36.2
collected 1342 items / 1297 deselected / 3 skipped / 42 selected                                                                                                                         

registry/test_model.py::TestActionTypes::test_creation[Classification] PASSED                                                                                                      [  2%]
registry/test_model.py::TestActionTypes::test_creation[Clustering] PASSED                                                                                                          [  4%]
registry/test_model.py::TestActionTypes::test_creation[Detection] PASSED                                                                                                           [  6%]
registry/test_model.py::TestActionTypes::test_creation[Other] PASSED                                                                                                               [  8%]
registry/test_model.py::TestActionTypes::test_creation[Regression] PASSED                                                                                                          [ 11%]
registry/test_model.py::TestActionTypes::test_creation[Transcription] PASSED                                                                                                       [ 13%]
registry/test_model.py::TestActionTypes::test_creation[Translation] PASSED                                                                                                         [ 15%]
registry/test_model.py::TestActionTypes::test_creation[_Unknown] SKIPPED                                                                                                           [ 17%]
registry/test_model.py::TestActionTypes::test_set[Classification] PASSED                                                                                                           [ 20%]
registry/test_model.py::TestActionTypes::test_set[Clustering] PASSED                                                                                                               [ 22%]
registry/test_model.py::TestActionTypes::test_set[Detection] PASSED                                                                                                                [ 24%]
registry/test_model.py::TestActionTypes::test_set[Other] PASSED                                                                                                                    [ 26%]
registry/test_model.py::TestActionTypes::test_set[Regression] PASSED                                                                                                               [ 28%]
registry/test_model.py::TestActionTypes::test_set[Transcription] PASSED                                                                                                            [ 31%]
registry/test_model.py::TestActionTypes::test_set[Translation] PASSED                                                                                                              [ 33%]
registry/test_model.py::TestActionTypes::test_set[_Unknown] SKIPPED                                                                                                                [ 35%]
registry/test_model.py::TestDataTypes::test_creation[Audio] PASSED                                                                                                                 [ 37%]
registry/test_model.py::TestDataTypes::test_creation[Image] PASSED                                                                                                                 [ 40%]
registry/test_model.py::TestDataTypes::test_creation[Other] PASSED                                                                                                                 [ 42%]
registry/test_model.py::TestDataTypes::test_creation[Tabular] PASSED                                                                                                               [ 44%]
registry/test_model.py::TestDataTypes::test_creation[Text] PASSED                                                                                                                  [ 46%]
registry/test_model.py::TestDataTypes::test_creation[Video] PASSED                                                                                                                 [ 48%]
registry/test_model.py::TestDataTypes::test_creation[_Unknown] SKIPPED                                                                                                             [ 51%]
registry/test_model.py::TestDataTypes::test_set[Audio] PASSED                                                                                                                      [ 53%]
registry/test_model.py::TestDataTypes::test_set[Image] PASSED                                                                                                                      [ 55%]
registry/test_model.py::TestDataTypes::test_set[Other] PASSED                                                                                                                      [ 57%]
registry/test_model.py::TestDataTypes::test_set[Tabular] PASSED                                                                                                                    [ 60%]
registry/test_model.py::TestDataTypes::test_set[Text] PASSED                                                                                                                       [ 62%]
registry/test_model.py::TestDataTypes::test_set[Video] PASSED                                                                                                                      [ 64%]
registry/test_model.py::TestDataTypes::test_set[_Unknown] SKIPPED                                                                                                                  [ 66%]
test_cli/test_registry.py::TestActionTypes::test_creation[Classification] PASSED                                                                                                   [ 68%]
test_cli/test_registry.py::TestActionTypes::test_creation[Clustering] PASSED                                                                                                       [ 71%]
test_cli/test_registry.py::TestActionTypes::test_creation[Detection] PASSED                                                                                                        [ 73%]
test_cli/test_registry.py::TestActionTypes::test_creation[Other] PASSED                                                                                                            [ 75%]
test_cli/test_registry.py::TestActionTypes::test_creation[Regression] PASSED                                                                                                       [ 77%]
test_cli/test_registry.py::TestActionTypes::test_creation[Transcription] PASSED                                                                                                    [ 80%]
test_cli/test_registry.py::TestActionTypes::test_creation[Translation] PASSED                                                                                                      [ 82%]
test_cli/test_registry.py::TestActionTypes::test_creation[_Unknown] SKIPPED                                                                                                        [ 84%]
test_cli/test_registry.py::TestDataTypes::test_creation[Audio] PASSED                                                                                                              [ 86%]
test_cli/test_registry.py::TestDataTypes::test_creation[Image] PASSED                                                                                                              [ 88%]
test_cli/test_registry.py::TestDataTypes::test_creation[Other] PASSED                                                                                                              [ 91%]
test_cli/test_registry.py::TestDataTypes::test_creation[Tabular] PASSED                                                                                                            [ 93%]
test_cli/test_registry.py::TestDataTypes::test_creation[Text] PASSED                                                                                                               [ 95%]
test_cli/test_registry.py::TestDataTypes::test_creation[Video] PASSED                                                                                                              [ 97%]
test_cli/test_registry.py::TestDataTypes::test_creation[_Unknown] SKIPPED                                                                                                          [100%]

================================================================================ short test summary info =================================================================================
SKIPPED [1] /opt/repositorio-git/verta/modeldb/client/verta/tests/test_backend.py:9: reduce DB pressure to establish test baseline
SKIPPED [1] /opt/repositorio-git/verta/modeldb/client/verta/tests/test_datasets.py:4: outdated tests for legacy API
SKIPPED [1] /opt/repositorio-git/verta/modeldb/client/verta/tests/test_cli/test_repository.py:11: repository sub-CLI has been disabled
SKIPPED [1] /opt/repositorio-git/verta/modeldb/client/verta/tests/registry/test_model.py:140: unsupported action type
SKIPPED [1] /opt/repositorio-git/verta/modeldb/client/verta/tests/registry/test_model.py:153: unsupported action type
SKIPPED [1] /opt/repositorio-git/verta/modeldb/client/verta/tests/registry/test_model.py:166: unsupported data type
SKIPPED [1] /opt/repositorio-git/verta/modeldb/client/verta/tests/registry/test_model.py:179: unsupported data type
SKIPPED [1] /opt/repositorio-git/verta/modeldb/client/verta/tests/test_cli/test_registry.py:679: unsupported action type
SKIPPED [1] /opt/repositorio-git/verta/modeldb/client/verta/tests/test_cli/test_registry.py:703: unsupported data type
================================================================ 39 passed, 9 skipped, 1297 deselected in 260.72 seconds =================================================================
```

