### PR TITLE
feat: Use backend-generated entity names

### DIFF
--- a/client/verta/tests/http_requests/test_deployed_model.py
+++ b/client/verta/tests/http_requests/test_deployed_model.py
@@ -19,7 +19,7 @@ class TestDeployedModel:
         ).LogisticRegression
 
         # create entities
-        registered_model = https_client.create_registered_model(generate_default_name())
+        registered_model = https_client.create_registered_model()
         created_entities.append(registered_model)
         endpoint = https_client.create_endpoint(generate_default_name())
         created_entities.append(endpoint)

--- a/client/verta/tests/registry/model_version/test_crud.py
+++ b/client/verta/tests/registry/model_version/test_crud.py
@@ -17,7 +17,7 @@ pytestmark = pytest.mark.not_oss  # skip if run in oss setup. Applied to entire 
 
 class TestCRUD:
     def test_create(self, registered_model):
-        version = registered_model.create_version(name)
+        version = registered_model.create_version()
         assert version
 
         with pytest.raises(requests.HTTPError, match="409.*already exists") as excinfo:

--- a/client/verta/tests/registry/model_version/test_crud.py
+++ b/client/verta/tests/registry/model_version/test_crud.py
@@ -17,17 +17,15 @@ pytestmark = pytest.mark.not_oss  # skip if run in oss setup. Applied to entire 
 
 class TestCRUD:
     def test_create(self, registered_model):
-        name = verta._internal_utils._utils.generate_default_name()
-        assert registered_model.create_version(name)
-        with pytest.raises(requests.HTTPError) as excinfo:
-            assert registered_model.create_version(name)
-        excinfo_value = str(excinfo.value).strip()
-        assert "409" in excinfo_value
-        assert "already exists" in excinfo_value
+        version = registered_model.create_version(name)
+        assert version
+
+        with pytest.raises(requests.HTTPError, match="409.*already exists") as excinfo:
+            assert registered_model.create_version(version.name)
 
     def test_set(self, registered_model):
-        name = verta._internal_utils._utils.generate_default_name()
-        version = registered_model.set_version(name=name)
+        version = registered_model.set_version()
+        assert version
 
         assert registered_model.set_version(name=version.name).id == version.id
 

--- a/client/verta/tests/registry/test_model.py
+++ b/client/verta/tests/registry/test_model.py
@@ -16,16 +16,15 @@ class TestModel:
         assert registered_model
         created_entities.append(registered_model)
 
-        name = verta._internal_utils._utils.generate_default_name()
         registered_model = client.create_registered_model(name)
         assert registered_model
         created_entities.append(registered_model)
-        with pytest.raises(requests.HTTPError) as excinfo:
+
+        name = registered_model.name
+        with pytest.raises(requests.HTTPError, match="409.*already exists"):
             assert client.create_registered_model(name)
-        excinfo_value = str(excinfo.value).strip()
-        assert "409" in excinfo_value
-        assert "already exists" in excinfo_value
-        with pytest.warns(UserWarning, match=".*already exists.*"):
+
+        with pytest.warns(UserWarning, match="already exists"):
             client.set_registered_model(
                 name=registered_model.name, desc="new description"
             )
@@ -36,7 +35,7 @@ class TestModel:
         with pytest.raises(ValueError):
             client.get_registered_model(name)
 
