### PR TITLE
chore!: Remove artifact path-only logging

### DIFF
--- a/client/verta/tests/test_experimentrun/test_artifacts.py
+++ b/client/verta/tests/test_experimentrun/test_artifacts.py
@@ -9,18 +9,6 @@ from verta._internal_utils import _artifact_utils
 
 
 class TestArtifacts:
-    def test_log_path(self, experiment_run, strs):
-        strs, holdout = strs[:-1], strs[-1]  # reserve last key
-
-        for key, artifact_path in zip(strs, strs):
-            experiment_run.log_artifact_path(key, artifact_path)
-
-        for key, artifact_path in zip(strs, strs):
-            assert experiment_run.get_artifact(key) == artifact_path
-
-        with pytest.raises(KeyError):
-            experiment_run.get_artifact(holdout)
-
     def test_clientside_storage(self, experiment_run, strs, in_tempdir, random_data):
         key = strs[0]
         filename = strs[1]
@@ -62,24 +50,6 @@ class TestArtifacts:
             else:
                 del os.environ[VERTA_ARTIFACT_DIR_KEY]
 
-    def test_download_path_only_error(self, experiment_run, strs, in_tempdir):
-        key = strs[0]
-        path = strs[1]
-
-        experiment_run.log_artifact_path(key, path)
-        with pytest.raises(ValueError):
-            experiment_run.download_artifact(key, path)
-
-    def test_blocklisted_key_error(self, experiment_run, all_values):
-        all_values = (value  # log_artifact treats str value as filepath to open
-                      for value in all_values if not isinstance(value, str))
-
-        for key, artifact in zip(_artifact_utils.BLOCKLISTED_KEYS, all_values):
-            with pytest.raises(ValueError, match="please use a different key$"):
-                experiment_run.log_image(key, artifact)
-            with pytest.raises(ValueError, match="please use a different key$"):
-                experiment_run.log_image_path(key, artifact)
-
 
 class TestImages:
     @staticmethod
@@ -89,18 +59,6 @@ class TestImages:
         bytestream = six.BytesIO()
         fig.savefig(bytestream)
         return Image.open(bytestream)
-
-    def test_log_path(self, experiment_run, strs):
-        strs, holdout = strs[:-1], strs[-1]  # reserve last key
-
-        for key, image_path in zip(strs, strs):
-            experiment_run.log_image_path(key, image_path)
-
-        for key, image_path in zip(strs, strs):
-            assert experiment_run.get_image(key) == image_path
-
-        with pytest.raises(KeyError):
-            experiment_run.get_image(holdout)
 
     def test_upload_blank_warning(self, experiment_run, strs):
         Image = pytest.importorskip("PIL.Image")
@@ -167,3 +125,11 @@ class TestImages:
         for key, image in reversed(list(six.viewitems(images))):
             with pytest.raises(ValueError):
                 experiment_run.log_image(key, image)
+
+    def test_blocklisted_key_error(self, experiment_run, all_values):
+        all_values = (value  # log_artifact treats str value as filepath to open
+                      for value in all_values if not isinstance(value, str))
+
+        for key, artifact in zip(_artifact_utils.BLOCKLISTED_KEYS, all_values):
+            with pytest.raises(ValueError, match="please use a different key$"):
+                experiment_run.log_image(key, artifact)

--- a/client/verta/tests/test_experimentrun/test_artifacts.py
+++ b/client/verta/tests/test_experimentrun/test_artifacts.py
@@ -9,6 +9,18 @@ from verta._internal_utils import _artifact_utils
 
 
 class TestArtifacts:
+    def test_log_path(self, experiment_run, strs):
+        strs, holdout = strs[:-1], strs[-1]  # reserve last key
+
+        for key, artifact_path in zip(strs, strs):
+            experiment_run.log_artifact_path(key, artifact_path)
+
+        for key, artifact_path in zip(strs, strs):
+            assert experiment_run.get_artifact(key) == artifact_path
+
+        with pytest.raises(KeyError):
+            experiment_run.get_artifact(holdout)
+
     def test_clientside_storage(self, experiment_run, strs, in_tempdir, random_data):
         key = strs[0]
         filename = strs[1]
