### PR TITLE
fix: restore the uppercasing of H2 changelog table names

### DIFF
--- a/backend/common/src/main/java/ai/verta/modeldb/common/CommonDBUtil.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/CommonDBUtil.java
@@ -366,6 +366,14 @@ public abstract class CommonDBUtil {
     // Change liquibase default table names
     String changeLogTableName = "database_change_log";
     String changeLogLockTableName = "database_change_log_lock";
+
+    if (config.getRdbConfiguration().isH2()) {
+      // H2 upper cases all table names, and liquibase has issues if you don't make this also upper
+      // case.
+      changeLogTableName = changeLogTableName.toUpperCase();
+      changeLogLockTableName = changeLogLockTableName.toUpperCase();
+    }
+
     System.getProperties().put("liquibase.databaseChangeLogTableName", changeLogTableName);
     System.getProperties().put("liquibase.databaseChangeLogLockTableName", changeLogLockTableName);
 


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

We need this H2 uppercasing until such time as all dependent projects have fixes that account for it.

## Risks and Area of Effect

## Testing
- [x] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

## Reverting
- [ ] Contains Migration - _Do Not Revert_