-        registered_model = client.set_registered_model(name)
+        registered_model = client.create_registered_model(name)
         created_entities.append(registered_model)
 
         assert (
@@ -84,10 +83,10 @@ class TestModel:
         assert str(registered_model.get_labels()) in repr
 
     def test_find(self, client, created_entities):
-        name = verta._internal_utils._utils.generate_default_name()
-        registered_model = client.set_registered_model(name)
+        registered_model = client.create_registered_model()
         created_entities.append(registered_model)
 
+        name = registered_model.name
         find = client.registered_models.find(["name == '{}'".format(name)])
         assert len(find) == 1
         for item in find:

--- a/client/verta/tests/registry/test_model.py
+++ b/client/verta/tests/registry/test_model.py
@@ -16,7 +16,7 @@ class TestModel:
         assert registered_model
         created_entities.append(registered_model)
 
-        registered_model = client.create_registered_model(name)
+        registered_model = client.create_registered_model()
         assert registered_model
         created_entities.append(registered_model)
 

--- a/client/verta/tests/test_dataset_versioning/test_dataset.py
+++ b/client/verta/tests/test_dataset_versioning/test_dataset.py
@@ -91,15 +91,16 @@ class TestCreateGet:
         assert dataset
         created_entities.append(dataset)
 
-        name = verta._internal_utils._utils.generate_default_name()
-        dataset = client.create_dataset(name)
+        dataset = client.create_dataset()
         assert dataset
         created_entities.append(dataset)
 
-        with pytest.raises(requests.HTTPError, match="already exists"):
+        name = dataset.name
+        with pytest.raises(requests.HTTPError, match="409.*already exists"):
             assert client.create_dataset(name)
+
         with pytest.warns(UserWarning, match="already exists"):
-            client.set_dataset(name=dataset.name, time_created=123)
+            client.set_dataset(name=name, time_created=123)
 
     def test_get(self, client, created_entities):
         name = verta._internal_utils._utils.generate_default_name()
@@ -107,7 +108,7 @@ class TestCreateGet:
         with pytest.raises(ValueError):
             client.get_dataset(name)
 
-        dataset = client.set_dataset(name)
+        dataset = client.create_dataset(name)
         created_entities.append(dataset)
 
         assert dataset.id == client.get_dataset(dataset.name).id

--- a/client/verta/tests/test_entities.py
+++ b/client/verta/tests/test_entities.py
@@ -183,15 +183,15 @@ class TestProject:
     def test_create(self, client):
         assert client.set_project()
         assert client.proj is not None
-        name = _utils.generate_default_name()
-        assert client.create_project(name)
+
+        assert client.create_project()
         assert client.proj is not None
-        with pytest.raises(requests.HTTPError) as excinfo:
+
+        name = client.proj.name
+        with pytest.raises(requests.HTTPError, match="409.*already exists"):
             assert client.create_project(name)
-        excinfo_value = str(excinfo.value).strip()
-        assert "409" in excinfo_value
-        assert "already exists" in excinfo_value
-        with pytest.warns(UserWarning, match=".*already exists.*"):
+
+        with pytest.warns(UserWarning, match="already exists"):
             client.get_or_create_project(name=name, tags=["tag1", "tag2"])
 
     def test_get(self, client):
@@ -200,7 +200,7 @@ class TestProject:
         with pytest.raises(ValueError):
             client.get_project(name)
 
-        proj = client.set_project(name)
+        proj = client.create_project(name)
 
         assert proj.id == client.get_project(proj.name).id
         assert proj.id == client.get_project(id=proj.id).id
@@ -252,15 +252,14 @@ class TestExperiment:
         assert client.set_experiment()
         assert client.expt is not None
 
-        name = _utils.generate_default_name()
-        assert client.create_experiment(name)
+        assert client.create_experiment()
         assert client.expt is not None
-        with pytest.raises(requests.HTTPError) as excinfo:
+
+        name = client.expt.name
+        with pytest.raises(requests.HTTPError, match="409.*already exists"):
             assert client.create_experiment(name)
-        excinfo_value = str(excinfo.value).strip()
-        assert "409" in excinfo_value
-        assert "already exists" in excinfo_value
-        with pytest.warns(UserWarning, match=".*already exists.*"):
+
+        with pytest.warns(UserWarning, match="already exists"):
             client.set_experiment(name=name, attrs={"a": 123})
 
     def test_get(self, client):
@@ -270,7 +269,7 @@ class TestExperiment:
         with pytest.raises(ValueError):
             client.get_experiment(name)
 
-        expt = client.set_experiment(name)
+        expt = client.create_experiment(name)
 
         assert expt.id == client.get_experiment(expt.name).id
         assert expt.id == client.get_experiment(id=expt.id).id
@@ -325,14 +324,14 @@ class TestExperimentRun:
 
         assert client.set_experiment_run()
 
-        name = _utils.generate_default_name()
-        assert client.create_experiment_run(name)
-        with pytest.raises(requests.HTTPError) as excinfo:
+        run = client.create_experiment_run()
+        assert run
+
+        name = run.name
+        with pytest.raises(requests.HTTPError, match="409.*already exists"):
             assert client.create_experiment_run(name)
-        excinfo_value = str(excinfo.value).strip()
-        assert "409" in excinfo_value
-        assert "already exists" in excinfo_value
-        with pytest.warns(UserWarning, match=".*already exists.*"):
+
+        with pytest.warns(UserWarning, match="already exists"):
             client.set_experiment_run(name=name, attrs={"a": 123})
 
     def test_get(self, client):
@@ -343,7 +342,7 @@ class TestExperimentRun:
         with pytest.raises(ValueError):
             client.get_experiment_run(name)
 
-        run = client.set_experiment_run(name)
+        run = client.create_experiment_run(name)
 
         assert run.id == client.get_experiment_run(run.name).id
         assert run.id == client.get_experiment_run(id=run.id).id

--- a/client/verta/tests/test_permissions/test_sharing_old.py
+++ b/client/verta/tests/test_permissions/test_sharing_old.py
@@ -14,8 +14,7 @@ class TestProject:
         """
         User 1 share a project in personal workspace to user 2.
         """
-        project_name = _utils.generate_default_name()
-        project = client.create_project(project_name)
+        project = client.create_project()
         project._add_collaborator(email=email_2)
 
         assert client_2.get_project(id=project.id)
@@ -25,9 +24,8 @@ class TestProject:
         """
         User 2 tries to access a org-public project created by a user in the same organization.
         """
-        project_name = _utils.generate_default_name()
         project = client.create_project(
-            project_name, workspace=organization.name, public_within_org=True
+            workspace=organization.name, public_within_org=True
         )
 
         organization.add_member(email_2)
@@ -41,9 +39,8 @@ class TestProject:
         """
         User 2 tries to access a non-org-public project created by a user in the same organization.
         """
-        project_name = _utils.generate_default_name()
         project = client.create_project(
-            project_name, workspace=organization.name, public_within_org=False
+            workspace=organization.name, public_within_org=False
         )
 
         organization.add_member(email_2)
@@ -56,9 +53,8 @@ class TestProject:
         """
         User 2 tries to access a non-org-public project created by another user, but has been shared to user 2.
         """
-        project_name = _utils.generate_default_name()
         project = client.create_project(
-            project_name, workspace=organization.name, public_within_org=False
+            workspace=organization.name, public_within_org=False
         )
 
         organization.add_member(email_2)
@@ -75,9 +71,8 @@ class TestDataset:
         """
         User 2 tries to access a org-public dataset created by a user in the same organization.
         """
-        dataset_name = _utils.generate_default_name()
         dataset = client.create_dataset(
-            dataset_name, workspace=organization.name, public_within_org=True
+            workspace=organization.name, public_within_org=True
         )
         created_entities.append(dataset)
 
@@ -92,9 +87,8 @@ class TestDataset:
         """
         User 2 tries to access a non-org-public dataset created by a user in the same organization.
         """
-        dataset_name = _utils.generate_default_name()
         dataset = client.create_dataset(
-            dataset_name, workspace=organization.name, public_within_org=False
+            workspace=organization.name, public_within_org=False
         )
         created_entities.append(dataset)
 
@@ -112,9 +106,8 @@ class TestRegisteredModel:
         """
         User 2 tries to access a org-public registered_model created by a user in the same organization.
         """
-        registered_model_name = _utils.generate_default_name()
         registered_model = client.create_registered_model(
-            registered_model_name, workspace=organization.name, public_within_org=True
+            workspace=organization.name, public_within_org=True
         )
         created_entities.append(registered_model)
 
@@ -131,9 +124,8 @@ class TestRegisteredModel:
         """
         User 2 tries to access a non-org-public registered_model created by a user in the same organization.
         """
-        registered_model_name = _utils.generate_default_name()
         registered_model = client.create_registered_model(
-            registered_model_name, workspace=organization.name, public_within_org=False
+            workspace=organization.name, public_within_org=False
         )
         created_entities.append(registered_model)
 

--- a/client/verta/verta/tracking/entities/_entity.py
+++ b/client/verta/verta/tracking/entities/_entity.py
@@ -126,7 +126,7 @@ class _ModelDBEntity(object):
     @classmethod
     def _get_or_create_by_name(cls, conn, name, getter, creator, checker):
         if name is None:
-            name = cls._generate_default_name()
+            return creator(name)
 
         obj = getter(name)
         if obj is None:
@@ -152,9 +152,6 @@ class _ModelDBEntity(object):
 
     @classmethod
     def _create(cls, conn, conf, *args, **kwargs):
-        if "name" in kwargs and kwargs["name"] is None:
-            kwargs["name"] = cls._generate_default_name()
-
         # translate between `public_within_org` and `visibility`
         VISIBILITY_KEY = "visibility"
         PUBLIC_WITHIN_ORG_KEY = "public_within_org"


### PR DESCRIPTION
<!-- Title of the PR must comply with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines. --> 
<!-- Title should include the JIRA ticket in square brackets after the conventional commit prefix. This will automatically link the PR in JIRA. -->
<!-- Example: "fix: [JIRA-123] Allow creation of groups with no members" -->

## Impact and Context
<!-- Brief description of why these changes are necessary. Don't rewrite the entire Jira ticket. -->

Use backends' automatically-generated human-readable three-word-phrase names.

## Risks and Area of Effect
<!--
  Describe both risk (how likely this is to break) and area of effect (how wide potential breakages could reach).
  These should be smaller scale than those documented in a design doc.
-->

I wonder if experiment run names would ever collide 🤔 

## Testing
<!-- Explain how this contribution has been tested, e.g. what tests were added and where they have been run. -->

I ran our entire suite in Python 3.9 and it passed!

Here's every entity that implements `_create_proto_internal()` (besides `DatasetVersion`, which doesn't use names):

![Screen Shot 2022-10-04 at 3 24 00 PM](https://user-images.githubusercontent.com/96442646/193943414-22ea98c0-7426-4f2c-ace5-2cb3f346a1b1.png)

Deployment-api still requires a client-provided path for endpoints (`422 Client Error: path in body is required`), so it's not included in this change.

## How to Revert
<!-- List steps required to revert this change. For example, note if we'd need to revert liquibase changes. -->

Revert this PR.