### PR TITLE
chore: Introduce a new Future that has an API that we prefer over the existing InternalFuture

### DIFF
--- a/backend/common/src/main/java/ai/verta/modeldb/common/futures/Future.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/futures/Future.java
@@ -374,6 +374,12 @@ public class Future<T> {
     }
   }
 
+  /** @deprecated Only use this as a part of the conversion process between versions of Futures. */
+  @Deprecated
+  public InternalFuture<T> toInternalFuture() {
+    return InternalFuture.from(stage);
+  }
+
   @VisibleForTesting
   static void resetExecutorForTest() {
     futureExecutor = null;

--- a/backend/common/src/main/java/ai/verta/modeldb/common/futures/FutureExecutor.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/futures/FutureExecutor.java
@@ -1,23 +1,21 @@
 package ai.verta.modeldb.common.futures;
 
-import io.grpc.Context;
-import io.opentracing.Scope;
-import io.opentracing.util.GlobalTracer;
+import io.opentelemetry.context.Context;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
 import org.springframework.lang.NonNull;
 
 public class FutureExecutor implements Executor {
-  final Executor other;
+  private final Executor delegate;
 
-  FutureExecutor(Executor other) {
-    this.other = io.opentelemetry.context.Context.taskWrapping(other);
+  private FutureExecutor(Executor delegate) {
+    this.delegate = Context.taskWrapping(delegate);
   }
 
   // Wraps an Executor and make it compatible with grpc's context
-  public static FutureExecutor makeCompatibleExecutor(Executor ex) {
-    return new FutureExecutor(ex);
+  public static FutureExecutor makeCompatibleExecutor(Executor delegate) {
+    return new FutureExecutor(delegate);
   }
 
   public static FutureExecutor initializeExecutor(Integer threadCount) {
@@ -34,20 +32,7 @@ public class FutureExecutor implements Executor {
   }
 
   @Override
-  public void execute(@NonNull Runnable r) {
-    if (GlobalTracer.isRegistered()) {
-      final var tracer = GlobalTracer.get();
-      final var span = tracer.scopeManager().activeSpan();
-      other.execute(
-          Context.current()
-              .wrap(
-                  () -> {
-                    try (Scope s = tracer.scopeManager().activate(span)) {
-                      r.run();
-                    }
-                  }));
-    } else {
-      other.execute(Context.current().wrap(r));
-    }
+  public void execute(@NonNull Runnable runnable) {
+    delegate.execute(runnable);
   }
 }

--- a/backend/common/src/main/java/ai/verta/modeldb/common/futures/FutureExecutor.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/futures/FutureExecutor.java
@@ -46,6 +46,6 @@ public class FutureExecutor implements Executor {
       r = grpcContext.wrap(r);
     }
 
-    other.execute(r);
+    delegate.execute(r);
   }
 }

--- a/backend/common/src/main/java/ai/verta/modeldb/common/futures/FutureGrpc.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/futures/FutureGrpc.java
@@ -22,4 +22,17 @@ public class FutureGrpc {
         },
         ex);
   }
+
+  public static <T extends GeneratedMessageV3> void serverResponse(
+      StreamObserver<T> observer, Future<T> f) {
+    f.whenComplete(
+        (v, t) -> {
+          if (t == null) {
+            observer.onNext(v);
+            observer.onCompleted();
+          } else {
+            CommonUtils.observeError(observer, t);
+          }
+        });
+  }
 }

--- a/backend/common/src/main/java/ai/verta/modeldb/common/futures/FutureJdbi.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/futures/FutureJdbi.java
@@ -84,4 +84,61 @@ public class FutureJdbi {
 
     return InternalFuture.from(promise);
   }
+
+  public <R, T extends Exception> Future<R> handleCompose(HandleCallback<Future<R>, T> callback) {
+    return handle(callback).thenCompose(x -> x);
+  }
+
+  public <R, T extends Exception> Future<R> handle(HandleCallback<R, T> callback) {
+    SupplierWithException<R, T> supplierWithException = () -> jdbi.withHandle(callback);
+    return handleOrTransaction(supplierWithException);
+  }
+
+  public <R, T extends Exception> Future<R> inTransaction(HandleCallback<R, T> callback) {
+    SupplierWithException<R, T> supplierWithException = () -> jdbi.inTransaction(callback);
+    return handleOrTransaction(supplierWithException);
+  }
+
+  private <R, T extends Exception> Future<R> handleOrTransaction(
+      SupplierWithException<R, T> supplier) {
+    CompletableFuture<R> promise = new CompletableFuture<>();
+
+    executor.execute(
+        () -> {
+          try {
+            promise.complete(supplier.get());
+          } catch (Throwable e) {
+            promise.completeExceptionally(e);
+          }
+        });
+
+    return Future.from(promise);
+  }
+
+  public <T extends Exception> Future<Void> handle(HandleConsumer<T> consumer) {
+    RunnableWithException<T> runnableWithException = () -> jdbi.useHandle(consumer);
+    return handleOrTransaction(runnableWithException);
+  }
+
+  public <T extends Exception> Future<Void> transaction(HandleConsumer<T> consumer) {
+    RunnableWithException<T> runnableWithException = () -> jdbi.useTransaction(consumer);
+    return handleOrTransaction(runnableWithException);
+  }
+
+  private <T extends Exception> Future<Void> handleOrTransaction(
+      RunnableWithException<T> runnableWithException) {
+    CompletableFuture<Void> promise = new CompletableFuture<>();
+
+    executor.execute(
+        () -> {
+          try {
+            runnableWithException.run();
+            promise.complete(null);
+          } catch (Throwable e) {
+            promise.completeExceptionally(e);
+          }
+        });
+
+    return Future.from(promise);
+  }
 }

