### PR TITLE
chore!: Remove support for Python 3.6

### DIFF
--- a/client/verta/setup.py
+++ b/client/verta/setup.py
@@ -29,7 +29,7 @@ setup(
     license=about["__license__"],
     url=about["__url__"],
     packages=find_packages(),
-    python_requires=">=3.6, <4",
+    python_requires=">=3.7, <4",
     install_requires=install_requires,
     extras_require={
         "unit_tests": unit_tests_requires,


### PR DESCRIPTION
<!-- Title of the PR must comply with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines. --> 
<!-- Title should include the JIRA ticket in square brackets after the conventional commit prefix. This will automatically link the PR in JIRA. -->
<!-- Example: "fix: [JIRA-123] Allow creation of groups with no members" -->

## Impact and Context
<!-- Brief description of why these changes are necessary. Don't rewrite the entire Jira ticket. -->

Update our package metadata to prohibit installation in Python 3.6.

## Risks and Area of Effect
<!--
  Describe both risk (how likely this is to break) and area of effect (how wide potential breakages could reach).
  These should be smaller scale than those documented in a design doc.
-->

Users still on Python 3.6 will no longer receive updates.

## Testing
<!-- Explain how this contribution has been tested, e.g. what tests were added and where they have been run. -->

—

## How to Revert
<!-- List steps required to revert this change. For example, note if we'd need to revert liquibase changes. -->

Revert this PR.