### PR TITLE
Fix liquibase path after liquibase version upgrade

### DIFF
--- a/backend/common/src/main/java/ai/verta/modeldb/common/CommonDBUtil.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/CommonDBUtil.java
@@ -8,7 +8,6 @@ import java.util.Calendar;
 import java.util.Locale;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
-import java.util.regex.Pattern;
 import liquibase.Contexts;
 import liquibase.LabelExpression;
 import liquibase.Liquibase;
@@ -185,12 +184,13 @@ public abstract class CommonDBUtil {
         changeCharsetToUtf(jdbcCon);
       }
 
-
       var changeLogTableName =
           System.getProperties().getProperty("liquibase.databaseChangeLogTableName");
-      var updateQuery = "update %s set FILENAME=substring(FILENAME, length('/src/main/resources/')) "
-          + "WHERE FILENAME LIKE ?";
-      try(var statement = jdbcCon.prepareStatement(String.format(updateQuery, changeLogTableName))) {
+      var updateQuery =
+          "update %s set FILENAME=substring(FILENAME, length('/src/main/resources/')) "
+              + "WHERE FILENAME LIKE ?";
+      try (var statement =
+          jdbcCon.prepareStatement(String.format(updateQuery, changeLogTableName))) {
         statement.setString(1, "%src/main/resources/liquibase%");
         statement.executeUpdate();
       }

--- a/backend/common/src/main/java/ai/verta/modeldb/common/CommonDBUtil.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/CommonDBUtil.java
@@ -8,6 +8,7 @@ import java.util.Calendar;
 import java.util.Locale;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
+import java.util.regex.Pattern;
 import liquibase.Contexts;
 import liquibase.LabelExpression;
 import liquibase.Liquibase;
@@ -182,6 +183,16 @@ public abstract class CommonDBUtil {
       var jdbcCon = new JdbcConnection(con);
       if (config.getRdbConfiguration().isMysql()) {
         changeCharsetToUtf(jdbcCon);
+      }
+
+
+      var changeLogTableName =
+          System.getProperties().getProperty("liquibase.databaseChangeLogTableName");
+      var updateQuery = "update %s set FILENAME=substring(FILENAME, length('/src/main/resources/')) "
+          + "WHERE FILENAME LIKE ?";
+      try(var statement = jdbcCon.prepareStatement(String.format(updateQuery, changeLogTableName))) {
+        statement.setString(1, "%src/main/resources/liquibase%");
+        statement.executeUpdate();
       }
 
       // Overwrite default liquibase table names by custom

--- a/backend/src/main/java/ai/verta/modeldb/utils/ModelDBHibernateUtil.java
+++ b/backend/src/main/java/ai/verta/modeldb/utils/ModelDBHibernateUtil.java
@@ -82,7 +82,7 @@ public class ModelDBHibernateUtil extends CommonHibernateUtil {
   }
 
   private static void initializedUtil() {
-    liquibaseRootFilePath = "\\src\\main\\resources\\liquibase\\db-changelog-master.xml";
+    liquibaseRootFilePath = "liquibase/db-changelog-master.xml";
     entities =
         new Class[] {
           ProjectEntity.class,

--- a/backend/src/main/resources/liquibase/create-index-changelog.xml
+++ b/backend/src/main/resources/liquibase/create-index-changelog.xml
@@ -3,7 +3,7 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd"
-        logicalFilePath="src/main/resources/liquibase/create-index-changelog.xml">
+        logicalFilePath="liquibase/create-index-changelog.xml">
 
     <changeSet author="anandJ" id="1-create-text-indexes-postgres" failOnError="false">
         <preConditions onFail="MARK_RAN">

--- a/backend/src/main/resources/liquibase/create-tables-changelog-1.0.xml
+++ b/backend/src/main/resources/liquibase/create-tables-changelog-1.0.xml
@@ -3,7 +3,7 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd"
-        logicalFilePath="src/main/resources/liquibase/create-tables-changelog-1.0.xml">
+        logicalFilePath="liquibase/create-tables-changelog-1.0.xml">
 
     <changeSet author="anandJ" id="createTable-1" failOnError="false">
         <createTable tableName="artifact_store">

--- a/backend/src/main/resources/liquibase/create-versioning-tables-changelog.xml
+++ b/backend/src/main/resources/liquibase/create-versioning-tables-changelog.xml
@@ -3,7 +3,7 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd"
-        logicalFilePath="src/main/resources/liquibase/create-tables-changelog-1.0.xml">
+        logicalFilePath="liquibase/create-tables-changelog-1.0.xml">
     <changeSet author="anand" id="create-commit">
         <preConditions onFail="MARK_RAN">
             <not>

--- a/backend/src/main/resources/liquibase/create-versioning-tables-changelog2.xml
+++ b/backend/src/main/resources/liquibase/create-versioning-tables-changelog2.xml
@@ -3,7 +3,7 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd"
-	logicalFilePath="src/main/resources/liquibase/create-tables-changelog-1.0.xml">
+	logicalFilePath="liquibase/create-tables-changelog-1.0.xml">
 
 	<changeSet author="raviS" id="create-git_code_blob">
 		<preConditions onFail="MARK_RAN">

--- a/backend/src/main/resources/liquibase/db-changelog-1.0.xml
+++ b/backend/src/main/resources/liquibase/db-changelog-1.0.xml
@@ -3,12 +3,12 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd"
-        logicalFilePath="src/main/resources/liquibase/db-changelog-1.0.xml">
+        logicalFilePath="liquibase/db-changelog-1.0.xml">
 
-    <include file="src/main/resources/liquibase/create-tables-changelog-1.0.xml"/>
+    <include file="liquibase/create-tables-changelog-1.0.xml"/>
 
     <changeSet id="1" author="anandJ" failOnError="false">
-        <sqlFile path="src/main/resources/liquibase/create_indexes.sql"/>
+        <sqlFile path="liquibase/create_indexes.sql"/>
     </changeSet>
 
     <changeSet id="tag-1.0" author="anandJ">
@@ -307,8 +307,8 @@
         </createIndex>
     </changeSet>
 
-    <include file="src/main/resources/liquibase/create-versioning-tables-changelog.xml"/>
-    <include file="src/main/resources/liquibase/create-versioning-tables-changelog2.xml"/>
+    <include file="liquibase/create-versioning-tables-changelog.xml"/>
+    <include file="liquibase/create-versioning-tables-changelog2.xml"/>
 
     <changeSet id="13-add_s3_dataset_component_blob_s3_version_id" author="anandJ">
         <preConditions onFail="MARK_RAN">
@@ -672,7 +672,7 @@
         </createTable>
     </changeSet>
 
-    <include file="src/main/resources/liquibase/create-index-changelog.xml"/>
+    <include file="liquibase/create-index-changelog.xml"/>
     <changeSet author="anandJ" id="migration_status_table">
         <preConditions onFail="MARK_RAN">
             <not>

--- a/backend/src/main/resources/liquibase/db-changelog-2.0.xml
+++ b/backend/src/main/resources/liquibase/db-changelog-2.0.xml
@@ -3,7 +3,7 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd"
-        logicalFilePath="src/main/resources/liquibase/db-changelog-2.0.xml">
+        logicalFilePath="liquibase/db-changelog-2.0.xml">
 
     <changeSet id="db_version_2.0.pre" author="raviS">
         <tagDatabase tag="db_version_2.0.pre"/>

--- a/backend/src/main/resources/liquibase/db-changelog-master.xml
+++ b/backend/src/main/resources/liquibase/db-changelog-master.xml
@@ -3,7 +3,7 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd">
 
-    <include file="src/main/resources/liquibase/db-changelog-1.0.xml"/>
-    <include file="src/main/resources/liquibase/db-changelog-2.0.xml"/>
+    <include file="liquibase/db-changelog-1.0.xml"/>
+    <include file="liquibase/db-changelog-2.0.xml"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
<!-- Title of the PR must comply with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines. --> 
<!-- Title should include the JIRA ticket in square brackets after the conventional commit prefix. This will automatically link the PR in JIRA. -->
<!-- Example: "fix: [JIRA-123] Allow creation of groups with no members" -->

## Impact and Context
<!-- Brief description of why these changes are necessary. Don't rewrite the entire Jira ticket. -->
After Liquibase version migration, modeldb was unable to up and threw error like 
```
Specifying files by absolute path was removed in Liquibase 4.0. Please use a relative path or add '/' to the classpath parameter.
```
Solution: An added solution based on the Liquibase official suggestion at [How the Liquibase searchPath works in 4.0 and later versions](https://docs.liquibase.com/concepts/changelogs/how-liquibase-finds-files.html)

## Risks and Area of Effect
<!--
  Describe both risk (how likely this is to break) and area of effect (how wide potential breakages could reach).
  These should be smaller scale than those documented in a design doc.
-->

## Testing
<!-- Explain how this contribution has been tested, e.g. what tests were added and where they have been run. -->

## How to Revert
<!-- List steps required to revert this change. For example, note if we'd need to revert liquibase changes. -->
