### PR TITLE
chore!: Remove get_artifact_parts() from public API

### DIFF
--- a/client/verta/tests/deployable_entity/test_artifacts.py
+++ b/client/verta/tests/deployable_entity/test_artifacts.py
@@ -13,6 +13,7 @@ import pytest
 import requests
 import six
 
+from verta.registry.entities import RegisteredModelVersion
 from verta._internal_utils import (
     _artifact_utils,
     _request_utils,
@@ -153,6 +154,9 @@ class TestArtifacts:
 
     @pytest.mark.not_oss
     def test_upload_multipart(self, deployable_entity, in_tempdir):
+        if isinstance(deployable_entity, RegisteredModelVersion):
+            pytest.skip("/getCommittedArtifactParts not implemented in registry")
+
         key = "large"
 
         # create artifact
@@ -172,7 +176,7 @@ class TestArtifacts:
 
         # get artifact parts
         committed_parts = deployable_entity.get_artifact_parts(key)
-        assert committed_parts
+        assert len(committed_parts) > 1
 
         # part checksums match actual file contents
         with open(tempf.name, 'rb') as f:

--- a/client/verta/tests/deployable_entity/test_artifacts.py
+++ b/client/verta/tests/deployable_entity/test_artifacts.py
@@ -175,7 +175,7 @@ class TestArtifacts:
             del os.environ['VERTA_ARTIFACT_PART_SIZE']
 
         # get artifact parts
-        committed_parts = deployable_entity.get_artifact_parts(key)
+        committed_parts = deployable_entity._get_artifact_parts(key)
         assert len(committed_parts) > 1
 
         # part checksums match actual file contents

--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -555,25 +555,6 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
             self._MODEL_KEY, download_to_path
         )
 
-    def get_artifact_parts(self, key):
-        endpoint = "{}://{}/api/v1/registry/model_versions/{}/getCommittedArtifactParts".format(
-            self._conn.scheme,
-            self._conn.socket,
-            self.id,
-        )
-        data = {'model_version_id': self.id, 'key': key}
-        response = _utils.make_request(
-            "GET", endpoint, self._conn, params=data)
-        _utils.raise_for_http_error(response)
-
-        committed_parts = _utils.body_to_json(
-            response).get('artifact_parts', [])
-        committed_parts = list(sorted(
-            committed_parts,
-            key=lambda part: int(part['part_number']),
-        ))
-        return committed_parts
-
     def del_model(self):
         """
         Deletes model of this Model Version.

--- a/client/verta/verta/tracking/entities/_experimentrun.py
+++ b/client/verta/verta/tracking/entities/_experimentrun.py
@@ -408,6 +408,24 @@ class ExperimentRun(_DeployableEntity):
 
             return response.content, artifact.path_only
 
+    def _get_artifact_parts(self, key):
+        endpoint = "{}://{}/api/v1/modeldb/experiment-run/getCommittedArtifactParts".format(
+            self._conn.scheme,
+            self._conn.socket,
+        )
+        data = {'id': self.id, 'key': key}
+        response = _utils.make_request(
+            "GET", endpoint, self._conn, params=data)
+        _utils.raise_for_http_error(response)
+
+        committed_parts = _utils.body_to_json(
+            response).get('artifact_parts', [])
+        committed_parts = list(sorted(
+            committed_parts,
+            key=lambda part: int(part['part_number']),
+        ))
+        return committed_parts
+
     # TODO: Fix up get dataset to handle the Dataset class when logging dataset
     # version
     def _get_dataset(self, key):
@@ -1439,24 +1457,6 @@ class ExperimentRun(_DeployableEntity):
 
     def download_model(self, download_to_path):
         return self.download_artifact(self._MODEL_KEY, download_to_path)
-
-    def get_artifact_parts(self, key):
-        endpoint = "{}://{}/api/v1/modeldb/experiment-run/getCommittedArtifactParts".format(
-            self._conn.scheme,
-            self._conn.socket,
-        )
-        data = {'id': self.id, 'key': key}
-        response = _utils.make_request(
-            "GET", endpoint, self._conn, params=data)
-        _utils.raise_for_http_error(response)
-
-        committed_parts = _utils.body_to_json(
-            response).get('artifact_parts', [])
-        committed_parts = list(sorted(
-            committed_parts,
-            key=lambda part: int(part['part_number']),
-        ))
-        return committed_parts
 
     def log_observation(self, key, value, timestamp=None, epoch_num=None, overwrite=False):
         """


### PR DESCRIPTION
<!-- Title of the PR must comply with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines. --> 
<!-- Title should include the JIRA ticket in square brackets after the conventional commit prefix. This will automatically link the PR in JIRA. -->
<!-- Example: "fix: [JIRA-123] Allow creation of groups with no members" -->

## Impact and Context
<!-- Brief description of why these changes are necessary. Don't rewrite the entire Jira ticket. -->

- removes `ModelVersion.get_artifact_parts()` because its endpoint doesn't exist in the backend (https://github.com/VertaAI/registry/pull/1024)
- makes `ExperimentRun.get_artifact_parts()` private since it's not meant for public use

## Risks and Area of Effect
<!--
  Describe both risk (how likely this is to break) and area of effect (how wide potential breakages could reach).
  These should be smaller scale than those documented in a design doc.
-->

Negligible: `ModelVersion.get_artifact_parts()` never worked, and `ExperimentRun.get_artifact_parts()` doesn't have much real-world use and was never visible in our API documentation.

## Testing
<!-- Explain how this contribution has been tested, e.g. what tests were added and where they have been run. -->

I ran the test locally and it succeeds now that it's unburdened by `ModelVersion.get_artifact_parts()`.

And honestly, this test should involve a mocked server or artifact uploader, but the client test suite doesn't have the pieces in place to make that happen 🤷 

## How to Revert
<!-- List steps required to revert this change. For example, note if we'd need to revert liquibase changes. -->

Revert this PR.