### PR TITLE
fix: [VUMM-656] Add safeguards for client config discovery

### DIFF
--- a/client/verta/tests/test_config.py
+++ b/client/verta/tests/test_config.py
@@ -9,6 +9,7 @@ import yaml
 import pytest
 
 from verta import Client
+from verta.client import VERTA_DISABLE_CLIENT_CONFIG_ENV_VAR
 from verta._internal_utils import _config_utils
 
 from . import utils
@@ -150,10 +151,11 @@ class TestRead:
         with _config_utils.read_merged_config() as config:
             assert config == expected_config
 
-    def test_skip_client_load_config(self, expected_config):
+    def test_skip_client_load_config(self, expected_config, monkeypatch):
+        monkeypatch.delenv(VERTA_DISABLE_CLIENT_CONFIG_ENV_VAR, raising=False)
         assert Client()._config == expected_config
 
-        os.environ["VERTA_DISABLE_CLIENT_CONFIG"] = "1"
+        monkeypatch.setenv(VERTA_DISABLE_CLIENT_CONFIG_ENV_VAR, "1")
         assert Client()._config == dict()
 
 

--- a/client/verta/tests/test_config.py
+++ b/client/verta/tests/test_config.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import os
 import shutil
 import tempfile
@@ -6,6 +8,7 @@ import yaml
 
 import pytest
 
+from verta import Client
 from verta._internal_utils import _config_utils
 
 from . import utils
@@ -146,6 +149,12 @@ class TestRead:
         expected_config[key] = value
         with _config_utils.read_merged_config() as config:
             assert config == expected_config
+
+    def test_skip_client_load_config(self, expected_config):
+        assert Client()._config == expected_config
+
+        os.environ["VERTA_DISABLE_CLIENT_CONFIG"] = "1"
+        assert Client()._config == dict()
 
 
 class TestWrite:

--- a/client/verta/verta/_internal_utils/_config_utils.py
+++ b/client/verta/verta/_internal_utils/_config_utils.py
@@ -136,6 +136,10 @@ def get_possible_config_file_dirs():
     * parent directories until the root
     * ``$HOME/.verta/``
 
