### PR TITLE
feat: [CAT-155] - Log dataset into RMV using Client

### DIFF
--- a/client/verta/tests/registry/model_version/test_log_dataset.py
+++ b/client/verta/tests/registry/model_version/test_log_dataset.py
@@ -24,10 +24,20 @@ class TestLogDataset:
             model_version.get_dataset_version("fake")
 
         dataset = model_version.get_dataset_version(key1)
-        assert dataset_version1.id == dataset.linked_artifact_id
+        assert dataset_version1.id == dataset.id
 
         dataset = model_version.get_dataset_version(key2)
-        assert dataset_version2.id in dataset.linked_artifact_id
+        assert dataset_version2.id == dataset.id
 
         dataset = model_version.get_dataset_version(key3)
-        assert dataset_version3.id in dataset.linked_artifact_id
+        assert dataset_version3.id == dataset.id
+
+        with pytest.raises(KeyError, match="no dataset found with key"):
+            model_version.del_dataset_version("fake")
+
+        model_version.del_dataset_version(key3)
+
+        model_version = client.get_registered_model_version(id=model_version.id)
+
+        with pytest.raises(KeyError, match="no dataset found with key"):
+            model_version.get_dataset_version(key3)

--- a/client/verta/tests/registry/model_version/test_log_dataset.py
+++ b/client/verta/tests/registry/model_version/test_log_dataset.py
@@ -20,10 +20,8 @@ class TestLogDataset:
 
         model_version = client.get_registered_model_version(id=model_version.id)
 
-        with pytest.raises(KeyError) as excinfo:
+        with pytest.raises(KeyError, match="no dataset found with key"):
             model_version.get_dataset_version("fake")
-
-        assert "no dataset found with key" in str(excinfo.value)
 
         dataset = model_version.get_dataset_version(key1)
         assert dataset_version1.id == dataset.linked_artifact_id

--- a/client/verta/tests/registry/model_version/test_log_dataset.py
+++ b/client/verta/tests/registry/model_version/test_log_dataset.py
@@ -2,61 +2,36 @@
 
 import pytest
 
-from verta._protos.public.common import CommonService_pb2 as _CommonCommonService
+from verta.dataset import Path
 
 pytestmark = pytest.mark.not_oss  # skip if run in oss setup. Applied to entire module
 
 class TestLogDataset:
-    def test_log_dataset(self, model_version):
+    def test_log_dataset(self, client, model_version, dataset):
         key1, key2, key3 = "version1", "version2", "version3"
 
-        model_version.log_dataset(
-            key=key1,
-            path="ModelVersionEntity/191/train",
-            path_only=True,
-            artifact_type=_CommonCommonService.ArtifactTypeEnum.DATA,
-            linked_artifact_id="fbcbd389db61d78c479634b0824cf063ffc63a6af7ba5d763388a42001ed6191",
-        )
+        dataset_version1 = dataset.create_version(Path("conftest.py"))
+        dataset_version2 = dataset.create_version(Path(["modelapi_hypothesis/"]))
+        dataset_version3 = dataset.create_version(Path(["modelapi_hypothesis/"]))
 
-        model_version.log_dataset(
-            key=key2,
-            path="ModelVersionEntity/192/train",
-            path_only=True,
-            artifact_type=_CommonCommonService.ArtifactTypeEnum.BLOB,
-            linked_artifact_id="fbcbd389db61d78c479634b0824cf063ffc63a6af7ba5d763388a42001ed6192",
-        )
+        model_version.log_dataset_version(key=key1, dataset_version=dataset_version1)
+        model_version.log_dataset_version(key=key2, dataset_version=dataset_version2)
+        model_version.log_dataset_version(key=key3, dataset_version=dataset_version3)
 
-        model_version.log_dataset(
-            key=key3,
-            path="ModelVersionEntity/193/train",
-            path_only=True,
-            artifact_type=_CommonCommonService.ArtifactTypeEnum.MODEL,
-            linked_artifact_id="fbcbd389db61d78c479634b0824cf063ffc63a6af7ba5d763388a42001ed6193",
-        )
-
-        keys = model_version.get_dataset_keys()
-
-        assert len(keys) == 3
-        assert key1 in keys
-        assert key2 in keys
-        assert key3 in keys
-
-        datasets = model_version.get_datasets()
-        assert len(datasets) == 3
+        model_version = client.get_registered_model_version(id=model_version.id)
 
         with pytest.raises(KeyError) as excinfo:
-            model_version.get_dataset("fake")
+            model_version.get_dataset_version("fake")
 
         assert "no dataset found with key" in str(excinfo.value)
 