--- a/backend/common/src/main/java/ai/verta/modeldb/common/futures/FutureRest.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/futures/FutureRest.java
@@ -25,4 +25,21 @@ public class FutureRest {
         ex);
     return promise;
   }
+
+  public static <T> CompletableFuture<T> serverResponse(Future<T> future) {
+    CompletableFuture<T> promise = new CompletableFuture<>();
+    future.whenComplete(
+        (v, t) -> {
+          if (t == null) {
+            try {
+              promise.complete(v);
+            } catch (Throwable e) {
+              CommonUtils.observeError(promise, t);
+            }
+          } else {
+            CommonUtils.observeError(promise, t);
+          }
+        });
+    return promise;
+  }
 }

--- a/backend/common/src/main/java/ai/verta/modeldb/common/futures/InternalFuture.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/futures/InternalFuture.java
@@ -348,4 +348,8 @@ public class InternalFuture<T> {
   public CompletionStage<T> toCompletionStage() {
     return stage;
   }
+
+  public Future<T> toFuture() {
+    return Future.from(stage);
+  }
 }

--- a/backend/common/src/test/java/ai/verta/modeldb/common/futures/FutureTest.java
+++ b/backend/common/src/test/java/ai/verta/modeldb/common/futures/FutureTest.java
@@ -1,0 +1,210 @@
+package ai.verta.modeldb.common.futures;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+class FutureTest {
+
+  @AfterEach
+  void tearDown() {
+    Future.resetExecutorForTest();
+  }
+
+  @BeforeEach
+  void setUp() {
+    FutureExecutor executor = FutureExecutor.newSingleThreadExecutor();
+    Future.setFutureExecutor(executor);
+  }
+
+  @Test
+  void executorRequired() {
+    Future.resetExecutorForTest();
+    assertThatThrownBy(() -> Future.of("foo"));
+    assertThatThrownBy(() -> Future.failedStage(new RuntimeException()));
+    assertThatThrownBy(() -> Future.supplyAsync(() -> "foo"));
+    assertThatThrownBy(() -> Future.runAsync(() -> {}));
+    assertThatThrownBy(() -> Future.sequence(List.of()));
+
+    Future.setFutureExecutor(FutureExecutor.newSingleThreadExecutor());
+    Future<String> baseFuture = Future.of("foo");
+    Future.resetExecutorForTest();
+    assertThatThrownBy(() -> Future.retriableStage(() -> baseFuture, throwable -> true));
+    assertThatThrownBy(() -> Future.flipOptional(Optional.of(baseFuture)));
+  }
+
+  @Test
+  void composition_failsFast() {
+    Future<String> testFuture =
+        Future.of("cheese")
+            .thenCompose(
+                s1 -> {
+                  throw new RuntimeException("borken");
+                })
+            .thenCompose(
+                s -> {
+                  Assertions.fail("should never execute the next stage");
+                  return Future.failedStage(new RuntimeException("broken"));
+                });
+
+    assertThatThrownBy(testFuture::get).isInstanceOf(RuntimeException.class).hasMessage("borken");
+  }
+
+  @Test
+  void thenSupply() throws Exception {
+    AtomicBoolean firstWasCalled = new AtomicBoolean();
+    Future<Void> testFuture =
+        Future.supplyAsync(
+            () -> {
+              firstWasCalled.set(true);
+              return null;
+            });
+    Future<String> result = testFuture.thenSupply(() -> Future.of("cheese"));
+    assertThat(result.get()).isEqualTo("cheese");
+    assertThat(firstWasCalled).isTrue();
+  }
+
+  @Test
+  void thenSupply_exception() {
+    AtomicBoolean secondWasCalled = new AtomicBoolean();
+    Future<Void> testFuture =
+        Future.supplyAsync(
+            () -> {
+              throw new IllegalStateException("failed");
+            });
+    Future<String> result =
+        testFuture.thenSupply(
+            () ->
+                Future.supplyAsync(
+                    () -> {
+                      secondWasCalled.set(true);
+                      return "cheese";
+                    }));
+    assertThatThrownBy(result::get)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("failed");
+    assertThat(secondWasCalled).isFalse();
+  }
+
+  @Test
+  @Timeout(2)
+  void retry_retryCheckerThrows() {
+    assertThatThrownBy(
+            () ->
+                Future.retriableStage(
+                        () -> Future.failedStage(new NullPointerException()),
+                        throwable -> {
+                          // retry checker throws an exception....
+                          throw new RuntimeException("uh oh!");
+                        })
+                    .get())
+        .isInstanceOf(ExecutionException.class)
+        .hasRootCauseInstanceOf(RuntimeException.class)
+        .hasRootCauseMessage("uh oh!");
+  }
+
+  @Test
+  void retry() throws Exception {
+    AtomicInteger sequencer = new AtomicInteger();
+
+    assertThat(
+            Future.retriableStage(
+                    () -> {
+                      if (sequencer.getAndIncrement() < 2) {
+                        return Future.failedStage(new NullPointerException());
+                      }
+                      return Future.of("success!");
+                    },
+                    throwable -> true)
+                .get())
+        .isEqualTo("success!");
+  }
+
+  @Test
+  @Timeout(2)
+  void sequence_exceptionHandling() {
+    assertThatThrownBy(
+            () ->
+                Future.sequence(
+                        List.of(Future.of("one"), Future.failedStage(new IOException("io failed"))))
+                    .get())
+        .isInstanceOf(IOException.class)
+        .hasMessage("io failed");
+  }
+
+  @Test
+  void sequence() throws Exception {
+    assertThat(Future.sequence(List.of(Future.of("one"), Future.of("two"))).get())
+        .containsExactly("one", "two");
+  }
+
+  @Test
+  void thenCombine() throws Exception {
+    assertThat(Future.of("one").thenCombine(Future.of("two"), (s, s2) -> s + s2).get())
+        .isEqualTo("onetwo");
+  }
+
+  @Test
+  void thenAccept() throws Exception {
+    AtomicReference<String> seenValue = new AtomicReference<>();
+    Future.of("one").thenAccept(seenValue::set).get();
+    assertThat(seenValue).hasValue("one");
+  }
+
+  @Test
+  void thenRun() throws Exception {
+    AtomicBoolean runnableCalled = new AtomicBoolean();
+    Future.of("one").thenRun(() -> runnableCalled.set(true)).get();
+    assertThat(runnableCalled).isTrue();
+  }
+
+  @Test
+  void flipOptional() throws Exception {
+    final var res1 = Future.flipOptional(Optional.of(Future.of("123"))).get();
+    assertThat(res1).isPresent().hasValue("123");
+
+    final var res2 = Future.flipOptional(Optional.empty()).get();
+    assertThat(res2).isEmpty();
+  }
+
+  @Test
+  void recover() throws Exception {
+    final var value =
+        Future.of(123)
+            .thenCompose(
+                v -> {
+                  if (true) {
+                    throw new RuntimeException();
+                  }
+                  return Future.of(123);
+                })
+            .recover(t -> 456)
+            .get();
+
+    assertThat(value).isEqualTo(456);
+  }
+
+  @Test
+  void fireAndForget() {
+    AtomicBoolean executed = new AtomicBoolean();
+    AtomicReference<String> forgottenResult = new AtomicReference<>();
+    Future.runAsync(() -> forgottenResult.set("complete!"))
+        .whenComplete((u, throwable) -> executed.set(true));
+
+    await().until(executed::get);
+    assertThat(forgottenResult).hasValue("complete!");
+  }
+}