@@ -50,6 +62,24 @@ class TestArtifacts:
             else:
                 del os.environ[VERTA_ARTIFACT_DIR_KEY]
 
+    def test_download_path_only_error(self, experiment_run, strs, in_tempdir):
+        key = strs[0]
+        path = strs[1]
+
+        experiment_run.log_artifact_path(key, path)
+        with pytest.raises(ValueError):
+            experiment_run.download_artifact(key, path)
+
+    def test_blocklisted_key_error(self, experiment_run, all_values):
+        all_values = (value  # log_artifact treats str value as filepath to open
+                      for value in all_values if not isinstance(value, str))
+
+        for key, artifact in zip(_artifact_utils.BLOCKLISTED_KEYS, all_values):
+            with pytest.raises(ValueError, match="please use a different key$"):
+                experiment_run.log_image(key, artifact)
+            with pytest.raises(ValueError, match="please use a different key$"):
+                experiment_run.log_image_path(key, artifact)
+
 
 class TestImages:
     @staticmethod
@@ -59,6 +89,18 @@ class TestImages:
         bytestream = six.BytesIO()
         fig.savefig(bytestream)
         return Image.open(bytestream)
+
+    def test_log_path(self, experiment_run, strs):
+        strs, holdout = strs[:-1], strs[-1]  # reserve last key
+
+        for key, image_path in zip(strs, strs):
+            experiment_run.log_image_path(key, image_path)
+
+        for key, image_path in zip(strs, strs):
+            assert experiment_run.get_image(key) == image_path
+
+        with pytest.raises(KeyError):
+            experiment_run.get_image(holdout)
 
     def test_upload_blank_warning(self, experiment_run, strs):
         Image = pytest.importorskip("PIL.Image")
@@ -125,11 +167,3 @@ class TestImages:
         for key, image in reversed(list(six.viewitems(images))):
             with pytest.raises(ValueError):
                 experiment_run.log_image(key, image)
-
-    def test_blocklisted_key_error(self, experiment_run, all_values):
-        all_values = (value  # log_artifact treats str value as filepath to open
-                      for value in all_values if not isinstance(value, str))
-
-        for key, artifact in zip(_artifact_utils.BLOCKLISTED_KEYS, all_values):
-            with pytest.raises(ValueError, match="please use a different key$"):
-                experiment_run.log_image(key, artifact)

--- a/client/verta/verta/tracking/entities/_experimentrun.py
+++ b/client/verta/verta/tracking/entities/_experimentrun.py
@@ -383,48 +383,6 @@ class ExperimentRun(_DeployableEntity):
 
         print("upload complete ({})".format(key))
 
-    def _log_artifact_path(self, key, artifact_path, artifact_type, overwrite=False):
-        """
-        Logs the filesystem path of an artifact to this Experiment Run.
-
-        Parameters
-        ----------
-        key : str
-            Name of the artifact.
-        artifact_path : str
-            Filesystem path of the artifact.
-        artifact_type : int
-            Variant of `_CommonCommonService.ArtifactTypeEnum`.
-        overwrite : bool, default False
-            Whether to allow overwriting an existing artifact with key `key`.
-        """
-        # log key-path to ModelDB
-        Message = _ExperimentRunService.LogArtifact
-        artifact_msg = _CommonCommonService.Artifact(key=key,
-                                                     path=artifact_path,
-                                                     path_only=True,
-                                                     artifact_type=artifact_type)
-        msg = Message(id=self.id, artifact=artifact_msg)
-        data = _utils.proto_to_json(msg)
-        if overwrite:
-            response = _utils.make_request("DELETE",
-                                           "{}://{}/api/v1/modeldb/experiment-run/deleteArtifact".format(
-                                               self._conn.scheme, self._conn.socket),
-                                           self._conn, json={'id': self.id, 'key': key})
-            _utils.raise_for_http_error(response)
-        response = _utils.make_request("POST",
-                                       "{}://{}/api/v1/modeldb/experiment-run/logArtifact".format(
-                                           self._conn.scheme, self._conn.socket),
-                                       self._conn, json=data)
-        if not response.ok:
-            if response.status_code == 409:
-                raise ValueError("artifact with key {} already exists;"
-                                 " consider setting overwrite=True".format(key))
-            else:
-                _utils.raise_for_http_error(response)
-
-        self._clear_cache()
-
     def _get_artifact_msg(self, key):
         # get key-path from ModelDB
         msg = _CommonService.GetArtifacts(id=self.id, key=key)