-        dataset = model_version.get_dataset(key1)
-        assert dataset.artifact_type == _CommonCommonService.ArtifactTypeEnum.DATA
-        assert "fbcbd389db61d78c479634b0824cf063ffc63a6af7ba5d763388a42001ed6191" in dataset.linked_artifact_id
+        dataset = model_version.get_dataset_version(key1)
+        assert dataset_version1.id in dataset.linked_artifact_id
 
-        dataset = model_version.get_dataset(key2)
-        assert dataset.artifact_type == _CommonCommonService.ArtifactTypeEnum.BLOB
-        assert "fbcbd389db61d78c479634b0824cf063ffc63a6af7ba5d763388a42001ed6192" in dataset.linked_artifact_id
+        dataset = model_version.get_dataset_version(key2)
+        #assert dataset.artifact_type == _CommonCommonService.ArtifactTypeEnum.BLOB
+        #assert "fbcbd389db61d78c479634b0824cf063ffc63a6af7ba5d763388a42001ed6192" in dataset.linked_artifact_id
 
-        dataset = model_version.get_dataset(key3)
-        assert dataset.artifact_type == _CommonCommonService.ArtifactTypeEnum.MODEL
-        assert "fbcbd389db61d78c479634b0824cf063ffc63a6af7ba5d763388a42001ed6193" in dataset.linked_artifact_id
+        dataset = model_version.get_dataset_version(key3)
+        #assert dataset.artifact_type == _CommonCommonService.ArtifactTypeEnum.MODEL
+        #assert "fbcbd389db61d78c479634b0824cf063ffc63a6af7ba5d763388a42001ed6193" in dataset.linked_artifact_id

--- a/client/verta/tests/registry/model_version/test_log_dataset.py
+++ b/client/verta/tests/registry/model_version/test_log_dataset.py
@@ -26,7 +26,7 @@ class TestLogDataset:
         assert "no dataset found with key" in str(excinfo.value)
 
         dataset = model_version.get_dataset_version(key1)
-        assert dataset_version1.id in dataset.linked_artifact_id
+        assert dataset_version1.id == dataset.linked_artifact_id
 
         dataset = model_version.get_dataset_version(key2)
         assert dataset_version2.id in dataset.linked_artifact_id

--- a/client/verta/tests/registry/model_version/test_log_dataset.py
+++ b/client/verta/tests/registry/model_version/test_log_dataset.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from verta._protos.public.common import CommonService_pb2 as _CommonCommonService
+
+pytestmark = pytest.mark.not_oss  # skip if run in oss setup. Applied to entire module
+
+class TestLogDataset:
+    def test_log_dataset(self, model_version):
+        key1, key2, key3 = "version1", "version2", "version3"
+
+        model_version.log_dataset(
+            key=key1,
+            path="ModelVersionEntity/191/train",
+            path_only=True,
+            artifact_type=_CommonCommonService.ArtifactTypeEnum.DATA,
+            linked_artifact_id="fbcbd389db61d78c479634b0824cf063ffc63a6af7ba5d763388a42001ed6200",
+        )
+
+        model_version.log_dataset(
+            key=key2,
+            path="ModelVersionEntity/192/train",
+            path_only=True,
+            artifact_type=_CommonCommonService.ArtifactTypeEnum.BLOB,
+            linked_artifact_id="fbcbd389db61d78c479634b0824cf063ffc63a6af7ba5d763388a42001ed6200",
+        )
+
+        model_version.log_dataset(
+            key=key3,
+            path="ModelVersionEntity/193/train",
+            path_only=True,
+            artifact_type=_CommonCommonService.ArtifactTypeEnum.MODEL,
+            linked_artifact_id="fbcbd389db61d78c479634b0824cf063ffc63a6af7ba5d763388a42001ed6200",
+        )
+
+        keys = model_version.get_dataset_keys()
+
+        assert len(keys) == 3
+        assert key1 in keys
+        assert key2 in keys
+        assert key3 in keys
+
+        datasets = model_version.get_datasets()
+        assert len(datasets) == 3
+
+        with pytest.raises(KeyError) as excinfo:
+            model_version.get_dataset("fake")
+
+        assert "no dataset found with key" in str(excinfo.value)
+
+        dataset = model_version.get_dataset(key1)
+        assert dataset.artifact_type == _CommonCommonService.ArtifactTypeEnum.DATA
+
+        dataset = model_version.get_dataset(key2)
+        assert dataset.artifact_type == _CommonCommonService.ArtifactTypeEnum.BLOB
+
+        dataset = model_version.get_dataset(key3)
+        assert dataset.artifact_type == _CommonCommonService.ArtifactTypeEnum.MODEL