--- a/backend/common/src/test/java/ai/verta/modeldb/common/futures/FutureTest.java
+++ b/backend/common/src/test/java/ai/verta/modeldb/common/futures/FutureTest.java
@@ -233,7 +233,7 @@ class FutureTest {
                         tracer.spanBuilder("two").startSpan().end();
                         return "two";
                       }))
-          .thenRun(() -> tracer.spanBuilder("four").startSpan().end())
+          .thenRun(() -> tracer.spanBuilder("three").startSpan().end())
           .get();
     } finally {
       outside.end();
@@ -248,8 +248,7 @@ class FutureTest {
                     s -> s.hasName("outer").hasEnded(),
                     s -> s.hasName("one").hasEnded(),
                     s -> s.hasName("two").hasEnded(),
-                    s -> s.hasName("three").hasEnded(),
-                    s -> s.hasName("four").hasEnded()));
+                    s -> s.hasName("three").hasEnded()));
   }
 
   @Test
@@ -291,7 +290,7 @@ class FutureTest {
                           return Future.of(key.get());
                         });
                   });
-          assertThat(key.get()).isEqualTo("2");
+          assertThat(future2.get()).isEqualTo("2");
           return null;
         });
   }


### PR DESCRIPTION
This option is to have a global FutureExecutor that is used by the Future implementation.

<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

## Risks and Area of Effect

## Testing
- [x] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

## Reverting
- [ ] Contains Migration - _Do Not Revert_