### PR TITLE
chore: expose the Future method to create from an existing CompletionStage

### DIFF
--- a/backend/common/src/main/java/ai/verta/modeldb/common/futures/Future.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/futures/Future.java
@@ -103,7 +103,11 @@ public class Future<T> {
     return Future.from(promise);
   }
 
-  static <R> Future<R> from(CompletionStage<R> other) {
+  /**
+   * Create a {@link Future} from an existing {@link CompletionStage}. Useful for interop with other
+   * libraries.
+   */
+  public static <R> Future<R> from(CompletionStage<R> other) {
     Preconditions.checkNotNull(
         futureExecutor, "A FutureExecutor is required to create a new Future.");
     return new Future<>(other);


### PR DESCRIPTION
Turns out this is needed to be public in some cases where we interact with other libraries.

<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

## Risks and Area of Effect

## Testing
- [ ] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

## Reverting
- [ ] Contains Migration - _Do Not Revert_