### PR TITLE
fix: Capture optimizer name in Keras 2.11.0

### DIFF
--- a/client/verta/verta/integrations/keras/__init__.py
+++ b/client/verta/verta/integrations/keras/__init__.py
@@ -58,7 +58,10 @@ class VertaCallback(keras.callbacks.Callback):
         try:
             self.run.log_hyperparameter("optimizer", model.optimizer._name)
         except:
-            pass  # don't halt execution
+            try:  # TensorFlow 2.11.0 makes the optimizer name public
+                self.run.log_hyperparameter("optimizer", model.optimizer.name)
+            except:
+                pass  # don't halt execution
 
         try:
             if isinstance(model.loss, six.string_types):

--- a/client/verta/verta/integrations/keras/__init__.py
+++ b/client/verta/verta/integrations/keras/__init__.py
@@ -58,7 +58,7 @@ class VertaCallback(keras.callbacks.Callback):
         try:
             self.run.log_hyperparameter("optimizer", model.optimizer._name)
         except:
-            try:  # TensorFlow 2.11.0 makes the optimizer name public
+            try:  # Keras 2.11.0 makes the optimizer name public
                 self.run.log_hyperparameter("optimizer", model.optimizer.name)
             except:
                 pass  # don't halt execution


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

`keras==2.11.0`—bundled with `tensorflow==2.11.0`, released Nov 14—changed `model.optimizer._name` to `model.optimizer.name`

## Risks and Area of Effect

I don't think anyone's even using this, but this is pretty low-risk anyway because it keeps existing behavior, and moves on if it errors.

## Testing

### Before fix

#### `tensorflow==2.10.0`

```
% pytest --disable-warnings test_integrations.py::TestKeras::test_functional_api
=========================================== test session starts ===========================================
platform darwin -- Python 3.10.6, pytest-7.1.3, pluggy-1.0.0
rootdir: /Users/miliu/Documents/modeldb/client/verta/tests, configfile: pytest.ini
plugins: xdist-2.5.0, forked-1.4.0, hypothesis-6.56.1
collected 1 item                                                                                          

test_integrations.py .                                                                              [100%]

===================================== 1 passed, 5 warnings in 20.48s ======================================

```

#### `tensorflow==2.11.0`

```
% pytest --disable-warnings test_integrations.py::TestKeras::test_functional_api
=========================================== test session starts ===========================================
platform darwin -- Python 3.10.6, pytest-7.1.3, pluggy-1.0.0
rootdir: /Users/miliu/Documents/modeldb/client/verta/tests, configfile: pytest.ini
plugins: xdist-2.5.0, forked-1.4.0, hypothesis-6.56.1
collected 1 item                                                                                          

test_integrations.py F                                                                              [100%]

================================================ FAILURES =================================================
______________________________________ TestKeras.test_functional_api ______________________________________
...
>       assert logged_hyperparams["optimizer"] == optimizer
E       KeyError: 'optimizer'

test_integrations.py:133: KeyError
```

### After fix

#### `tensorflow==2.10.0`

```
% pytest --disable-warnings test_integrations.py::TestKeras::test_functional_api
=========================================== test session starts ===========================================
platform darwin -- Python 3.10.6, pytest-7.1.3, pluggy-1.0.0
rootdir: /Users/miliu/Documents/modeldb/client/verta/tests, configfile: pytest.ini
plugins: xdist-2.5.0, forked-1.4.0, hypothesis-6.56.1
collected 1 item                                                                                          

test_integrations.py .                                                                              [100%]

===================================== 1 passed, 5 warnings in 21.61s ======================================

```

#### `tensorflow==2.11.0`

```
% pytest --disable-warnings test_integrations.py::TestKeras::test_functional_api
=========================================== test session starts ===========================================
platform darwin -- Python 3.10.6, pytest-7.1.3, pluggy-1.0.0
rootdir: /Users/miliu/Documents/modeldb/client/verta/tests, configfile: pytest.ini
plugins: xdist-2.5.0, forked-1.4.0, hypothesis-6.56.1
collected 1 item                                                                                          

test_integrations.py .                                                                              [100%]

===================================== 1 passed, 2 warnings in 33.52s ======================================

```

## Reverting

Revert this PR.