### PR TITLE
[VUMM-699] Fix the liquibase issue for the allstate

### DIFF
--- a/backend/common/src/main/java/ai/verta/modeldb/common/CommonDBUtil.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/CommonDBUtil.java
@@ -2,8 +2,15 @@ package ai.verta.modeldb.common;
 
 import ai.verta.modeldb.common.config.DatabaseConfig;
 import ai.verta.modeldb.common.config.RdbConfig;
+import ai.verta.modeldb.common.exceptions.ModelDBException;
 import ai.verta.modeldb.common.exceptions.UnavailableException;
+import com.google.gson.Gson;
+import com.google.gson.stream.JsonReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
 import java.sql.*;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Locale;
 import java.util.concurrent.CompletionException;
@@ -174,7 +181,7 @@ public abstract class CommonDBUtil {
       String changeSetToRevertUntilTag,
       String liquibaseRootPath,
       ResourceAccessor resourceAccessor)
-      throws LiquibaseException, SQLException, InterruptedException {
+      throws LiquibaseException, SQLException, InterruptedException, FileNotFoundException {
     var rdb = config.getRdbConfiguration();
 
     // Get database connection
@@ -188,6 +195,8 @@ public abstract class CommonDBUtil {
           System.getProperties().getProperty("liquibase.databaseChangeLogTableName");
 
       if (tableExists(con, config, changeLogTableName)) {
+        resetChangeSetLogData(jdbcCon, changeLogTableName);
+
         String trimOperation;
         if (config.getRdbConfiguration().isMssql()) {
           LOGGER.info("MSSQL detected. Using custom update to liquibase filename records.");
@@ -241,6 +250,33 @@ public abstract class CommonDBUtil {
           releaseLiquibaseLock(config);
         }
       }
+    }
+  }
+
+  private static void resetChangeSetLogData(JdbcConnection jdbcCon, String changeLogTableName) {
+    try {
+      var rootPath = CommonDBUtil.class.getClassLoader().getResource("liquibase");
+      File migrationDirectory = new File(rootPath.toURI());
+      File file = new File(migrationDirectory, "reset_filepath_database_change_log_2022_10.json");
+      if (file.exists()) {
+        Gson gson = new Gson();
+        JsonReader reader = new JsonReader(new FileReader(file));
+        ChangeSetId[] changeSetIdArray = gson.fromJson(reader, ChangeSetId[].class);
+        var changeSetIds = Arrays.asList(changeSetIdArray);
+        var updateQuery = "update %s set FILENAME=? WHERE ID=?";
+        try (var statement =
+            jdbcCon.prepareStatement(String.format(updateQuery, changeLogTableName))) {
+          for (var changeSetId : changeSetIds) {
+            statement.setString(1, changeSetId.getFileName());
+            statement.setString(2, changeSetId.getId());
+            statement.addBatch();
+          }
+          int[] count = statement.executeBatch();
+          LOGGER.trace("Reset database_change_log file path entries: {}", count.length);
+        }
+      }
+    } catch (Exception ex) {
+      throw new ModelDBException(ex);
     }
   }
 
@@ -309,7 +345,7 @@ public abstract class CommonDBUtil {
 
   protected void runLiquibaseMigration(
       DatabaseConfig config, String liquibaseRootPath, ResourceAccessor resourceAccessor)
-      throws InterruptedException, LiquibaseException, SQLException {
+      throws InterruptedException, LiquibaseException, SQLException, FileNotFoundException {
     // Change liquibase default table names
     String changeLogTableName = "database_change_log";
     String changeLogLockTableName = "database_change_log_lock";
@@ -386,5 +422,18 @@ public abstract class CommonDBUtil {
       return cause.getMessage().toLowerCase(Locale.ROOT).contains("unable to advance");
     }
     return false;
+  }
+
+  protected static class ChangeSetId {
+    private String id;
+    private String fileName;
+
+    public String getId() {
+      return id;
+    }
+
+    public String getFileName() {
+      return fileName;
+    }
   }
 }

--- a/backend/common/src/main/java/ai/verta/modeldb/common/CommonDBUtil.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/CommonDBUtil.java
@@ -204,9 +204,8 @@ public abstract class CommonDBUtil {
           // looks like sql server doesn't support the "length" function, so hardcode it here.
           trimOperation = "REPLACE(FILENAME, 'src/main/resources/', '')";
         } else {
-          // note: the leading slash here is a trick; the column doesn't have the leading slash, but
-          // adding it makes the length turn out right.
-          trimOperation = "substring(FILENAME, length('/src/main/resources/'))";
+          // note: we add 1 to the length because substring is 1-based instead of 0-based
+          trimOperation = "substring(FILENAME, length('src/main/resources/')+1)";
         }
         var updateQuery = "update %s set FILENAME=" + trimOperation + " WHERE FILENAME LIKE ?";
         try (var statement =

--- a/backend/common/src/main/java/ai/verta/modeldb/common/CommonDBUtil.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/CommonDBUtil.java
@@ -192,7 +192,7 @@ public abstract class CommonDBUtil {
         if (config.getRdbConfiguration().isMssql()) {
           LOGGER.info("MSSQL detected. Using custom update to liquibase filename records.");
           // looks like sql server doesn't support the "length" function, so hardcode it here.
-          trimOperation = "substring(FILENAME, 1, 19)";
+          trimOperation = "trim('/src/main/resources/' FROM FILENAME)";
         } else {
           trimOperation = "substring(FILENAME, length('/src/main/resources/'))";
         }

--- a/backend/common/src/main/java/ai/verta/modeldb/common/CommonDBUtil.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/CommonDBUtil.java
@@ -270,7 +270,8 @@ public abstract class CommonDBUtil {
       try (var statement =
           jdbcCon.prepareStatement(String.format(updateQuery, changeLogTableName))) {
         for (var changeSetId : changeSetIdArray) {
-          LOGGER.debug("Adding to batch: filename '{}', ID '{}'", changeSetId.fileName, changeSetId.id);
+          LOGGER.debug(
+              "Adding to batch: filename '{}', ID '{}'", changeSetId.fileName, changeSetId.id);
           statement.setString(1, changeSetId.getFileName());
           statement.setString(2, changeSetId.getId());
           statement.addBatch();

--- a/backend/common/src/main/java/ai/verta/modeldb/common/CommonDBUtil.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/CommonDBUtil.java
@@ -185,7 +185,7 @@ public abstract class CommonDBUtil {
       String changeSetToRevertUntilTag,
       String liquibaseRootPath,
       ResourceAccessor resourceAccessor)
-      throws LiquibaseException, SQLException, InterruptedException, FileNotFoundException {
+      throws LiquibaseException, SQLException, InterruptedException {
     var rdb = config.getRdbConfiguration();
 
     // Get database connection
@@ -349,7 +349,7 @@ public abstract class CommonDBUtil {
 
   protected void runLiquibaseMigration(
       DatabaseConfig config, String liquibaseRootPath, ResourceAccessor resourceAccessor)
-      throws InterruptedException, LiquibaseException, SQLException, FileNotFoundException {
+      throws InterruptedException, LiquibaseException, SQLException {
     // Change liquibase default table names
     String changeLogTableName = "database_change_log";
     String changeLogLockTableName = "database_change_log_lock";

--- a/backend/common/src/main/java/ai/verta/modeldb/common/CommonDBUtil.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/CommonDBUtil.java
@@ -270,7 +270,7 @@ public abstract class CommonDBUtil {
       try (var statement =
           jdbcCon.prepareStatement(String.format(updateQuery, changeLogTableName))) {
         for (var changeSetId : changeSetIdArray) {
-          LOGGER.debug(
+          LOGGER.info(
               "Adding to batch: filename '{}', ID '{}'", changeSetId.fileName, changeSetId.id);
           statement.setString(1, changeSetId.getFileName());
           statement.setString(2, changeSetId.getId());

--- a/backend/common/src/main/java/ai/verta/modeldb/common/CommonDBUtil.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/CommonDBUtil.java
@@ -7,9 +7,7 @@ import ai.verta.modeldb.common.exceptions.UnavailableException;
 import com.google.common.io.Resources;
 import com.google.gson.Gson;
 import com.google.gson.stream.JsonReader;
-import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileReader;
 import java.io.StringReader;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -21,7 +19,6 @@ import java.util.Locale;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
-
 import liquibase.Contexts;
 import liquibase.LabelExpression;
 import liquibase.Liquibase;

--- a/backend/common/src/main/java/ai/verta/modeldb/common/CommonDBUtil.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/CommonDBUtil.java
@@ -7,7 +7,6 @@ import ai.verta.modeldb.common.exceptions.UnavailableException;
 import com.google.common.io.Resources;
 import com.google.gson.Gson;
 import com.google.gson.stream.JsonReader;
-import java.io.FileNotFoundException;
 import java.io.StringReader;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;

--- a/backend/common/src/main/java/ai/verta/modeldb/common/CommonDBUtil.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/CommonDBUtil.java
@@ -205,8 +205,10 @@ public abstract class CommonDBUtil {
         if (config.getRdbConfiguration().isMssql()) {
           LOGGER.info("MSSQL detected. Using custom update to liquibase filename records.");
           // looks like sql server doesn't support the "length" function, so hardcode it here.
-          trimOperation = "REPLACE(FILENAME, '/src/main/resources/', '')";
+          trimOperation = "REPLACE(FILENAME, 'src/main/resources/', '')";
         } else {
+          // note: the leading slash here is a trick; the column doesn't have the leading slash, but
+          // adding it makes the length turn out right.
           trimOperation = "substring(FILENAME, length('/src/main/resources/'))";
         }
         var updateQuery = "update %s set FILENAME=" + trimOperation + " WHERE FILENAME LIKE ?";

--- a/backend/common/src/main/java/ai/verta/modeldb/common/CommonDBUtil.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/CommonDBUtil.java
@@ -205,7 +205,7 @@ public abstract class CommonDBUtil {
         if (config.getRdbConfiguration().isMssql()) {
           LOGGER.info("MSSQL detected. Using custom update to liquibase filename records.");
           // looks like sql server doesn't support the "length" function, so hardcode it here.
-          trimOperation = "trim('/src/main/resources/' FROM FILENAME)";
+          trimOperation = "REPLACE(FILENAME, '/src/main/resources/', '')";
         } else {
           trimOperation = "substring(FILENAME, length('/src/main/resources/'))";
         }

--- a/backend/common/src/main/java/ai/verta/modeldb/common/CommonDBUtil.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/CommonDBUtil.java
@@ -180,16 +180,6 @@ public abstract class CommonDBUtil {
       DatabaseConfig config,
       String changeSetToRevertUntilTag,
       String liquibaseRootPath,
-      ResourceAccessor resourceAccessor)
-      throws LiquibaseException, SQLException, InterruptedException {
-    createTablesLiquibaseMigration(
-        config, changeSetToRevertUntilTag, liquibaseRootPath, resourceAccessor, Optional.empty());
-  }
-
-  protected void createTablesLiquibaseMigration(
-      DatabaseConfig config,
-      String changeSetToRevertUntilTag,
-      String liquibaseRootPath,
       ResourceAccessor resourceAccessor,
       Optional<String> changeSetRemappingFile)
       throws LiquibaseException, SQLException, InterruptedException {
@@ -354,6 +344,12 @@ public abstract class CommonDBUtil {
       LOGGER.error(e.getMessage(), e);
       throw e;
     }
+  }
+
+  protected void runLiquibaseMigration(
+      DatabaseConfig config, String liquibaseRootPath, ResourceAccessor resourceAccessor)
+      throws InterruptedException, LiquibaseException, SQLException {
+    runLiquibaseMigration(config, liquibaseRootPath, resourceAccessor, Optional.empty());
   }
 
   protected void runLiquibaseMigration(

--- a/backend/src/main/java/ai/verta/modeldb/utils/CommonHibernateUtil.java
+++ b/backend/src/main/java/ai/verta/modeldb/utils/CommonHibernateUtil.java
@@ -254,7 +254,7 @@ public abstract class CommonHibernateUtil extends CommonDBUtil {
   }
 
   public void runLiquibaseMigration(DatabaseConfig config)
-      throws InterruptedException, LiquibaseException, SQLException, FileNotFoundException {
+      throws InterruptedException, LiquibaseException, SQLException {
     runLiquibaseMigration(
         config,
         liquibaseRootFilePath,

--- a/backend/src/main/java/ai/verta/modeldb/utils/CommonHibernateUtil.java
+++ b/backend/src/main/java/ai/verta/modeldb/utils/CommonHibernateUtil.java
@@ -11,9 +11,9 @@ import ai.verta.modeldb.common.exceptions.UnavailableException;
 import com.microsoft.sqlserver.jdbc.SQLServerDataSource;
 import io.grpc.health.v1.HealthCheckResponse;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.sql.*;
 import java.util.EnumSet;
+import java.util.Optional;
 import liquibase.exception.LiquibaseException;
 import liquibase.resource.FileSystemResourceAccessor;
 import org.apache.logging.log4j.LogManager;
@@ -258,6 +258,7 @@ public abstract class CommonHibernateUtil extends CommonDBUtil {
     runLiquibaseMigration(
         config,
         liquibaseRootFilePath,
-        new FileSystemResourceAccessor(new File(System.getProperty(CommonConstants.USER_DIR))));
+        new FileSystemResourceAccessor(new File(System.getProperty(CommonConstants.USER_DIR))),
+        Optional.of("liquibase/reset_filepath_database_change_log_2022_10.json"));
   }
 }

--- a/backend/src/main/java/ai/verta/modeldb/utils/CommonHibernateUtil.java
+++ b/backend/src/main/java/ai/verta/modeldb/utils/CommonHibernateUtil.java
@@ -11,6 +11,7 @@ import ai.verta.modeldb.common.exceptions.UnavailableException;
 import com.microsoft.sqlserver.jdbc.SQLServerDataSource;
 import io.grpc.health.v1.HealthCheckResponse;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.sql.*;
 import java.util.EnumSet;
 import liquibase.exception.LiquibaseException;
@@ -253,7 +254,7 @@ public abstract class CommonHibernateUtil extends CommonDBUtil {
   }
 
   public void runLiquibaseMigration(DatabaseConfig config)
-      throws InterruptedException, LiquibaseException, SQLException {
+      throws InterruptedException, LiquibaseException, SQLException, FileNotFoundException {
     runLiquibaseMigration(
         config,
         liquibaseRootFilePath,

--- a/backend/src/main/java/ai/verta/modeldb/utils/CommonHibernateUtil.java
+++ b/backend/src/main/java/ai/verta/modeldb/utils/CommonHibernateUtil.java
@@ -11,7 +11,6 @@ import ai.verta.modeldb.common.exceptions.UnavailableException;
 import com.microsoft.sqlserver.jdbc.SQLServerDataSource;
 import io.grpc.health.v1.HealthCheckResponse;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.sql.*;
 import java.util.EnumSet;
 import liquibase.exception.LiquibaseException;

--- a/backend/src/main/resources/liquibase/reset_filepath_database_change_log_2022_10.json
+++ b/backend/src/main/resources/liquibase/reset_filepath_database_change_log_2022_10.json
@@ -1,0 +1,1342 @@
+[
+	{
+		"id" : "createTable-1",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "create_artifact_store",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "create_comment",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "create_dataset",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "create_git_snapshot",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "create_job",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "create_path_dataset_version_info",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "create_query_dataset_version_info",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "create_raw_dataset_version_info",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "create_dataset_part_info",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "create_dataset_version",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "create_git_snapshot_file_paths",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "create_query_parameter",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "create_user_comment",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "create_artifact",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "create_code_version",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "create_experiment",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "create_feature",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "create_experiment_run",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "create_keyvalue",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "create_observation",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "create_project",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "create_tag_mapping",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "create_attribute",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "create_lineage",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "fk_artifact_fk_project_id",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "fk_artifact_fk_experiment_id",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "fk_artifact_fk_experiment_run_id",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "fk_feature_fk_project_id",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "fk_feature_fk_experiment_id",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "fk_feature_fk_experiment_run_id",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "fk_feature_fk_raw_dataset_version_info_id",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "tables-3",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "tables-tag-1.2",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "tables-4",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "fk_keyvalue_fk_project_id",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "fk_keyvalue_fk_experiment_id",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "fk_keyvalue_fk_experiment_run_id",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "fk_keyvalue_fk_dataset_id",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "fk_keyvalue_fk_dataset_version_id",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "fk_keyvalue_fk_job_id",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "fk_observation_fk_project_id",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "fk_observation_fk_experiment_id",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "fk_observation_fk_experiment_run_id",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "fk_observation_fk_artifact_id",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "fk_observation_fk_keyvaluemapping_id",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "1",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "tag-1.0",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "2-createSequence",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "tag-1.1",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "tables-tag-1.3",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "5-indexes-on-attribute",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "5.1-indexes-on-attribute",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "5.2-indexes-on-attribute",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "tables-tag-1.4",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "6-indexes-on-keyValue",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "6.1-indexes-on-keyValue",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "tables-tag-1.5",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "7-indexes-on-project-name-owner",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "7.1-indexes-on-project-name-owner",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "tables-tag-1.6",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "8-workspaces-project",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "8.1-drop-index-p_name_owner",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "8.2-add-workspaces-project",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "8.3-add-workspaces-type-project",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "9-workspaces-dataset",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "9.1-add-workspaces-dataset",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "9.2-add-workspaces-type-dataset",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "10-workspaces-assign-workspace",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "11-index-projectname-workspace-workspacetype",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "11.1-index-projectname-workspace-workspacetype",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "11.2-index-datasetname-workspace-workspacetype",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "12-create-indexes-lineage",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "12.1-create-indexes-lineage",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "12.2-create-indexes-lineage",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "create-commit",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "create-repository",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "create-repository_commit",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "create-folder_element",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "create-path_dataset_component_blob",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "create-s3_dataset_component_blob",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "create-tag",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "create-labels_mapping",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "create-commit_parent",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "add-date-updated-in-commit",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "create-git_code_blob",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "branch_create_table",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "add-parent-order-column-to-commit-parent",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "create-dataset-repository-mapping-table",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "create-notebook_code_blob",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "create-hyperparameter_element_config_blob",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "create-hyperparameter_set_config_blob",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "create-hyperparameter_discrete_set_element_mapping",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "create-config_blob",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "create-python_environment_blob",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "create-docker_environment_blob",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "create-environment_blob",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "create-python_environment_requirements",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "create-environment_command_line",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "create-environment_variables",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "artifact_part_table_create",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "copyDataToATempTableArtifact_part_temp",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "dropOldArtifactPartTable",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "create-versioning-table",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "addUniqueConstraint-versioning_modeldb_entity_mapping",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "createTempTableWithNewKeysOfFolderElement",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "copyDataToANewTable",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "replaceOldFolderElement",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "add-visibility-column-to-repository",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "add-access-modifier-column-to-repository",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "add-repository-description-column",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "add-attributes-to-repository",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "add-description-blob-table",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "add-entity-hash-on-attribute",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "index-entity-hash-on-attribute",
+		"fileName" : "src/main/resources/liquibase/create-tables-changelog-1.0.xml"
+	},
+	{
+		"id" : "13-add_s3_dataset_component_blob_s3_version_id",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "vmem-add-column-versioning-blob-type",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "vmem-add-column-config_blob_hash",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "SetNullS3VersionEmpty",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "artifact_table_update_upload_id",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "artifact_table_update_upload_completed",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "vmem-config-blob-mapping-table",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "vmem-hyperparameter-element-mapping-table",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "createTempTableWithNewKeysOfArtifact_part",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "createNewArtifactPartTable",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "copy_temp_to_new_artifact_part_table",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "drop_temp_artifact_part_table",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "add-project-deleted-column",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "add-experiment-deleted-column",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "add-experiment-run-deleted-column",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "add-dataset-deleted-column",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "add-dataset-version-deleted-column",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "add-repository-version-deleted-column",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "SetNullS3VersionEmpty-2",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "add-internal_path-pdcb",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "add-internal_path-s3dcb",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "upload_status_table_create",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "add-epoch_number",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "add-epoch_number-without-default",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "set-commit_parent-parent_order-0",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "create_c_e_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "key-value-property-mapping-table",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "1-create-text-indexes-postgres",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "1-create-text-indexes-mysql",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "recreate-text-indexes-postgres",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_er_experiment_id_index",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_kv_dsv_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_kv_p_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_kv_j_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_kv_e_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_kv_d_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_kv_er_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_at_d_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_at_dsv_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_at_e_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_at_er_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_a_e_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_a_p_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_p_name",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_at_j_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_at_p_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_a_er_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_a_l_a_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_t_e_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_t_dsv_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_t_ds_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_t_p_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_t_er_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_o_kv_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_o_e_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_o_a_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_o_er_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_o_p_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_er_cvs_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_er_dc",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_f_er_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_f_p_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_f_e_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_er_dp",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_er_n",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_er_o",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_er_p_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_p_cvs_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_e_cvs_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_uc_c_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_gfp_g_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_dsv_qdsv_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_dsv_rdsv_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_dsp_pdsv_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_cv_gss_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_cv_ca_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_dsv_pdsv_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_f_rdsv_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_qp_qdsv_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_kv_kv_val_sql",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_kv_kv_key_sql",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_at_kv_key_sql",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_kv_kv_val_postgres",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_kv_kv_key_postgres",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "create_at_kv_key_postgres",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "index_exp_name_project_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "index_exp_run_name_project_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "index_exp_run_id_project_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "index_exp_run_project_id_experiment_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "index_exp_project_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "index_vmem_exp_run_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "index_vmem_repo_id_commit",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "index_vmem_versioning_location_postgresql",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "index_vmem_versioning_location_mysql",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "index_vmem_versioning_blob_type",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "index_vmem_table",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "migration_status_table",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "db_version_1.0",
+		"fileName" : "src/main/resources/liquibase/db-changelog-1.0.xml"
+	},
+	{
+		"id" : "db_version_2.0.pre",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "index_exp_project_id_date_updated",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "index_project_id_date_updated",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "index_exp_run_ex_id_date_updated",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "index_dv_dataset_id_time_updated",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "index_dv_dataset_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "index_dataset_id_time_updated",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "index_repo_repo_id_date_updated",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "index_repository_commit_repo_id",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "index_commit_commit_hash_date_created",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "index_dataset_dataset_id_deleted",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "index_dataset_version_id_deleted",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "index_dataset_version_dataset_id_version_deleted",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "index_experiment_exp_id_deleted",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "index_experiment_run_name_pro_id_exp_id_deleted",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "db_version_2.1",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "db_version_2.2",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "index_experiment_run_id_deleted",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "index_project_id_deleted",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "index_repository_id_deleted",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "11.1.1-drop-index-projectname-workspace-workspacetype",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "11.1.2-index-projectname-workspace-workspacetype-deleted",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "11.2.1-drop-index-datasetname-workspace-workspacetype",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "11.2.2-index-datasetname-workspace-workspacetype_deleted",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "index_project_deleted",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "index_repository_deleted",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "index_experiment_deleted",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "index_experiment_run_deleted",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "index_dataset_deleted",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "index_dataset_version_deleted",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "index_project_date_updated",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "db_version_2.3",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "db_version_2.4",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "add-environment-in-experiment-run",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "index_exp_date_updated",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "index_repo_date_updated",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "index_dataset_time_updated",
+		"fileName" : "src/main/resources/liquibase/create-index-changelog.xml"
+	},
+	{
+		"id" : "index_labels_mapping_entity_hash_entity_type",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "index_labels_mapping_label",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "add-base-path-in-path-dataset-component-blob",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "add-base-path-in-s3-dataset-component-blob",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "create-query_dataset_component_blob-table",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "create-audit_service_local_audit_log",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "db_version_2.5",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "add-workspace-id-to-project",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "db_version_2.6",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "rename-workspace-to-legacy-workspace-id-on-project",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "db_version_2.7",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "add-workspace-id-to-dataset",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "db_version_2.8",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "rename-workspace-to-legacy-workspace-id-on-dataset",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "db_version_2.9",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "db_version_2.10",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "rename-workspace-id-to-legacy-workspace-id-on-repository",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "add-workspace-id-on-repository",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "db_version_2.11",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "rename-legacy-workspace-id-to-workspace-on-project",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "db_version_2.12",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "rename-legacy-workspace-id-to-workspace-on-dataset",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "db_version_2.13",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "rename-workspace-id-to-workspace-service-id-on-repository",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "db_version_2.14",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "rename-legacy-workspace-id-to-workspace-id-on-repository",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "db_version_2.15",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "add-created-on-project",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "db_version_2.16",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "db_version_2.17",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "add-created-on-repository",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "db_version_2.18",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "set-created-true-on-project-for-existing-projects",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "set-created-true-on-repository-for-existing-repositories",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "db_version_2.19",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "add-visibility-migration-project",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "add-visibility-migration-repository",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "index_visibility_migration_project",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "index_visibility_migration_repository",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "db_version_2.20",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "set-visibility-migration-false-on-repositories",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "set-visibility-migration-false-on-projects",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "modify-name-length-repository",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "db_version_2.21",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "drop-old-audit_service_local_audit_log",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "create-new-audit_service_local_audit_log",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "create-audit_resource_workspace_mapping",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "db_version_2.22",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "add-version-number-on-commit",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "db_version_2.32",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "set-empty-versioning_key-instead-of-null-in-run",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "db_version_2.23",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "change-tables-to-utf",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "db_version_2.24",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "add-created-on-experiment-run",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "set-created-true-for-existing-experiment-run",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "db_version_2.25",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "set-created-true-based-on-column-type-existing-experiment-run",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "db_version_2.26",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "delete-audit_resource_workspace_mapping-table",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "delete-audit_service_local_audit_log-table",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "db_version_2.27",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "add-version-number-on-project",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "db_version_2.28",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "add-version-number-on-experiment",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "db_version_2.29",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "add-version-number-on-experiment-run",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "db_version_2.30",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "add-version-number-on-repository",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "db_version_2.31",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "add-raw_requirements-in-python_environment_blob",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "add-raw_constraints-in-python_environment_blob",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "db_version_2.33",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "add-serialization-on-artifact",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "add-version-number-on-artifact",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "db_version_2.34",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "marked-existing-artifact-uploaded-true",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "db_version_2.35",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "create-event-table",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "db_version_2.36",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "marked-existing-artifact-uploaded-true-mssql",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "db_version_2.37",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "add-created-on-experiment",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "set-created-true-based-on-column-type-existing-experiment",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	},
+	{
+		"id" : "db_version_2.38",
+		"fileName" : "src/main/resources/liquibase/db-changelog-2.0.xml"
+	}
+]


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context
**Issue:** When changes were made to fix the Liquibase error (https://github.com/VertaAI/modeldb/pull/3175#issue-1364449687), an issue was found with the MSSQL database for my code base. Changes on this PR for MSSQL: https://github.com/VertaAI/modeldb/pull/3188/files did not function correctly or run the migration on MSSQL successfully. Further changes for the same thing at PR: https://github.com/VertaAI/modeldb/pull/3201/files#diff-c6389d60cbb34698def2d907f24829276d5a1fc67003645d8d05b652913a09fbR207 unfortunately made things worse and resulted in bad entries in the changelog table's FILENAME values.

This PR adds code to reset the state of the changelog table, and to have the proper MSSQL command to fix any other entries that used the old file paths.

## Risks and Area of Effect

## Testing
- [ ] Unit test
- [x] Deployed to dev env
- [x] Other (explain) 
Extensive testing was done in multiple mysql and mssql environments, doing a full upgrade at each step of the way from 2022_08 -> 2022_09 -> 2022_10 + these patches. For all cases, modeldb successfully applied migrations and started properly. The state of the table was verified to look good.


## Reverting
- [ ] Contains Migration - _Do Not Revert_