### PR TITLE
fix: Make context propagation deterministic

### DIFF
--- a/backend/common/pom.xml
+++ b/backend/common/pom.xml
@@ -94,6 +94,11 @@
             <artifactId>opentelemetry-semconv</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.opentelemetry.instrumentation</groupId>
             <artifactId>opentelemetry-spring-webmvc-5.3</artifactId>
             <version>${otel.instrumentation.version}</version>

--- a/backend/common/src/main/java/ai/verta/modeldb/common/futures/FutureExecutor.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/futures/FutureExecutor.java
@@ -1,12 +1,10 @@
 package ai.verta.modeldb.common.futures;
 
-import io.grpc.Context;
 import io.opentracing.Scope;
 import io.opentracing.util.GlobalTracer;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
-
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.With;
@@ -19,7 +17,8 @@ public class FutureExecutor implements Executor {
   @With private final io.grpc.Context grpcContext;
 
   public FutureExecutor captureContext() {
-    return withOtelContext(io.opentelemetry.context.Context.current()).withGrpcContext(io.grpc.Context.current());
+    return withOtelContext(io.opentelemetry.context.Context.current())
+        .withGrpcContext(io.grpc.Context.current());
   }
 
   // Wraps an Executor and make it compatible with grpc's context
@@ -54,12 +53,11 @@ public class FutureExecutor implements Executor {
       final var span = tracer.scopeManager().activeSpan();
       Runnable finalR = r;
       other.execute(
-
-                  () -> {
-                    try (Scope s = tracer.scopeManager().activate(span)) {
-                      finalR.run();
-                    }
-                  });
+          () -> {
+            try (Scope s = tracer.scopeManager().activate(span)) {
+              finalR.run();
+            }
+          });
     } else {
       other.execute(r);
     }

--- a/backend/common/src/main/java/ai/verta/modeldb/common/futures/FutureExecutor.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/futures/FutureExecutor.java
@@ -6,18 +6,25 @@ import io.opentracing.util.GlobalTracer;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.With;
 import org.springframework.lang.NonNull;
 
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class FutureExecutor implements Executor {
-  final Executor other;
+  private final Executor other;
+  @With private final io.opentelemetry.context.Context otelContext;
+  @With private final io.grpc.Context grpcContext;
 
-  FutureExecutor(Executor other) {
-    this.other = io.opentelemetry.context.Context.taskWrapping(other);
+  public FutureExecutor captureContext() {
+    return withOtelContext(io.opentelemetry.context.Context.current()).withGrpcContext(io.grpc.Context.current());
   }
 
   // Wraps an Executor and make it compatible with grpc's context
   public static FutureExecutor makeCompatibleExecutor(Executor ex) {
-    return new FutureExecutor(ex);
+    return new FutureExecutor(ex, null, null);
   }
 
   public static FutureExecutor initializeExecutor(Integer threadCount) {
@@ -35,19 +42,26 @@ public class FutureExecutor implements Executor {
 
   @Override
   public void execute(@NonNull Runnable r) {
+    if (otelContext != null) {
+      r = otelContext.wrap(r);
+    }
+    if (grpcContext != null) {
+      r = grpcContext.wrap(r);
+    }
+
     if (GlobalTracer.isRegistered()) {
       final var tracer = GlobalTracer.get();
       final var span = tracer.scopeManager().activeSpan();
+      Runnable finalR = r;
       other.execute(
-          Context.current()
-              .wrap(
+
                   () -> {
                     try (Scope s = tracer.scopeManager().activate(span)) {
-                      r.run();
+                      finalR.run();
                     }
-                  }));
+                  });
     } else {
-      other.execute(Context.current().wrap(r));
+      other.execute(r);
     }
   }
 }

--- a/backend/common/src/main/java/ai/verta/modeldb/common/futures/FutureExecutor.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/futures/FutureExecutor.java
@@ -1,7 +1,5 @@
 package ai.verta.modeldb.common.futures;
 
-import io.opentracing.Scope;
-import io.opentracing.util.GlobalTracer;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
@@ -48,18 +46,6 @@ public class FutureExecutor implements Executor {
       r = grpcContext.wrap(r);
     }
 
-    if (GlobalTracer.isRegistered()) {
-      final var tracer = GlobalTracer.get();
-      final var span = tracer.scopeManager().activeSpan();
-      Runnable finalR = r;
-      other.execute(
-          () -> {
-            try (Scope s = tracer.scopeManager().activate(span)) {
-              finalR.run();
-            }
-          });
-    } else {
-      other.execute(r);
-    }
+    other.execute(r);
   }
 }

