### PR TITLE
chore: Remove some uses of six

### DIFF
--- a/client/verta/tests/test_entities.py
+++ b/client/verta/tests/test_entities.py
@@ -5,6 +5,7 @@ import six
 import itertools
 import os
 import shutil
+from urllib.parse import urlparse
 
 import requests
 
@@ -17,8 +18,6 @@ from . import utils
 import verta
 from verta._internal_utils import _utils
 import json
-
-from verta.external.six.moves.urllib.parse import urlparse  # pylint: disable=import-error, no-name-in-module
 
 
 KWARGS = {

--- a/client/verta/verta/_internal_utils/_artifact_utils.py
+++ b/client/verta/verta/_internal_utils/_artifact_utils.py
@@ -2,6 +2,7 @@
 
 import hashlib
 import os
+import pickle
 import shutil
 import tempfile
 import zipfile
@@ -9,7 +10,6 @@ import zipfile
 import cloudpickle
 
 from ..external import six
-from ..external.six.moves import cPickle as pickle  # pylint: disable=import-error, no-name-in-module
 
 from .. import __about__
 

--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -14,6 +14,7 @@ import string
 import sys
 import threading
 import time
+from urllib.parse import urljoin
 import warnings
 
 import click
@@ -25,7 +26,6 @@ from google.protobuf import json_format
 from google.protobuf.struct_pb2 import Value, ListValue, Struct, NULL_VALUE
 
 from ..external import six
-from ..external.six.moves.urllib.parse import urljoin  # pylint: disable=import-error, no-name-in-module
 
 from verta.credentials import EmailCredentials, JWTCredentials
 

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 
 import os
 import re
+from urllib.parse import urlparse
 import warnings
 
 import requests
@@ -13,7 +14,6 @@ from ._internal_utils._utils import check_unnecessary_params_warning
 from ._protos.public.modeldb import CommonService_pb2 as _CommonService
 
 from .external import six
-from .external.six.moves.urllib.parse import urlparse  # pylint: disable=import-error, no-name-in-module
 
 from ._internal_utils import (
     _config_utils,

--- a/client/verta/verta/dataset/_s3.py
+++ b/client/verta/verta/dataset/_s3.py
@@ -5,9 +5,9 @@ from __future__ import print_function
 import os
 import pathlib
 import tempfile
+from urllib.parse import urlparse
 
 from ..external import six
-from ..external.six.moves.urllib.parse import urlparse  # pylint: disable=import-error, no-name-in-module
 
 from .._protos.public.modeldb.versioning import VersioningService_pb2 as _VersioningService
 

--- a/client/verta/verta/deployment/_deployedmodel.py
+++ b/client/verta/verta/deployment/_deployedmodel.py
@@ -4,13 +4,12 @@ import json
 import gzip
 import os
 import time
+from urllib.parse import urlparse
 import warnings
 
 import requests
 
-
 from ..external import six
-from ..external.six.moves.urllib.parse import urlparse  # pylint: disable=import-error, no-name-in-module
 
 from .._internal_utils import _utils
 from verta import credentials
@@ -247,7 +246,7 @@ class DeployedModel(object):
                 num_retries += 1
 
         _utils.raise_for_http_error(response)
-    
+
 
     def predict_with_id(self, x, compress=False, max_retries=5, always_retry_404=True, always_retry_429=True):
         num_retries = 0

--- a/client/verta/verta/endpoint/_endpoint.py
+++ b/client/verta/verta/endpoint/_endpoint.py
@@ -3,11 +3,11 @@
 from __future__ import print_function
 import sys
 import time
+from urllib.parse import urlparse
 import json
 import yaml
 
 from verta.external import six
-from verta.external.six.moves.urllib.parse import urlparse  # pylint: disable=import-error, no-name-in-module
 
 from verta.deployment import DeployedModel
 from verta._internal_utils import _utils, arg_handler
@@ -116,7 +116,7 @@ class Endpoint(object):
         production_stage = self._get_production_stage()
         components =  production_stage["components"]
         # Note: the line below triggers a spurious and incorrect pylint error
-        build_id = next(six.moves.map(lambda component: component["build_id"], components),None) # pylint: disable=no-member
+        build_id = next(map(lambda component: component["build_id"], components),None)
         if build_id:
             build = self._get_build(build_id)
             return build

--- a/client/verta/verta/tracking/entities/_experimentrun.py
+++ b/client/verta/verta/tracking/entities/_experimentrun.py
@@ -6,6 +6,7 @@ import ast
 import copy
 import os
 import pathlib
+import pickle
 import pprint
 import shutil
 import sys
@@ -19,7 +20,6 @@ from verta._protos.public.modeldb import CommonService_pb2 as _CommonService
 from verta._protos.public.modeldb import ExperimentRunService_pb2 as _ExperimentRunService
 
 from verta.external import six
-from verta.external.six.moves import cPickle as pickle  # pylint: disable=import-error, no-name-in-module
 
 from verta._internal_utils import (
     _artifact_utils,


### PR DESCRIPTION
<!-- Title of the PR must comply with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines. --> 
<!-- Title should include the JIRA ticket in square brackets after the conventional commit prefix. This will automatically link the PR in JIRA. -->
<!-- Example: "fix: [JIRA-123] Allow creation of groups with no members" -->

## Impact and Context
<!-- Brief description of why these changes are necessary. Don't rewrite the entire Jira ticket. -->

Since we've dropped support for older Python versions, we can remove these uses of `six`. 

## Risks and Area of Effect
<!--
  Describe both risk (how likely this is to break) and area of effect (how wide potential breakages could reach).
  These should be smaller scale than those documented in a design doc.
-->

`urlparse` is used in core codepaths of the client, but I consider this low-risk because we're still importing the exact same thing, just through a different path.

## Testing
<!-- Explain how this contribution has been tested, e.g. what tests were added and where they have been run. -->

We should be good if the linting jobs are happy.

## How to Revert
<!-- List steps required to revert this change. For example, note if we'd need to revert liquibase changes. -->

Revert this PR.