--- a/client/verta/tests/registry/model_version/test_log_dataset.py
+++ b/client/verta/tests/registry/model_version/test_log_dataset.py
@@ -29,9 +29,7 @@ class TestLogDataset:
         assert dataset_version1.id in dataset.linked_artifact_id
 
         dataset = model_version.get_dataset_version(key2)
-        #assert dataset.artifact_type == _CommonCommonService.ArtifactTypeEnum.BLOB
-        #assert "fbcbd389db61d78c479634b0824cf063ffc63a6af7ba5d763388a42001ed6192" in dataset.linked_artifact_id
+        assert dataset_version2.id in dataset.linked_artifact_id
 
         dataset = model_version.get_dataset_version(key3)
-        #assert dataset.artifact_type == _CommonCommonService.ArtifactTypeEnum.MODEL
-        #assert "fbcbd389db61d78c479634b0824cf063ffc63a6af7ba5d763388a42001ed6193" in dataset.linked_artifact_id
+        assert dataset_version3.id in dataset.linked_artifact_id

--- a/client/verta/tests/registry/model_version/test_log_dataset.py
+++ b/client/verta/tests/registry/model_version/test_log_dataset.py
@@ -37,7 +37,5 @@ class TestLogDataset:
 
         model_version.del_dataset_version(key3)
 
-        model_version = client.get_registered_model_version(id=model_version.id)
-
         with pytest.raises(KeyError, match="no dataset found with key"):
             model_version.get_dataset_version(key3)

--- a/client/verta/tests/registry/model_version/test_log_dataset.py
+++ b/client/verta/tests/registry/model_version/test_log_dataset.py
@@ -15,7 +15,7 @@ class TestLogDataset:
             path="ModelVersionEntity/191/train",
             path_only=True,
             artifact_type=_CommonCommonService.ArtifactTypeEnum.DATA,
-            linked_artifact_id="fbcbd389db61d78c479634b0824cf063ffc63a6af7ba5d763388a42001ed6200",
+            linked_artifact_id="fbcbd389db61d78c479634b0824cf063ffc63a6af7ba5d763388a42001ed6191",
         )
 
         model_version.log_dataset(
@@ -23,7 +23,7 @@ class TestLogDataset:
             path="ModelVersionEntity/192/train",
             path_only=True,
             artifact_type=_CommonCommonService.ArtifactTypeEnum.BLOB,
-            linked_artifact_id="fbcbd389db61d78c479634b0824cf063ffc63a6af7ba5d763388a42001ed6200",
+            linked_artifact_id="fbcbd389db61d78c479634b0824cf063ffc63a6af7ba5d763388a42001ed6192",
         )
 
         model_version.log_dataset(
@@ -31,7 +31,7 @@ class TestLogDataset:
             path="ModelVersionEntity/193/train",
             path_only=True,
             artifact_type=_CommonCommonService.ArtifactTypeEnum.MODEL,
-            linked_artifact_id="fbcbd389db61d78c479634b0824cf063ffc63a6af7ba5d763388a42001ed6200",
+            linked_artifact_id="fbcbd389db61d78c479634b0824cf063ffc63a6af7ba5d763388a42001ed6193",
         )
 
         keys = model_version.get_dataset_keys()
@@ -51,9 +51,12 @@ class TestLogDataset:
 
         dataset = model_version.get_dataset(key1)
         assert dataset.artifact_type == _CommonCommonService.ArtifactTypeEnum.DATA
+        assert "fbcbd389db61d78c479634b0824cf063ffc63a6af7ba5d763388a42001ed6191" in dataset.linked_artifact_id
 
         dataset = model_version.get_dataset(key2)
         assert dataset.artifact_type == _CommonCommonService.ArtifactTypeEnum.BLOB
+        assert "fbcbd389db61d78c479634b0824cf063ffc63a6af7ba5d763388a42001ed6192" in dataset.linked_artifact_id
 
         dataset = model_version.get_dataset(key3)
         assert dataset.artifact_type == _CommonCommonService.ArtifactTypeEnum.MODEL
+        assert "fbcbd389db61d78c479634b0824cf063ffc63a6af7ba5d763388a42001ed6193" in dataset.linked_artifact_id

