### PR TITLE
chore: Remove unused training_data attr constants

### DIFF
--- a/client/verta/verta/tracking/entities/_deployable_entity.py
+++ b/client/verta/verta/tracking/entities/_deployable_entity.py
@@ -40,8 +40,6 @@ _CACHE_DIR = os.path.join(
 )
 
 _INTERNAL_ATTR_PREFIX = "__verta_"
-_FEATURE_DATA_ATTR_PREFIX = _INTERNAL_ATTR_PREFIX + "feature_data_"
-_TRAINING_DATA_ATTR_PREFIX = _INTERNAL_ATTR_PREFIX + "training_data_"
 
 
 @six.add_metaclass(abc.ABCMeta)


### PR DESCRIPTION
<!-- Title of the PR must comply with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines. --> 
<!-- Title should include the JIRA ticket in square brackets after the conventional commit prefix. This will automatically link the PR in JIRA. -->
<!-- Example: "fix: [JIRA-123] Allow creation of groups with no members" -->

## Impact and Context
<!-- Brief description of why these changes are necessary. Don't rewrite the entire Jira ticket. -->

These are no longer used by the client since `RegisteredModelVersion.log_training_data_profile()` was removed in https://github.com/VertaAI/modeldb/pull/2812. To reduce confusion, I'd like to remove them entirely.

## Risks and Area of Effect
<!--
  Describe both risk (how likely this is to break) and area of effect (how wide potential breakages could reach).
  These should be smaller scale than those documented in a design doc.
-->

None; they aren't used in the codebase anymore.

## Testing
<!-- Explain how this contribution has been tested, e.g. what tests were added and where they have been run. -->

I `grep`ed the codebase for references and there are none.

## How to Revert
<!-- List steps required to revert this change. For example, note if we'd need to revert liquibase changes. -->

Revert this PR.