--- a/backend/common/src/main/java/ai/verta/modeldb/common/futures/InternalFuture.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/futures/InternalFuture.java
@@ -115,8 +115,7 @@ public class InternalFuture<T> {
             executor));
   }
 
-  public <U> InternalFuture<U> thenApply(
-      Function<? super T, ? extends U> fn, FutureExecutor ex) {
+  public <U> InternalFuture<U> thenApply(Function<? super T, ? extends U> fn, FutureExecutor ex) {
     final var executor = ex.captureContext();
     return from(
         stage.thenApplyAsync(
@@ -270,8 +269,7 @@ public class InternalFuture<T> {
    * Syntactic sugar for {@link #thenCompose(Function, Executor)} with the function ignoring the
    * input.
    */
-  public <U> InternalFuture<U> thenSupply(
-      Supplier<InternalFuture<U>> supplier, FutureExecutor ex) {
+  public <U> InternalFuture<U> thenSupply(Supplier<InternalFuture<U>> supplier, FutureExecutor ex) {
     final var executor = ex.captureContext();
     return thenCompose(ignored -> supplier.get(), executor);
   }

--- a/backend/common/src/main/java/ai/verta/modeldb/common/futures/InternalFuture.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/futures/InternalFuture.java
@@ -118,9 +118,10 @@ public class InternalFuture<T> {
   public <U> InternalFuture<U> thenApply(
       Function<? super T, ? extends U> fn, FutureExecutor ex) {
     final var executor = ex.captureContext();
-    return from(
-        stage.thenApplyAsync(
-            traceFunction(callingContext.wrapFunction(fn), "futureThenApply"), executor));
+    return from(stage.thenApplyAsync(fn, executor));
+//    return from(
+//        stage.thenApplyAsync(
+//            traceFunction(callingContext.wrapFunction(fn), "futureThenApply"), executor));
   }
 
   private <U> Function<? super T, ? extends U> traceFunction(

--- a/backend/common/src/main/java/ai/verta/modeldb/common/futures/InternalFuture.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/futures/InternalFuture.java
@@ -118,9 +118,9 @@ public class InternalFuture<T> {
   public <U> InternalFuture<U> thenApply(Function<? super T, ? extends U> fn, FutureExecutor ex) {
     final var executor = ex.captureContext();
     return from(stage.thenApplyAsync(fn, executor));
-//    return from(
-//        stage.thenApplyAsync(
-//            traceFunction(callingContext.wrapFunction(fn), "futureThenApply"), executor));
+    //    return from(
+    //        stage.thenApplyAsync(
+    //            traceFunction(callingContext.wrapFunction(fn), "futureThenApply"), executor));
   }
 
   private <U> Function<? super T, ? extends U> traceFunction(

--- a/backend/common/src/test/java/ai/verta/modeldb/common/futures/InternalFutureTest.java
+++ b/backend/common/src/test/java/ai/verta/modeldb/common/futures/InternalFutureTest.java
@@ -6,6 +6,10 @@ import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
 
 import io.grpc.Context;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
@@ -15,8 +19,12 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 class InternalFutureTest {
+  @RegisterExtension
+  static final OpenTelemetryExtension otelTesting = OpenTelemetryExtension.create();
+
   @Test
   void composition_failsFast() {
     FutureExecutor executor = FutureExecutor.newSingleThreadExecutor();
@@ -156,6 +164,53 @@ class InternalFutureTest {
 
     await().until(executed::get);
     assertThat(forgottenResult).hasValue("complete!");
+  }
+
+  @Test
+  void trace() throws Exception {
+    FutureExecutor executor = FutureExecutor.initializeExecutor(2);
+
+    Tracer tracer = otelTesting.getOpenTelemetry().getTracer("testTracer");
+    Span outside = tracer.spanBuilder("outer").startSpan();
+    try (Scope ignored = outside.makeCurrent()) {
+      InternalFuture.supplyAsync(
+              () -> {
+                tracer.spanBuilder("one").startSpan().end();
+                return "one";
+              },
+              executor)
+          .thenCompose(
+              a ->
+                  InternalFuture.supplyAsync(
+                      () -> {
+                        tracer.spanBuilder("two").startSpan().end();
+                        return "two";
+                      },
+                      executor),
+              executor)
+          .thenApply(
+              s -> {
+                tracer.spanBuilder("three").startSpan().end();
+                return "three";
+              },
+              executor)
+          .thenRun(() -> tracer.spanBuilder("four").startSpan().end(), executor)
+          .get();
+    } finally {
+      outside.end();
+    }
+
+    otelTesting
+        .assertTraces()
+        .hasSize(1)
+        .hasTracesSatisfyingExactly(
+            trace ->
+                trace.hasSpansSatisfyingExactlyInAnyOrder(
+                    s -> s.hasName("outer").hasEnded(),
+                    s -> s.hasName("one").hasEnded(),
+                    s -> s.hasName("two").hasEnded(),
+                    s -> s.hasName("three").hasEnded(),
+                    s -> s.hasName("four").hasEnded()));
   }
 
   @Test

--- a/backend/common/src/test/java/ai/verta/modeldb/common/futures/InternalFutureTest.java
+++ b/backend/common/src/test/java/ai/verta/modeldb/common/futures/InternalFutureTest.java
@@ -5,14 +5,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
 
+import io.grpc.Context;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
-
-import io.grpc.Context;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -159,41 +158,50 @@ class InternalFutureTest {
     assertThat(forgottenResult).hasValue("complete!");
   }
 
-    @Test
-    public void context() throws Exception {
-        final var rootContext = Context.ROOT;
-        final var executor = FutureExecutor.initializeExecutor(10);
-        final Context.Key<String> key = Context.key("key");
-        rootContext.call(() -> {
-            assertEquals(null, key.get());
-            final var context1 = rootContext.withValue(key, "1");
-            final var future1 = context1.call(() -> {
-                assertEquals("1", key.get());
-                return InternalFuture.supplyAsync(() -> {
+  @Test
+  public void context() throws Exception {
+    final var rootContext = Context.ROOT;
+    final var executor = FutureExecutor.initializeExecutor(10);
+    final Context.Key<String> key = Context.key("key");
+    rootContext.call(
+        () -> {
+          assertEquals(null, key.get());
+          final var context1 = rootContext.withValue(key, "1");
+          final var future1 =
+              context1.call(
+                  () -> {
                     assertEquals("1", key.get());
-                    try {
-                        Thread.sleep(10);
-                    } catch (InterruptedException e) {
-                        e.printStackTrace();
-                    }
-                    return key.get();
-                }, executor);
-            });
-            final var context2 = context1.withValue(key, "2");
-            final var future2 = context2.call(() -> {
-                assertEquals("2", key.get());
-                return future1.thenApply(val -> {
+                    return InternalFuture.supplyAsync(
+                        () -> {
+                          assertEquals("1", key.get());
+                          try {
+                            Thread.sleep(10);
+                          } catch (InterruptedException e) {
+                            e.printStackTrace();
+                          }
+                          return key.get();
+                        },
+                        executor);
+                  });
+          final var context2 = context1.withValue(key, "2");
+          final var future2 =
+              context2.call(
+                  () -> {
                     assertEquals("2", key.get());
-                    try {
-                        Thread.sleep(10);
-                    } catch (InterruptedException e) {
-                        e.printStackTrace();
-                    }
-                    return key.get();
-                }, executor);
-            });
-            assertEquals("2", future2.get());
-            return null;
+                    return future1.thenApply(
+                        val -> {
+                          assertEquals("2", key.get());
+                          try {
+                            Thread.sleep(10);
+                          } catch (InterruptedException e) {
+                            e.printStackTrace();
+                          }
+                          return key.get();
+                        },
+                        executor);
+                  });
+          assertEquals("2", future2.get());
+          return null;
         });
-    }
+  }
 }


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context
By wrapping the executor, we end up passing context in a non-deterministic way, based on which thread it runs, which depends on whether the future had already been completed. This changes the futures implementation to be deterministic.

## Risks and Area of Effect
Some parts of the code might have made assumptions about when the context is propagated and this might make them fail.

## Testing
- [ ] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

## Reverting
- [ ] Contains Migration - _Do Not Revert_