### PR TITLE
chore!: Remove deprecated run.log_dataset()

### DIFF
--- a/client/verta/verta/tracking/entities/_experimentrun.py
+++ b/client/verta/verta/tracking/entities/_experimentrun.py
@@ -1006,30 +1006,6 @@ class ExperimentRun(_DeployableEntity):
         self._refresh_cache()
         return self._hyperparameters
 
-    def log_dataset(self, key, dataset, overwrite=False):
-        """
-        Alias for :meth:`~ExperimentRun.log_dataset_version`.
-
-        .. deprecated:: 0.14.12
-            :meth:`~ExperimentRun.log_dataset` can no longer be used to log artifacts.
-            :meth:`~ExperimentRun.log_artifact` should be used instead.
-
-        """
-        if isinstance(dataset, _dataset.Dataset):
-            raise TypeError(
-                "directly logging a Dataset is not supported;"
-                " please create a DatasetVersion for logging"
-            )
-
-        if not isinstance(dataset, _dataset_version.DatasetVersion):
-            raise TypeError(
-                "`dataset` must be of type DatasetVersion;"
-                " to log an artifact, consider using run.log_artifact() instead"
-            )
-
-        self.log_dataset_version(
-            key=key, dataset_version=dataset, overwrite=overwrite)
-
     def log_dataset_version(self, key, dataset_version, overwrite=False):
         """
         Logs a Verta DatasetVersion to this ExperimentRun with the given key.


### PR DESCRIPTION
<!-- Title of the PR must comply with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines. --> 
<!-- Title should include the JIRA ticket in square brackets after the conventional commit prefix. This will automatically link the PR in JIRA. -->
<!-- Example: "fix: [JIRA-123] Allow creation of groups with no members" -->

## Impact and Context
<!-- Brief description of why these changes are necessary. Don't rewrite the entire Jira ticket. -->

This function's presence in our API has been confusing. In particular, its docstring could be interpreted as "dataset versioning as a whole is deprecated in favor of artifacts", which is inaccurate. We may as well just remove it.

## Risks and Area of Effect
<!--
  Describe both risk (how likely this is to break) and area of effect (how wide potential breakages could reach).
  These should be smaller scale than those documented in a design doc.
-->

Negligible: This method has been deprecated since July 2020, and is very isolated in its functionality.

## Testing
<!-- Explain how this contribution has been tested, e.g. what tests were added and where they have been run. -->

Did a check for `\.log_dataset\(` to verify it's not being used here nor in our examples repo.

## How to Revert
<!-- List steps required to revert this change. For example, note if we'd need to revert liquibase changes. -->

Revert this PR.