### PR TITLE
chore: Constrain Jinja2 for building docs locally

### DIFF
--- a/client/verta/docs/requirements.txt
+++ b/client/verta/docs/requirements.txt
@@ -1,3 +1,4 @@
+Jinja2<3.1; python_version != '2.7'
 sphinx==3.5.4; python_version != '2.7'
 sphinx_copybutton; python_version != '2.7'
 


### PR DESCRIPTION
<!-- Title of the PR must comply with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines. --> 
<!-- Title should include the JIRA ticket in square brackets after the conventional commit prefix. This will automatically link the PR in JIRA. -->
<!-- Example: "fix: [JIRA-123] Allow creation of groups with no members" -->

## Impact and Context
<!-- Brief description of why these changes are necessary. Don't rewrite the entire Jira ticket. -->

`Jinja2==3.1.0` removed APIs used by this version of Sphinx.

## Risks and Area of Effect
<!--
  Describe both risk (how likely this is to break) and area of effect (how wide potential breakages could reach).
  These should be smaller scale than those documented in a design doc.
-->

—

## Testing
<!-- Explain how this contribution has been tested, e.g. what tests were added and where they have been run. -->

I was able to build our API docs locally with this change.

## How to Revert
<!-- List steps required to revert this change. For example, note if we'd need to revert liquibase changes. -->

Revert this PR.