--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -1572,6 +1572,12 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
         """
         for dataset in self._msg.datasets:
             if dataset.key == key:
-                return dataset
+                return _dataset_version.DatasetVersion(
+                    self._conn,
+                    self._conf,
+                    _dataset_version.DatasetVersion._get_proto_by_id(
+                        self._conn, dataset.linked_artifact_id
+                    ),
+                )
 
         raise KeyError("no dataset found with key {}".format(key))

--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -43,7 +43,7 @@ from .. import lock, DockerImage
 from ..stage_change import _StageChange
 
 from verta.dataset.entities import (
-    _dataset
+    _dataset_version
 )
 
 logger = logging.getLogger(__name__)

--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -1532,7 +1532,7 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
             Dataset version.
 
         """
-        if not isinstance(dataset_version, _dataset.DatasetVersion):
+        if not isinstance(dataset_version, _dataset_version.DatasetVersion):
             raise TypeError("`dataset_version` must be of type DatasetVersion")
 
         artifact_msg = _CommonCommonService.Artifact(
@@ -1566,7 +1566,7 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
 
         Returns
         -------
-        `DatasetVersion <dataset.html>`_
+        :class:`~verta.dataset.entities.DatasetVersion`
             DatasetVersion associated with the given key.
 
         """
@@ -1581,3 +1581,33 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
                 )
 
         raise KeyError("no dataset found with key {}".format(key))
+
+    def del_dataset_version(self, key):
+        """
+        Deletes the DatasetVersion with name `key` from this Model Version.
+
+        Parameters
+        ----------
+        key : str
+            Name of dataset version.
+
+        """
+        if key == self._MODEL_KEY:
+            raise ValueError(
+                "model can't be deleted through del_dataset_version(); consider using del_model() instead"
+            )
+
+        self._fetch_with_no_cache()
+
+        ind = -1
+        for i in range(len(self._msg.datasets)):
+            dataset = self._msg.datasets[i]
+            if dataset.key == key:
+                ind = i
+                break
+
+        if ind == -1:
+            raise KeyError("no dataset found with key {}".format(key))
+
+        del self._msg.datasets[ind]
+        self._update(self._msg, method="PUT")

--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -1571,6 +1571,7 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
 
         """
         self._refresh_cache()
+
         for dataset in self._msg.datasets:
             if dataset.key == key:
                 return _dataset_version.DatasetVersion(

--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -1570,6 +1570,7 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
             DatasetVersion associated with the given key.
 
         """
+        self._refresh_cache()
         for dataset in self._msg.datasets:
             if dataset.key == key:
                 return _dataset_version.DatasetVersion(

--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -1593,11 +1593,6 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
             Name of dataset version.
 
         """
-        if key == self._MODEL_KEY:
-            raise ValueError(
-                "model can't be deleted through del_dataset_version(); consider using del_model() instead"
-            )
-
         self._fetch_with_no_cache()
 
         ind = -1


### PR DESCRIPTION
# Summary

Log dataset into RMV using Client

# References

https://vertaai.atlassian.net/browse/CAT-155?atlOrigin=eyJpIjoiNmU5YjM3YTg2N2M1NDUxMmIyMGU1NWE2OWNkMDUwYTUiLCJwIjoiaiJ9

# Test Result (2022-11-07 10:00 GMT -3)
```
export VERTA_HOST="https://modelcatalog.dev.verta.ai/"
export VERTA_EMAIL="marcelo@verta.ai"
export VERTA_DEV_KEY="7ae98d72-d0dd-4034-9fb1-e2f79e894fd9"
python3.9 -m pytest -k "TestLogDataset" -rfE
============================================================================= test session starts ==============================================================================
platform linux -- Python 3.9.15, pytest-7.2.0, pluggy-1.0.0
rootdir: /opt/repositorio-git/verta/modeldb/client/verta/tests, configfile: pytest.ini
plugins: xdist-3.0.2, hypothesis-6.56.4
collected 1258 items / 1257 deselected / 3 skipped / 1 selected                                                                                                                

registry/model_version/test_log_dataset.py .                                                                                                                             [100%]

=============================================================================== warnings summary ===============================================================================
test_utils/test_pip_requirements.py:170
  /opt/repositorio-git/verta/modeldb/client/verta/tests/test_utils/test_pip_requirements.py:170: NonInteractiveExampleWarning: The `.example()` method is good for exploring strategies, but should only be used interactively.  We recommend using `@given` for tests - it performs better, saves and replays failures to avoid flakiness, and reports minimal examples. (strategy: versions())
    version=versions().example(),  # pylint: disable=no-member

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================== 1 passed, 3 skipped, 1257 deselected, 1 warning in 28.00s ===========================================================


```
