### PR TITLE
fix: remove the extra, unused S3Service bean definition. (#3138)

### DIFF
--- a/backend/src/main/java/ai/verta/modeldb/configuration/AppConfigBeans.java
+++ b/backend/src/main/java/ai/verta/modeldb/configuration/AppConfigBeans.java
@@ -2,12 +2,10 @@ package ai.verta.modeldb.configuration;
 
 import ai.verta.modeldb.App;
 import ai.verta.modeldb.DAOSet;
-import ai.verta.modeldb.ModelDBConstants;
 import ai.verta.modeldb.ServiceSet;
 import ai.verta.modeldb.advancedService.AdvancedServiceImpl;
 import ai.verta.modeldb.artifactStore.storageservice.ArtifactStoreService;
 import ai.verta.modeldb.artifactStore.storageservice.nfs.FileStorageProperties;
-import ai.verta.modeldb.artifactStore.storageservice.s3.S3Service;
 import ai.verta.modeldb.comment.CommentServiceImpl;
 import ai.verta.modeldb.common.CommonUtils;
 import ai.verta.modeldb.common.authservice.AuthInterceptor;
@@ -18,7 +16,6 @@ import ai.verta.modeldb.common.configuration.EnabledMigration;
 import ai.verta.modeldb.common.configuration.RunLiquibaseSeparately;
 import ai.verta.modeldb.common.configuration.RunLiquibaseSeparately.RunLiquibaseWithMainService;
 import ai.verta.modeldb.common.exceptions.ExceptionInterceptor;
-import ai.verta.modeldb.common.exceptions.ModelDBException;
 import ai.verta.modeldb.common.futures.FutureUtil;
 import ai.verta.modeldb.common.interceptors.MetadataForwarder;
 import ai.verta.modeldb.config.MDBConfig;
@@ -82,15 +79,6 @@ public class AppConfigBeans {
   @Bean
   public OpenTelemetry openTelemetry(Config config) {
     return config.getOpenTelemetry();
-  }
-
-  @Bean
-  public S3Service getS3Service() throws ModelDBException, IOException {
-    String bucketName = System.getProperty(ModelDBConstants.CLOUD_BUCKET_NAME);
-    if (bucketName != null && !bucketName.isEmpty()) {
-      return new S3Service(System.getProperty(ModelDBConstants.CLOUD_BUCKET_NAME));
-    }
-    return null;
   }
 
   @Bean


### PR DESCRIPTION
This is a cherry-pick PR to fix below:

* fix: remove the extra, unused S3Service bean definition.

* https://jenkins.dev.verta.ai/job/build/job/autoformat/job/modeldb-backend/305/

Co-authored-by: Jenkins <jenkins@verta.ai>

<!-- Title of the PR must comply with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines. --> 
<!-- Title should include the JIRA ticket in square brackets after the conventional commit prefix. This will automatically link the PR in JIRA. -->
<!-- Example: "fix: [JIRA-123] Allow creation of groups with no members" -->

## Impact and Context
<!-- Brief description of why these changes are necessary. Don't rewrite the entire Jira ticket. -->

## Risks and Area of Effect
<!--
  Describe both risk (how likely this is to break) and area of effect (how wide potential breakages could reach).
  These should be smaller scale than those documented in a design doc.
-->

## Testing
<!-- Explain how this contribution has been tested, e.g. what tests were added and where they have been run. -->

## How to Revert
<!-- List steps required to revert this change. For example, note if we'd need to revert liquibase changes. -->
