### PR TITLE
test: Replace deprecated pytest.warns(None)

### DIFF
--- a/client/verta/tests/registry/model_version/test_crud.py
+++ b/client/verta/tests/registry/model_version/test_crud.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import warnings
+
 import pytest
 import requests
 
@@ -179,7 +181,7 @@ class TestCRUD:
         assert model_version.get_attributes() == dict([old_attr, second_attr])
 
         # with `overwrite`
-        with pytest.warns(None) as record:
+        with warnings.catch_warnings(record=True) as record:
             model_version.add_attributes(dict([new_attr, second_attr]), overwrite=True)
         assert not record  # no warning
         assert model_version.get_attributes() == dict([new_attr, second_attr])

--- a/client/verta/tests/registry/test_standard_model.py
+++ b/client/verta/tests/registry/test_standard_model.py
@@ -4,6 +4,7 @@
 
 from datetime import timedelta
 import re
+import warnings
 
 import hypothesis
 import hypothesis.strategies as st
@@ -90,7 +91,7 @@ class TestModelValidator:
         decorated_verta_models,
     )
     def test_decorated_verta(self, model):
-        with pytest.warns(None) as record:
+        with warnings.catch_warnings(record=True) as record:
             model_validator.must_verta(model)
         assert not record  # no warning of missing decorator on predict()
 
@@ -254,7 +255,7 @@ class TestStandardModels:
     def test_decorated_verta(self, registered_model, endpoint, model):
         np = pytest.importorskip("numpy")
 
-        with pytest.warns(None) as record:
+        with warnings.catch_warnings(record=True) as record:
             model_ver = registered_model.create_standard_model(
                 model,
                 Python(["pytest"]),  # source module imports pytest


### PR DESCRIPTION
<!-- Title of the PR must comply with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines. --> 
<!-- Title should include the JIRA ticket in square brackets after the conventional commit prefix. This will automatically link the PR in JIRA. -->
<!-- Example: "fix: [JIRA-123] Allow creation of groups with no members" -->

## Impact and Context
<!-- Brief description of why these changes are necessary. Don't rewrite the entire Jira ticket. -->

`pytest.warns(None)` is deprecated, for which `pytest` raises a warning. And so, because these tests assert "no warning is raised", they fail!

## Risks and Area of Effect
<!--
  Describe both risk (how likely this is to break) and area of effect (how wide potential breakages could reach).
  These should be smaller scale than those documented in a design doc.
-->

None: test code only.

## Testing
<!-- Explain how this contribution has been tested, e.g. what tests were added and where they have been run. -->

With #3254, I locally tested `registry/model_version/test_crud.py::TestCRUD::test_attributes_overwrite` and `registry/test_standard_model.py` in Python 3.10 to verify that they succeed.

## How to Revert
<!-- List steps required to revert this change. For example, note if we'd need to revert liquibase changes. -->

Revert this PR.