### PR TITLE
docs: Clarify Resources docstring

### DIFF
--- a/client/verta/verta/endpoint/resources.py
+++ b/client/verta/verta/endpoint/resources.py
@@ -12,7 +12,8 @@ class Resources(object):
     Computational resources allowed for an endpoint's model, to be passed to
     :meth:`Endpoint.update() <verta.endpoint.Endpoint.update>`.
     
-    
+    For more information about how resources are used for endpoints, see
+    https://docs.verta.ai/verta/deployment/guides/endpoint-resources.
 
     For `memory`, Verta uses the same representation `as Kubernetes
     <https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory>`__:

--- a/client/verta/verta/endpoint/resources.py
+++ b/client/verta/verta/endpoint/resources.py
@@ -9,19 +9,12 @@ from ..external import six
 
 class Resources(object):
     """
-    Computational resources allowed for an endpoint's model, to be passed to
-    :meth:`Endpoint.update() <verta.endpoint.Endpoint.update>`.
-    
+    `Kubernetes computational resources
+    <https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes>`__
+    allowed for an endpoint's model, to be passed to :meth:`Endpoint.update() <verta.endpoint.Endpoint.update>`.
+
     For more information about how resources are used for endpoints, see
     https://docs.verta.ai/verta/deployment/guides/endpoint-resources.
-
-    For `memory`, Verta uses the same representation `as Kubernetes
-    <https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory>`__:
-
-        You can express memory as a plain integer or as a fixed-point integer
-        using one of these suffixes: **E, P, T, G, M, K**. You can also use the
-        power-of-two equivalents: **Ei, Pi, Ti, Gi, Mi, Ki**. For example, the
-        following represent roughly the same value: 128974848, 129e6, 129M, 123Mi.
 
     The JSON equivalent for this is:
 
@@ -36,7 +29,12 @@ class Resources(object):
     cpu : float > 0
         CPU cores allowed for an endpoint's model.
     memory : str
-        Memory allowed for an endpoint's model.
+        Memory allowed for an endpoint's model. Expects the same representation as Kubernetes:
+        
+            You can express memory as a plain integer or as a fixed-point integer
+            using one of these suffixes: **E, P, T, G, M, K**. You can also use the
+            power-of-two equivalents: **Ei, Pi, Ti, Gi, Mi, Ki**. For example, the
+            following represent roughly the same value: 128974848, 129e6, 129M, 123Mi.
 
     Examples
     --------

--- a/client/verta/verta/endpoint/resources.py
+++ b/client/verta/verta/endpoint/resources.py
@@ -11,8 +11,10 @@ class Resources(object):
     """
     Computational resources allowed for an endpoint's model, to be passed to
     :meth:`Endpoint.update() <verta.endpoint.Endpoint.update>`.
+    
+    
 
-    Verta uses the same representation for memory `as Kubernetes
+    For `memory`, Verta uses the same representation `as Kubernetes
     <https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory>`__:
 
         You can express memory as a plain integer or as a fixed-point integer
@@ -33,7 +35,7 @@ class Resources(object):
     cpu : float > 0
         CPU cores allowed for an endpoint's model.
     memory : str
-        Memory allows for an endpoint's model.
+        Memory allowed for an endpoint's model.
 
     Examples
     --------

--- a/client/verta/verta/endpoint/resources.py
+++ b/client/verta/verta/endpoint/resources.py
@@ -13,9 +13,6 @@ class Resources(object):
     <https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes>`__
     allowed for an endpoint's model, to be passed to :meth:`Endpoint.update() <verta.endpoint.Endpoint.update>`.
 
-    For more information about how resources are used for endpoints, see
-    https://docs.verta.ai/verta/deployment/guides/endpoint-resources.
-
     The JSON equivalent for this is:
 
     .. code-block:: json


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

- Change main link to **"Resource units in Kubernetes"** for more direct context on what the values mean.
- Move explanation of expected values for `memory` to **Parameters**

## Risks and Area of Effect

—

## Testing
- [ ] Unit test
- [ ] Deployed to dev env
- [x] Other (explain) 

As rendered in [the PR preview](https://verta--3416.org.readthedocs.build/en/3416/_autogen/verta.endpoint.resources.Resources.html#verta.endpoint.resources.Resources):

![Screen Shot 2022-11-30 at 9 53 06 AM](https://user-images.githubusercontent.com/96442646/204871935-ed295f62-5a35-4c5f-a0f1-19a3b9cfa6f4.png)

## Reverting
- [ ] Contains Migration - _Do Not Revert_

Revert this PR and run our client/publish-rtd Jenkins job.