@@ -1321,27 +1279,6 @@ class ExperimentRun(_DeployableEntity):
         self._log_artifact(
             key, image, _CommonCommonService.ArtifactTypeEnum.IMAGE, extension, overwrite=overwrite)
 
-    def log_image_path(self, key, image_path):
-        """
-        Logs the filesystem path of an image to this Experiment Run.
-
-        This function makes no attempt to open a file at `image_path`. Only the path string itself
-        is logged.
-
-        Parameters
-        ----------
-        key : str
-            Name of the image.
-        image_path : str
-            Filesystem path of the image.
-
-        """
-        _artifact_utils.validate_key(key)
-        _utils.validate_flat_key(key)
-
-        self._log_artifact_path(
-            key, image_path, _CommonCommonService.ArtifactTypeEnum.IMAGE)
-
     def get_image(self, key):
         """
         Gets the image artifact with name `key` from this Experiment Run.
@@ -1422,29 +1359,6 @@ class ExperimentRun(_DeployableEntity):
 
         self._log_artifact(
             key, artifact, _CommonCommonService.ArtifactTypeEnum.BLOB, extension, overwrite=overwrite)
-
-    def log_artifact_path(self, key, artifact_path, overwrite=False):
-        """
-        Logs the filesystem path of an artifact to this Experiment Run.
-
-        This function makes no attempt to open a file at `artifact_path`. Only the path string itself
-        is logged.
-
-        Parameters
-        ----------
-        key : str
-            Name of the artifact.
-        artifact_path : str
-            Filesystem path of the artifact.
-        overwrite : bool, default False
-            Whether to allow overwriting an existing artifact with key `key`.
-
-        """
-        _artifact_utils.validate_key(key)
-        _utils.validate_flat_key(key)
-
-        self._log_artifact_path(
-            key, artifact_path, _CommonCommonService.ArtifactTypeEnum.BLOB, overwrite=overwrite)
 
     def get_artifact(self, key):
         """

--- a/client/verta/verta/tracking/entities/_experimentrun.py
+++ b/client/verta/verta/tracking/entities/_experimentrun.py
@@ -383,6 +383,48 @@ class ExperimentRun(_DeployableEntity):
 
         print("upload complete ({})".format(key))
 
+    def _log_artifact_path(self, key, artifact_path, artifact_type, overwrite=False):
+        """
+        Logs the filesystem path of an artifact to this Experiment Run.
+
+        Parameters
+        ----------
+        key : str
+            Name of the artifact.
+        artifact_path : str
+            Filesystem path of the artifact.
+        artifact_type : int
+            Variant of `_CommonCommonService.ArtifactTypeEnum`.
+        overwrite : bool, default False
+            Whether to allow overwriting an existing artifact with key `key`.
+        """
+        # log key-path to ModelDB
+        Message = _ExperimentRunService.LogArtifact
+        artifact_msg = _CommonCommonService.Artifact(key=key,
+                                                     path=artifact_path,
+                                                     path_only=True,
+                                                     artifact_type=artifact_type)
+        msg = Message(id=self.id, artifact=artifact_msg)
+        data = _utils.proto_to_json(msg)
+        if overwrite:
+            response = _utils.make_request("DELETE",
+                                           "{}://{}/api/v1/modeldb/experiment-run/deleteArtifact".format(
+                                               self._conn.scheme, self._conn.socket),
+                                           self._conn, json={'id': self.id, 'key': key})
+            _utils.raise_for_http_error(response)
+        response = _utils.make_request("POST",
+                                       "{}://{}/api/v1/modeldb/experiment-run/logArtifact".format(
+                                           self._conn.scheme, self._conn.socket),
+                                       self._conn, json=data)
+        if not response.ok:
+            if response.status_code == 409:
+                raise ValueError("artifact with key {} already exists;"
+                                 " consider setting overwrite=True".format(key))
+            else:
+                _utils.raise_for_http_error(response)
+
+        self._clear_cache()
+
     def _get_artifact_msg(self, key):
         # get key-path from ModelDB
         msg = _CommonService.GetArtifacts(id=self.id, key=key)
