### PR TITLE
fix: Address a race condition in the migrator if two processes try to…

### DIFF
--- a/backend/common/src/main/java/ai/verta/modeldb/common/db/migration/Migrator.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/db/migration/Migrator.java
@@ -34,7 +34,7 @@ public class Migrator {
 
   public void performMigration(Integer desiredVersion) throws SQLException, MigrationException {
     MigrationDatastore migrationDatastore = setupDatastore();
-    migrationDatastore.lock();
+    MigrationTools.lockDatabase(migrationDatastore);
     try {
       MigrationState currentState = findCurrentState();
       if (currentState == null) {


### PR DESCRIPTION
… run migrations at the same time.

Addresses the race condition in 2 ways:
1. Lock the database earlier in the process, before figuring out what migrations to apply
2. When updating the `schema_migrations` table, check the current version as a part of the UPDATE SQL to make sure something hasn't updated it underneath us.

<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

## Risks and Area of Effect

## Testing
- [x] Unit test
- [x] Deployed to dev env
- [ ] Other (explain) 

## Reverting
- [ ] Contains Migration - _Do Not Revert_