### PR TITLE
ci: Finish makefile recipes for client publication

### DIFF
--- a/client/verta/Makefile
+++ b/client/verta/Makefile
@@ -1,6 +1,6 @@
 # build wheel and source distributions
 build: clean
-	python setup.py sdist bdist_wheel --universal
+	python3 setup.py sdist bdist_wheel --universal
 
 # clean previously-created builds
 clean:
@@ -9,10 +9,10 @@ clean:
 # upload distributions to PyPI
 upload:
 	# checking TWINE_USERNAME and TWINE_PASSWORD env vars
-	python -m twine upload --non-interactive dist/*
+	python3 -m twine upload --non-interactive dist/*
 
 # tag the current commit using the client's version number
-tag: VERSION=$$(python -c 'import verta; print(verta.__version__)')
+tag: VERSION=$$(python3 -c 'import verta; print(verta.__version__)')
 tag: TAG="client-v$(VERSION)"
 tag:
 	git tag -a $(TAG) -m ''

--- a/client/verta/Makefile
+++ b/client/verta/Makefile
@@ -1,3 +1,5 @@
+VERSION:=$$(python3 -c 'import verta; print(verta.__version__)')
+
 # build wheel and source distributions
 build: clean
 	python3 setup.py sdist bdist_wheel --universal
@@ -12,8 +14,6 @@ upload:
 	python3 -m twine upload --non-interactive dist/*
 
 # tag the current commit using the client's version number
-tag: VERSION=$$(python3 -c 'import verta; print(verta.__version__)')
-tag: TAG="client-v$(VERSION)"
 tag:
-	git tag -a $(TAG) -m ''
-	git push origin tag $(TAG)
+	git tag -a client-v$(VERSION) -m ''
+	git push origin tag client-v$(VERSION)

--- a/client/verta/Makefile
+++ b/client/verta/Makefile
@@ -7,7 +7,7 @@ clean:
 	rm -rf build dist verta.egg-info
 
 # upload distributions to PyPI
-upload: build
+upload:
 	python -m twine upload dist/* -u $(PYPI_USERNAME) -p $(PYPI_PASSWORD)
 
 # tag the current commit using the client's version number

--- a/client/verta/Makefile
+++ b/client/verta/Makefile
@@ -9,3 +9,10 @@ clean:
 # upload distributions to PyPI
 upload: build
 	python -m twine upload dist/* -u \${PYPI_USERNAME} -p \${PYPI_PASSWORD}
+
+# tag the current commit using the client's version number
+tag: VERSION=$$(python -c 'import verta; print(verta.__version__)')
+tag: TAG="client-v$(VERSION)"
+tag:
+	git tag -a $(TAG) -m ''
+	git push origin tag $(TAG)

--- a/client/verta/Makefile
+++ b/client/verta/Makefile
@@ -9,7 +9,7 @@ clean:
 # upload distributions to PyPI
 upload:
 	# checking TWINE_USERNAME and TWINE_PASSWORD env vars
-	python -m twine upload dist/*
+	python -m twine upload --non-interactive dist/*
 
 # tag the current commit using the client's version number
 tag: VERSION=$$(python -c 'import verta; print(verta.__version__)')

--- a/client/verta/Makefile
+++ b/client/verta/Makefile
@@ -8,7 +8,7 @@ clean:
 
 # upload distributions to PyPI
 upload: build
-	python -m twine upload dist/* -u \${PYPI_USERNAME} -p \${PYPI_PASSWORD}
+	python -m twine upload dist/* -u $(PYPI_USERNAME) -p $(PYPI_PASSWORD)
 
 # tag the current commit using the client's version number
 tag: VERSION=$$(python -c 'import verta; print(verta.__version__)')

--- a/client/verta/Makefile
+++ b/client/verta/Makefile
@@ -8,7 +8,8 @@ clean:
 
 # upload distributions to PyPI
 upload:
-	python -m twine upload dist/* -u $(PYPI_USERNAME) -p $(PYPI_PASSWORD)
+	# checking TWINE_USERNAME and TWINE_PASSWORD env vars
+	python -m twine upload dist/*
 
 # tag the current commit using the client's version number
 tag: VERSION=$$(python -c 'import verta; print(verta.__version__)')


### PR DESCRIPTION
<!-- Title of the PR must comply with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines. --> 
<!-- Title should include the JIRA ticket in square brackets after the conventional commit prefix. This will automatically link the PR in JIRA. -->
<!-- Example: "fix: [JIRA-123] Allow creation of groups with no members" -->

## Impact and Context
<!-- Brief description of why these changes are necessary. Don't rewrite the entire Jira ticket. -->

- Change `make upload` to read PyPI credentials from the environment instead of passing them as arguments so that `make` doesn't print their values to the console.
- Add `make tag`, which performs this step in [our client publication instructions](https://github.com/VertaAI/modeldb/blob/222d2b1/client/CONTRIBUTING.md#package-publication):
  > Once the pull request is approved and merged, a Verta core team member shall tag the merge commit using e.g. `git tag -a client-v0.0.0 -m '' && git push --follow-tags`, with the appropriate version number.

CI will start using these in https://github.com/VertaAI/cluster-setup/pull/3469.

## Risks and Area of Effect
<!--
  Describe both risk (how likely this is to break) and area of effect (how wide potential breakages could reach).
  These should be smaller scale than those documented in a design doc.
-->

—

## Testing
<!-- Explain how this contribution has been tested, e.g. what tests were added and where they have been run. -->

I checked that `build` matches [what we currently do in CI](https://github.com/VertaAI/cluster-setup/blob/0c3bd1f/ci/python_client/publish-pypi.Jenkinsfile#L56) to publish the client.

I tested `upload` against [PyPI's testing server](https://packaging.python.org/en/latest/guides/using-testpypi/).

I tested `tag` (cleaning up the dummy tag afterwards).

## How to Revert
<!-- List steps required to revert this change. For example, note if we'd need to revert liquibase changes. -->

Revert this PR.