### PR TITLE
Fix connection commit issue when we use migrator tool

### DIFF
--- a/backend/common/src/main/java/ai/verta/modeldb/common/CommonDBUtil.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/CommonDBUtil.java
@@ -387,15 +387,17 @@ public abstract class CommonDBUtil {
       throws SQLException, MigrationException {
     RdbConfig rdbConfiguration = config.getRdbConfiguration();
     createDBIfNotExists(rdbConfiguration);
-    Connection connection = acquireDatabaseConnection(config, rdbConfiguration);
-    Migrator migrator =
-        new Migrator(
-            connection,
-            findResourcesDirectory(migrationResourcesRootDirectory, rdbConfiguration),
-            rdbConfiguration);
-    boolean liquibaseTableExists = tableExists(connection, config, "database_change_log");
-    migrator.preInitializeIfRequired(liquibaseTableExists, currentVersion);
-    migrator.performMigration();
+    try (Connection connection = acquireDatabaseConnection(config, rdbConfiguration)) {
+      Migrator migrator =
+          new Migrator(
+              connection,
+              findResourcesDirectory(migrationResourcesRootDirectory, rdbConfiguration),
+              rdbConfiguration);
+      boolean liquibaseTableExists = tableExists(connection, config, "database_change_log");
+      migrator.preInitializeIfRequired(liquibaseTableExists, currentVersion);
+      migrator.performMigration();
+      connection.commit();
+    }
   }
 
   private String findResourcesDirectory(String rootDirectory, RdbConfig rdbConfiguration) {


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context
https://jenkins.dev.verta.ai/job/build/job/registry-backend-test/873/consoleFull
Problem: We have two test suites in Registry Backend. 
1. MonitoringTestSuite
2. RegistryTestSuite
So when we are trying to run `PullRequestSuite` it will trigger migration two times from each test suite. but when the second suite tries to execute the migration, it will get the last migration (ex: 4 number) as dirty due to the connection not being closed. In the actual scenario, it should not be dirty. so 

Solution: when I am closing that connection after successful migration and try to run it again then it works fine.

## Risks and Area of Effect

## Testing
- [ ] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

## Reverting
- [ ] Contains Migration - _Do Not Revert_