@@ -1279,6 +1321,27 @@ class ExperimentRun(_DeployableEntity):
         self._log_artifact(
             key, image, _CommonCommonService.ArtifactTypeEnum.IMAGE, extension, overwrite=overwrite)
 
+    def log_image_path(self, key, image_path):
+        """
+        Logs the filesystem path of an image to this Experiment Run.
+
+        This function makes no attempt to open a file at `image_path`. Only the path string itself
+        is logged.
+
+        Parameters
+        ----------
+        key : str
+            Name of the image.
+        image_path : str
+            Filesystem path of the image.
+
+        """
+        _artifact_utils.validate_key(key)
+        _utils.validate_flat_key(key)
+
+        self._log_artifact_path(
+            key, image_path, _CommonCommonService.ArtifactTypeEnum.IMAGE)
+
     def get_image(self, key):
         """
         Gets the image artifact with name `key` from this Experiment Run.
@@ -1359,6 +1422,29 @@ class ExperimentRun(_DeployableEntity):
 
         self._log_artifact(
             key, artifact, _CommonCommonService.ArtifactTypeEnum.BLOB, extension, overwrite=overwrite)
+
+    def log_artifact_path(self, key, artifact_path, overwrite=False):
+        """
+        Logs the filesystem path of an artifact to this Experiment Run.
+
+        This function makes no attempt to open a file at `artifact_path`. Only the path string itself
+        is logged.
+
+        Parameters
+        ----------
+        key : str
+            Name of the artifact.
+        artifact_path : str
+            Filesystem path of the artifact.
+        overwrite : bool, default False
+            Whether to allow overwriting an existing artifact with key `key`.
+
+        """
+        _artifact_utils.validate_key(key)
+        _utils.validate_flat_key(key)
+
+        self._log_artifact_path(
+            key, artifact_path, _CommonCommonService.ArtifactTypeEnum.BLOB, overwrite=overwrite)
 
     def get_artifact(self, key):
         """


### PR DESCRIPTION
<!-- Title of the PR must comply with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines. --> 
<!-- Title should include the JIRA ticket in square brackets after the conventional commit prefix. This will automatically link the PR in JIRA. -->
<!-- Example: "fix: [JIRA-123] Allow creation of groups with no members" -->

## Impact and Context
<!-- Brief description of why these changes are necessary. Don't rewrite the entire Jira ticket. -->

Since our implementation of untrusted artifact paths in March (https://github.com/VertaAI/modeldb/pull/2927), the backend rejects the client's artifact path and substitutes its own. This breaks `ExperimentRun`'s `log_artifact_path()` and `log_image_path()`, and it would be a significant undertaking to re-enable that functionality. This PR removes the methods from our API.

## Risks and Area of Effect
<!--
  Describe both risk (how likely this is to break) and area of effect (how wide potential breakages could reach).
  These should be smaller scale than those documented in a design doc.
-->

These APIs will no longer be available through the client, though they also have not been operational at all since early this year.

## Testing
<!-- Explain how this contribution has been tested, e.g. what tests were added and where they have been run. -->

A search of the client source and tests for `\.log[_a-z]+_path` confirms that it has been removed completely.

## How to Revert
<!-- List steps required to revert this change. For example, note if we'd need to revert liquibase changes. -->

Revert this PR.