+    .. versionchanged:: 0.20.4
+        Directories for which ``os.listdir()`` fails (e.g. permission denied,
+        doesn't exist for some reason) are gracefully skipped.
+
     Returns
     -------
     dirpaths : list of str
@@ -159,7 +163,18 @@ def get_possible_config_file_dirs():
     if os.path.isdir(HOME_VERTA_DIR):
         candidates.append(HOME_VERTA_DIR)
 
-    return candidates
+    # filter out directories that can't be listed
+    dirpaths = []
+    for dirpath in candidates:
+        try:
+            os.listdir(dirpath)
+        except Exception as e:
+            logger.debug("skipping directory for client config:\n    %s", str(e))
+            continue
+        else:
+            dirpaths.append(dirpath)
+
+    return dirpaths
 
 
 def find_closest_config_file():

--- a/client/verta/verta/_internal_utils/_config_utils.py
+++ b/client/verta/verta/_internal_utils/_config_utils.py
@@ -43,6 +43,7 @@ def read_merged_config():
     """
     config = {}
     for filepath in reversed(find_config_files()):
+        # TODO: gracefully handle config files that can't be opened
         merge(config, load(filepath))
 
     yield config

--- a/client/verta/verta/_internal_utils/_config_utils.py
+++ b/client/verta/verta/_internal_utils/_config_utils.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import json
+import logging
 import os
 
 import yaml
@@ -9,6 +10,9 @@ import yaml
 from .._protos.public.client import Config_pb2 as _ConfigProtos
 
 from . import _utils
+
+
+logger = logging.getLogger(__name__)
 
 
 # TODO: make this a named tuple, if it would help readability
@@ -139,23 +143,23 @@ def get_possible_config_file_dirs():
         being first.
 
     """
-    dirpaths = []
+    candidates = []
 
     # current dir
     curr_dir = os.getcwd()
-    dirpaths.append(curr_dir)
+    candidates.append(curr_dir)
 
     # parent dirs
     parent_dir = os.path.dirname(curr_dir)
-    while parent_dir != dirpaths[-1]:
-        dirpaths.append(parent_dir)
+    while parent_dir != candidates[-1]:
+        candidates.append(parent_dir)
         parent_dir = os.path.dirname(parent_dir)
 
     # home verta dir
     if os.path.isdir(HOME_VERTA_DIR):
-        dirpaths.append(HOME_VERTA_DIR)
+        candidates.append(HOME_VERTA_DIR)
 
-    return dirpaths
+    return candidates
 
 
 def find_closest_config_file():

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -120,7 +120,8 @@ class Client(object):
     """
     def __init__(self, host=None, port=None, email=None, dev_key=None,
                  max_retries=5, ignore_conn_err=False, use_git=True, debug=False, extra_auth_headers={}, jwt_token=None, jwt_token_sig=None, _connect=True):
-        self._load_config()
+        if not os.environ.get("VERTA_DISABLE_CLIENT_CONFIG"):
+            self._load_config()
 
         host = self._get_with_fallback(host, env_var="VERTA_HOST", config_var="host")
         if host is None:

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -60,6 +60,10 @@ class Client(object):
     .. deprecated:: 0.13.3
        The `expt_runs` attribute will be removed in an upcoming version; consider using `proj.expt_runs` and
        `expt.expt_runs` instead.
+    .. versionadded:: 0.20.4
+       The ``VERTA_DISABLE_CLIENT_CONFIG`` environment variable, when set to
+       a non-empty value, disables discovery of client config files for use in
+       protected filesystems.
 
     This class provides functionality for starting/resuming Projects, Experiments, and Experiment Runs.
 

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -50,6 +50,10 @@ from .endpoint import Endpoints
 from .endpoint.update import DirectUpdateStrategy
 from .visibility import _visibility
 
+
+VERTA_DISABLE_CLIENT_CONFIG_ENV_VAR = "VERTA_DISABLE_CLIENT_CONFIG"
+
+
 class Client(object):
     """
     Object for interfacing with the Verta backend.
@@ -221,7 +225,7 @@ class Client(object):
         return ExperimentRuns(self._conn, self._conf).with_workspace(self.get_workspace())
 
     def _load_config(self):
-        if not os.environ.get("VERTA_DISABLE_CLIENT_CONFIG"):
+        if not os.environ.get(VERTA_DISABLE_CLIENT_CONFIG_ENV_VAR):
             with _config_utils.read_merged_config() as config:
                 self._config = config
         else:

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -120,8 +120,7 @@ class Client(object):
     """
     def __init__(self, host=None, port=None, email=None, dev_key=None,
                  max_retries=5, ignore_conn_err=False, use_git=True, debug=False, extra_auth_headers={}, jwt_token=None, jwt_token_sig=None, _connect=True):
-        if not os.environ.get("VERTA_DISABLE_CLIENT_CONFIG"):
-            self._load_config()
+        self._load_config()
 
         host = self._get_with_fallback(host, env_var="VERTA_HOST", config_var="host")
         if host is None:
@@ -218,8 +217,11 @@ class Client(object):
         return ExperimentRuns(self._conn, self._conf).with_workspace(self.get_workspace())
 
     def _load_config(self):
-        with _config_utils.read_merged_config() as config:
-            self._config = config
+        if not os.environ.get("VERTA_DISABLE_CLIENT_CONFIG"):
+            with _config_utils.read_merged_config() as config:
+                self._config = config
+        else:
+            self._config = dict()
 
     def _set_from_config_if_none(self, var, resource_name):
         if var is None:

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -225,11 +225,12 @@ class Client(object):
         return ExperimentRuns(self._conn, self._conf).with_workspace(self.get_workspace())
 
     def _load_config(self):
-        if not os.environ.get(VERTA_DISABLE_CLIENT_CONFIG_ENV_VAR):
+        if (VERTA_DISABLE_CLIENT_CONFIG_ENV_VAR in os.environ
+                and os.environ[VERTA_DISABLE_CLIENT_CONFIG_ENV_VAR] != ""):
+            self._config = dict()
+        else:
             with _config_utils.read_merged_config() as config:
                 self._config = config
-        else:
-            self._config = dict()
 
     def _set_from_config_if_none(self, var, resource_name):
         if var is None:


### PR DESCRIPTION
<!-- Title of the PR must comply with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines. --> 
<!-- Title should include the JIRA ticket in square brackets after the conventional commit prefix. This will automatically link the PR in JIRA. -->
<!-- Example: "fix: [JIRA-123] Allow creation of groups with no members" -->

## Impact and Context
<!-- Brief description of why these changes are necessary. Don't rewrite the entire Jira ticket. -->

The Verta client may be instantiated in environments where the user doesn't have full read access to the filesystem. This raises exceptions on instantiation due to the client config file functionality, which checks parent directories all the way to the root.

This PR adds two solutions for this:

1. Skip directories that can't be read.
2. Add an environment variable (`VERTA_DISABLE_CLIENT_CONFIG`) to disable config file functionality altogether.

## Risks and Area of Effect
<!--
  Describe both risk (how likely this is to break) and area of effect (how wide potential breakages could reach).
  These should be smaller scale than those documented in a design doc.
-->

AoE: This could affect any use of the client config file, which today isn't all that much—it basically lets a user set a default workspace, project name, registered model name, etc. for their filesystem.

Risk: Low for breakage, with test coverage!

## Testing
<!-- Explain how this contribution has been tested, e.g. what tests were added and where they have been run. -->

I've added a test for the environment variable, and the config tests continue to pass

```
% pytest test_config.py -vvra
==================================================== test session starts ====================================================
platform darwin -- Python 3.9.2, pytest-7.1.2, pluggy-1.0.0 -- /Users/miliu/.pyenv/versions/3.9.2/envs/dev3/bin/python3.9
cachedir: .pytest_cache
hypothesis profile 'default' -> suppress_health_check=[HealthCheck.too_slow], database=DirectoryBasedExampleDatabase('/Users/
miliu/Documents/modeldb/client/verta/tests/.hypothesis/examples')
rootdir: /Users/miliu/Documents/modeldb/client/verta/tests, configfile: pytest.ini
plugins: xdist-2.5.0, forked-1.4.0, hypothesis-6.53.0
collected 8 items                                                                                                           

test_config.py::TestRead::test_discovery PASSED                                                                       [ 12%]
test_config.py::TestRead::test_merge PASSED                                                                           [ 25%]
test_config.py::TestRead::test_merge_and_overwrite PASSED                                                             [ 37%]
test_config.py::TestRead::test_skip_client_load_config PASSED                                                         [ 50%]
test_config.py::TestWrite::test_create_empty[~] PASSED                                                                [ 62%]
test_config.py::TestWrite::test_create_empty[.] PASSED                                                                [ 75%]
test_config.py::TestWrite::test_update_closest PASSED                                                                 [ 87%]
test_config.py::TestWrite::test_does_not_update_home PASSED                                                           [100%]

=============================================== 8 passed, 5 warnings in 6.66s ===============================================
```

I've also manually tested the directory skip behavior

![Screen Shot 2022-09-12 at 10 46 32 AM](https://user-images.githubusercontent.com/96442646/189734513-f6b614eb-6d05-44af-9303-2bd4284390b4.png)

## How to Revert
<!-- List steps required to revert this change. For example, note if we'd need to revert liquibase changes. -->

Revert this PR.