### PR TITLE
test: Sidestep parallelism issue with config file tests

### DIFF
--- a/client/verta/tests/test_config.py
+++ b/client/verta/tests/test_config.py
@@ -11,6 +11,9 @@ from verta._internal_utils import _config_utils
 from . import utils
 
 
+pytestmark = [pytest.mark.xdist_group(name="verta_config")]
+
+
 @pytest.fixture
 def expected_config(in_tempdir):
     """

--- a/client/verta/tests/test_entities.py
+++ b/client/verta/tests/test_entities.py
@@ -38,11 +38,11 @@ TAG = "my-tag"
 class TestClient:
 
     @pytest.mark.skipif(not all(env_var in os.environ for env_var in ('VERTA_HOST', 'VERTA_EMAIL', 'VERTA_DEV_KEY')), reason="insufficient Verta credentials")
-    def test_config_file(self):
+    def test_config_file(self, in_tempdir):
         self.config_file_with_type_util(connect = False)
 
     @pytest.mark.skipif(not all(env_var in os.environ for env_var in ('VERTA_HOST', 'VERTA_EMAIL', 'VERTA_DEV_KEY')), reason="insufficient Verta credentials")
-    def test_config_file_connect(self):
+    def test_config_file_connect(self, in_tempdir):
         self.config_file_with_type_util(connect = True)
 
     def config_file_with_type_util(self, connect):


### PR DESCRIPTION
<!-- Title of the PR must comply with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines. --> 
<!-- Title should include the JIRA ticket in square brackets after the conventional commit prefix. This will automatically link the PR in JIRA. -->
<!-- Example: "fix: [JIRA-123] Allow creation of groups with no members" -->

## Impact and Context
<!-- Brief description of why these changes are necessary. Don't rewrite the entire Jira ticket. -->

The tests in `test_config.py` involve the creation and deletion of a Verta config file in one's home directory. This results in conflicts when the tests are run concurrently.

`pytest-xdist` offers a way to group tests to indicate that they should be run on the same worker, which has the effect of preventing tests in the same group from running simultaneously (since the worker can only run one at a time).

To make use of the group, `pytest` does need to be run with the `--dist loadgroup` option; I've opened https://github.com/VertaAI/cluster-setup/pull/5185 to do just that in our CI. There doesn't seem to be an easy way to just set this as the default in the pytest config 😞 

## Risks and Area of Effect
<!--
  Describe both risk (how likely this is to break) and area of effect (how wide potential breakages could reach).
  These should be smaller scale than those documented in a design doc.
-->

—

## Testing
<!-- Explain how this contribution has been tested, e.g. what tests were added and where they have been run. -->

### Before

A failure and an error on most test runs:

```
% pytest -n 10 test_config.py -ra
. . .
================================================== short test summary info ==================================================
ERROR test_config.py::TestRead::test_discovery - FileNotFoundError: [Errno 2] No such file or directory: '/Users/miliu/.ve...
FAILED test_config.py::TestRead::test_discovery - AssertionError: assert ['/private/va..._config.yaml'] == ['/private/va.....
==================================== 1 failed, 6 passed, 13 warnings, 1 error in 10.69s =====================================
```

### After

Success every time!

```
% pytest -n 10 --dist loadgroup test_config.py -ra
. . .
============================================== 7 passed, 13 warnings in 9.00s ===============================================
```

## How to Revert
<!-- List steps required to revert this change. For example, note if we'd need to revert liquibase changes. -->

Revert this PR.
