### PR TITLE
chore: [VUMM-758] Do not use personal workspace for permission v2

### DIFF
--- a/client/verta/tests/clean_test_accounts.py
+++ b/client/verta/tests/clean_test_accounts.py
@@ -105,9 +105,7 @@ def delete_builds(clients):
     """
     logger.info("deleting builds")
     for client in clients:
-        workspaces = client._conn._get_visible_orgs() + [
-            client._conn.get_personal_workspace()
-        ]
+        workspaces = client._conn._get_visible_workspaces()
         for workspace in workspaces:
             # get builds
             response = requests.get(
@@ -147,9 +145,7 @@ def delete_endpoints(clients):
     """
     logger.info("deleting endpoints")
     for client in clients:
-        workspaces = client._conn._get_visible_orgs() + [
-            client._conn.get_personal_workspace()
-        ]
+        workspaces = client._conn._get_visible_workspaces()
         for workspace in workspaces:
             for endpoint in client.endpoints.with_workspace(workspace):
                 path = endpoint.path  # need to get from obj before deletion
@@ -182,7 +178,7 @@ def delete_orgs(clients):
     """
     logger.info("deleting orgs")
     for client in clients:
-        for org_name in client._conn._get_visible_orgs():
+        for org_name in client._conn._get_visible_workspaces():
             try:
                 client._get_organization(org_name).delete()
             except requests.HTTPError as e:

--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -329,24 +329,6 @@ class Connection(object):
         workspace = self.must_proto_response(response, Workspace_pb2.Workspace)
         return workspace.username or workspace.org_name
 
-    def get_personal_workspace(self):
-        email = self.auth.get("Grpc-Metadata-email")
-        if email is not None:
-            msg = UACService_pb2.GetUser(email=email)
-            response = self.make_proto_request(
-                "GET", "/api/v1/uac-proxy/uac/getUser", params=msg
-            )
-
-            if (
-                response.ok and self.is_html_response(response)
-            ) or response.status_code == requests.codes.not_found:  # fetched webapp  # UAC not found
-                pass  # fall through to OSS default workspace
-            else:
-                return self.must_proto_response(
-                    response, UACService_pb2.UserInfo
-                ).verta_info.username
-        return self._OSS_DEFAULT_WORKSPACE
-
     def get_default_workspace(self):
         response = self.make_proto_request(
             "GET", "/api/v1/uac-proxy/uac/getCurrentUser"
@@ -362,10 +344,7 @@ class Connection(object):
         if workspace_id:
             return self.get_workspace_name_from_id(workspace_id)
         else:  # old backend
-            if self._PERMISSION_V2:
-                raise ValueError("default_workspace_id is not set")
-            else:
-                return self.get_personal_workspace()
+            raise ValueError("default_workspace_id is not set")
 
 
 class NoneProtoResponse(object):

--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -344,7 +344,7 @@ class Connection(object):
         if workspace_id:
             return self.get_workspace_name_from_id(workspace_id)
         else:
-            raise ValueError("default_workspace_id is not set")
+            raise RuntimeError("default workspace is not set")
 
 
 class NoneProtoResponse(object):

--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -343,7 +343,7 @@ class Connection(object):
         workspace_id = user_info.verta_info.default_workspace_id
         if workspace_id:
             return self.get_workspace_name_from_id(workspace_id)
-        else:  # old backend
+        else:
             raise ValueError("default_workspace_id is not set")
 
 

--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -49,6 +49,7 @@ THREAD_LOCALS.active_experiment_run = None
 
 class Connection(object):
     _OSS_DEFAULT_WORKSPACE = "personal"
+    _PERMISSION_V2 = True
 
     def __init__(
         self,
@@ -259,7 +260,7 @@ class Connection(object):
         else:
             return None
 
-    def _get_visible_orgs(self):
+    def _get_visible_workspaces(self):
         response = self.make_proto_request(
             "GET", "/api/v1/uac-proxy/workspace/getVisibleWorkspaces"
         )
@@ -361,7 +362,10 @@ class Connection(object):
         if workspace_id:
             return self.get_workspace_name_from_id(workspace_id)
         else:  # old backend
-            return self.get_personal_workspace()
+            if self._PERMISSION_V2:
+                raise ValueError("default_workspace_id is not set")
+            else:
+                return self.get_personal_workspace()
 
 
 class NoneProtoResponse(object):

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -376,7 +376,7 @@ class Client(object):
             Name of the Project.
         workspace : str, optional
             Workspace under which the Project with name `name` exists. If not provided, the current
-            user's personal workspace will be used.
+            user's default workspace will be used.
         id : str, optional
             ID of the Project. This parameter cannot be provided alongside `name`.
 
@@ -441,7 +441,7 @@ class Client(object):
             Attributes of the Project.
         workspace : str, optional
             Workspace under which the Project with name `name` exists. If not provided, the current
-            user's personal workspace will be used.
+            user's default workspace will be used.
         public_within_org : bool, optional
             If creating a Project in an organization's workspace: ``True`` for
             public, ``False`` for private. In older backends, default is
@@ -796,7 +796,7 @@ class Client(object):
             Labels of the registered_model.
         workspace : str, optional
             Workspace under which the registered_model with name `name` exists. If not provided, the current
-            user's personal workspace will be used.
+            user's default workspace will be used.
         public_within_org : bool, optional
             If creating a registered_model in an organization's workspace:
             ``True`` for public, ``False`` for private. In older backends,
@@ -963,7 +963,7 @@ class Client(object):
             Description of the endpoint.
         workspace : str, optional
             Workspace under which the endpoint with name `name` exists. If not provided, the current
-            user's personal workspace will be used.
+            user's default workspace will be used.
         public_within_org : bool, optional
             If creating an endpoint in an organization's workspace: ``True``
             for public, ``False`` for private. In older backends, default is
@@ -1094,7 +1094,7 @@ class Client(object):
             Attributes of the Project.
         workspace : str, optional
             Workspace under which the Project with name `name` exists. If not provided, the current
-            user's personal workspace will be used.
+            user's default workspace will be used.
         public_within_org : bool, optional
             If creating a Project in an organization's workspace: ``True`` for
             public, ``False`` for private. In older backends, default is
@@ -1264,7 +1264,7 @@ class Client(object):
             Labels of the registered_model.
         workspace : str, optional
             Workspace under which the registered_model with name `name` exists. If not provided, the current
-            user's personal workspace will be used.
+            user's default workspace will be used.
         public_within_org : bool, optional
             If creating a registered_model in an organization's workspace:
             ``True`` for public, ``False`` for private. In older backends,
@@ -1337,7 +1337,7 @@ class Client(object):
             Description of the endpoint.
         workspace : str, optional
             Workspace under which the endpoint with name `name` exists. If not provided, the current
-            user's personal workspace will be used.
+            user's default workspace will be used.
         public_within_org : bool, optional
             If creating an endpoint in an organization's workspace: ``True``
             for public, ``False`` for private. In older backends, default is
@@ -1412,7 +1412,7 @@ class Client(object):
             Environment variables.
         workspace : str, optional
             Workspace for the endpoint. If not provided, the current user's
-            personal workspace will be used.
+            default workspace will be used.
 
         Returns
         -------
@@ -1486,7 +1486,7 @@ class Client(object):
             Attributes of the dataset.
         workspace : str, optional
             Workspace under which the dataset with name `name` exists. If not provided, the current
-            user's personal workspace will be used.
+            user's default workspace will be used.
         public_within_org : bool, optional
             If creating a dataset in an organization's workspace: ``True`` for
             public, ``False`` for private. In older backends, default is
@@ -1593,7 +1593,7 @@ class Client(object):
             Attributes of the dataset.
         workspace : str, optional
             Workspace under which the dataset with name `name` exists. If not provided, the current
-            user's personal workspace will be used.
+            user's default workspace will be used.
         public_within_org : bool, optional
             If creating a dataset in an organization's workspace: ``True`` for
             public, ``False`` for private. In older backends, default is
@@ -1647,7 +1647,7 @@ class Client(object):
             Name of the dataset. This parameter cannot be provided alongside `id`.
         workspace : str, optional
             Workspace under which the dataset with name `name` exists. If not provided, the current
-            user's personal workspace will be used.
+            user's default workspace will be used.
         id : str, optional
             ID of the dataset. This parameter cannot be provided alongside `name`.
 


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

The concept of a "personal workspace" is being removed in permission v2. This PR removes `Connection.get_personal_workspace()`.

## Risks and Area of Effect

This should have no impact for users. New clients can continue to be used with pre-permission v2 platforms.

`Connection.get_personal_workspace()` was only being used as a fallback for `Connection.get_default_workspace()` for backends older than Jan 2021 (https://github.com/VertaAI/modeldb/pull/1915), and all users are assigned a `default_workspace_id` as soon as they are created ([Slack thread](https://vertaai.slack.com/archives/C0306V04EJC/p1674757850181529)).

There is an issue where internal accounts bootstrapped with UAC aren't assigned a `default_workspace_id`, but that's a separate matter for the backend, and can be worked around clientside.

## Testing
- [x] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

Test suite passes against a v1 environment ([Slack thread](https://vertaai.slack.com/archives/C03PWNZU5CM/p1674775415283039?thread_ts=1674666909.564999&cid=C03PWNZU5CM)).

## Reverting
- [ ] Contains Migration - _Do Not Revert_

Revert this PR.