### PR TITLE
[VUMM-745] "java.lang.NullPointerException: extraHeaders" when loading projects list

### DIFF
--- a/backend/common/src/main/java/ai/verta/modeldb/common/futures/FutureJdbi.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/futures/FutureJdbi.java
@@ -1,7 +1,5 @@
 package ai.verta.modeldb.common.futures;
 
-import ai.verta.modeldb.common.interceptors.MetadataForwarder;
-import io.grpc.Context;
 import java.util.concurrent.CompletableFuture;
 import org.jdbi.v3.core.statement.StatementExceptions;
 
@@ -41,20 +39,16 @@ public class FutureJdbi {
   private <R, T extends Exception> InternalFuture<R> withHandleOrTransaction(
       SupplierWithException<R, T> supplier) {
     CompletableFuture<R> promise = new CompletableFuture<>();
-
-    var metadata = MetadataForwarder.getMetadata();
-    executor.execute(
-        () -> {
-          var context =
-              Context.current().withValue(MetadataForwarder.METADATA_INFO, metadata).attach();
-          try {
-            promise.complete(supplier.get());
-          } catch (Throwable e) {
-            promise.completeExceptionally(e);
-          } finally {
-            Context.current().detach(context);
-          }
-        });
+    executor
+        .captureContext()
+        .execute(
+            () -> {
+              try {
+                promise.complete(supplier.get());
+              } catch (Throwable e) {
+                promise.completeExceptionally(e);
+              }
+            });
 
     return InternalFuture.from(promise);
   }
@@ -78,21 +72,17 @@ public class FutureJdbi {
   private <T extends Exception> InternalFuture<Void> useHandleOrTransaction(
       final RunnableWithException<T> runnableWithException) {
     CompletableFuture<Void> promise = new CompletableFuture<>();
-
-    var metadata = MetadataForwarder.getMetadata();
-    executor.execute(
-        () -> {
-          var context =
-              Context.current().withValue(MetadataForwarder.METADATA_INFO, metadata).attach();
-          try {
-            runnableWithException.run();
-            promise.complete(null);
-          } catch (Throwable e) {
-            promise.completeExceptionally(e);
-          } finally {
-            Context.current().detach(context);
-          }
-        });
+    executor
+        .captureContext()
+        .execute(
+            () -> {
+              try {
+                runnableWithException.run();
+                promise.complete(null);
+              } catch (Throwable e) {
+                promise.completeExceptionally(e);
+              }
+            });
 
     return InternalFuture.from(promise);
   }


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context
The problem was happen because we have to call UAC from `FutureJdbi.withHandle` so our GRPC context is not shared with `FutureJdbi.withHandle` so when we are trying to fetch headers that context was null and we got the error.

Solution: I have passed the GRPC context to `FutureJdbi`'s methods while executing.
## Risks and Area of Effect

## Testing
- [ ] Unit test
- [ ] Deployed to dev env
- [x] Other (explain) 
- I can reproduce it locally so I have tested the same using postman.
- Also tested deploying on aj.dev and it works fine now.

## Reverting
- [ ] Contains Migration - _Do Not Revert_