### PR TITLE
fix: use CopyOnWriteArrayList instead of Linked List for concurrency safety

### DIFF
--- a/backend/common/src/main/java/ai/verta/modeldb/common/query/QueryFilterContext.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/query/QueryFilterContext.java
@@ -4,6 +4,7 @@ import ai.verta.modeldb.common.config.DatabaseConfig;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
 import org.jdbi.v3.core.statement.Query;
 
@@ -15,9 +16,9 @@ public class QueryFilterContext {
   private Optional<Integer> pageSize;
 
   public QueryFilterContext() {
-    conditions = new LinkedList<>();
-    binds = new LinkedList<>();
-    orderItems = new LinkedList<>();
+    conditions = new CopyOnWriteArrayList<>();
+    binds = new CopyOnWriteArrayList<>();
+    orderItems = new CopyOnWriteArrayList<>();
     pageNumber = Optional.empty();
     pageSize = Optional.empty();
   }

--- a/backend/common/src/main/java/ai/verta/modeldb/common/query/QueryFilterContext.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/query/QueryFilterContext.java
@@ -1,7 +1,6 @@
 package ai.verta.modeldb.common.query;
 
 import ai.verta.modeldb.common.config.DatabaseConfig;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;


### PR DESCRIPTION
…safety

<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context
LinkedList == bad

## Risks and Area of Effect

## Testing
- [ ] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

## Reverting
- [ ] Contains Migration - _Do Not Revert_