### PR TITLE
chore!: [VRD-423] Remove support for Python 2.7 and 3.5

### DIFF
--- a/client/verta/docs/requirements.txt
+++ b/client/verta/docs/requirements.txt
@@ -1,6 +1,6 @@
-Jinja2<3.1; python_version != '2.7'
-sphinx==3.5.4; python_version != '2.7'
-sphinx_copybutton; python_version != '2.7'
+Jinja2<3.1
+sphinx==3.5.4
+sphinx_copybutton
 
-click; python_version != '2.7'
-sphinx-click==2.7.1; python_version != '2.7'
+click
+sphinx-click==2.7.1

--- a/client/verta/requirements-dev.txt
+++ b/client/verta/requirements-dev.txt
@@ -11,7 +11,6 @@ wheel>=0.32
 
 # unit testing dependencies
 boto3
-future; python_version == '2.7'  # for PyTorch
 google-cloud-bigquery
 h5py<3.0.0; python_version < '3.9'  # https://github.com/tensorflow/tensorflow/issues/44467
 matplotlib<3.0; python_version < '3.8'
@@ -23,8 +22,7 @@ scikit-learn<0.21; python_version < '3.8'  # https://scikit-learn.org/stable/ins
 scikit-learn>=0.22; python_version >= '3.8'
 scipy<1.3; python_version < '3.8'
 scipy>=1.4; python_version >= '3.8'
-spacy!=2.3.1,<2.3.3; python_version < '3.6'  # https://github.com/explosion/spaCy/issues/5729, https://github.com/explosion/spaCy/issues/6454
-spacy; python_version >= '3.6'
+spacy
 tensorflow<2.0; python_version < '3.8'
 tensorflow>=2.2; python_version >= '3.8' and python_version < '3.9'  # https://www.tensorflow.org/install/pip
 torch

--- a/client/verta/setup.py
+++ b/client/verta/setup.py
@@ -29,7 +29,7 @@ setup(
     license=about["__license__"],
     url=about["__url__"],
     packages=find_packages(),
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
+    python_requires=">=3.6, <4",
     install_requires=install_requires,
     extras_require={
         "unit_tests": unit_tests_requires,

--- a/client/verta/tests/test_cli/test_registry.py
+++ b/client/verta/tests/test_cli/test_registry.py
@@ -254,7 +254,7 @@ class TestCreate:
             model_api["model_packaging"] = {
                 "deserialization": "cloudpickle",
                 "type": "torch",
-                "python_version": "2.7.17"
+                "python_version": "3.9.13"
             }
             model_version.log_artifact(_artifact_utils.MODEL_API_KEY, model_api, True, "json")
 

--- a/client/verta/tests/versioning/environment/conftest.py
+++ b/client/verta/tests/versioning/environment/conftest.py
@@ -26,7 +26,7 @@ def requirements_file_without_versions(requirements_file):
 def requirements_file_with_unsupported_lines():
     with tempfile.NamedTemporaryFile("w+") as tempf:
         requirements = [
-            "verta;python_version>=2.7",
+            "verta;python_version>=3.8",
             "--no-binary :all:",
             "--only-binary :none:",
             "--require-hashes",

--- a/client/verta/tests/versioning/environment/test_python.py
+++ b/client/verta/tests/versioning/environment/test_python.py
@@ -75,7 +75,7 @@ class TestObject:
         requirements = [
             "-e git+https://github.com/matplotlib/matplotlib.git@master#egg=matplotlib",
         ]
-        constraints = ["pytest > 6; python_version >= '2.7'"]
+        constraints = ["pytest > 6; python_version >= '3.8'"]
 
         env = Python(
             requirements=requirements,


### PR DESCRIPTION
<!-- Title of the PR must comply with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines. --> 
<!-- Title should include the JIRA ticket in square brackets after the conventional commit prefix. This will automatically link the PR in JIRA. -->
<!-- Example: "fix: [JIRA-123] Allow creation of groups with no members" -->

## Impact and Context
<!-- Brief description of why these changes are necessary. Don't rewrite the entire Jira ticket. -->

Update our package metadata to prohibit installation in Python 2.7 and 3.5, and update our development/docs dependencies accordingly.

## Risks and Area of Effect
<!--
  Describe both risk (how likely this is to break) and area of effect (how wide potential breakages could reach).
  These should be smaller scale than those documented in a design doc.
-->

Users still on Python 2.7 and 3.5 will no longer receive updates.

## Testing
<!-- Explain how this contribution has been tested, e.g. what tests were added and where they have been run. -->

—

## How to Revert
<!-- List steps required to revert this change. For example, note if we'd need to revert liquibase changes. -->

Revert this PR.