### PR TITLE
chore: Add a metric that measures the time a Future waits before being executed

### DIFF
--- a/backend/common/src/main/java/ai/verta/modeldb/common/futures/FutureExecutor.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/futures/FutureExecutor.java
@@ -21,6 +21,7 @@ public class FutureExecutor implements Executor {
   @With private final io.grpc.Context grpcContext;
 
   public FutureExecutor captureContext() {
+    //set the current nano time into the context, so we can measure how long it takes to actually execute the future.
     io.opentelemetry.context.Context otelContext = Context.current();
     otelContext = otelContext.with(EXECUTION_TIMER_KEY, System.nanoTime());
     return withOtelContext(otelContext).withGrpcContext(io.grpc.Context.current());
@@ -60,6 +61,7 @@ public class FutureExecutor implements Executor {
 
   private Runnable wrapWithTimer(Runnable r) {
     return () -> {
+      //pull the start time out of the context, and record how much time has elapsed.
       Long startTime = io.opentelemetry.context.Context.current().get(EXECUTION_TIMER_KEY);
       if (startTime != null) {
         long endTime = System.nanoTime();

--- a/backend/common/src/main/java/ai/verta/modeldb/common/futures/FutureExecutor.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/futures/FutureExecutor.java
@@ -21,7 +21,8 @@ public class FutureExecutor implements Executor {
   @With private final io.grpc.Context grpcContext;
 
   public FutureExecutor captureContext() {
-    //set the current nano time into the context, so we can measure how long it takes to actually execute the future.
+    // set the current nano time into the context, so we can measure how long it takes to actually
+    // execute the future.
     io.opentelemetry.context.Context otelContext = Context.current();
     otelContext = otelContext.with(EXECUTION_TIMER_KEY, System.nanoTime());
     return withOtelContext(otelContext).withGrpcContext(io.grpc.Context.current());
@@ -61,7 +62,7 @@ public class FutureExecutor implements Executor {
 
   private Runnable wrapWithTimer(Runnable r) {
     return () -> {
-      //pull the start time out of the context, and record how much time has elapsed.
+      // pull the start time out of the context, and record how much time has elapsed.
       Long startTime = io.opentelemetry.context.Context.current().get(EXECUTION_TIMER_KEY);
       if (startTime != null) {
         long endTime = System.nanoTime();

--- a/backend/common/src/main/java/ai/verta/modeldb/common/futures/FutureExecutor.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/futures/FutureExecutor.java
@@ -1,13 +1,12 @@
 package ai.verta.modeldb.common.futures;
 
-import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ForkJoinPool;
-
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.metrics.LongHistogram;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.ContextKey;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ForkJoinPool;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.With;

--- a/backend/common/src/main/java/ai/verta/modeldb/common/futures/FutureExecutor.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/futures/FutureExecutor.java
@@ -22,7 +22,7 @@ public class FutureExecutor implements Executor {
   @With private final io.grpc.Context grpcContext;
 
   public FutureExecutor captureContext() {
-    Context otelContext = Context.current();
+    io.opentelemetry.context.Context otelContext = Context.current();
     otelContext = otelContext.with(EXECUTION_TIMER_KEY, System.nanoTime());
     return withOtelContext(otelContext).withGrpcContext(io.grpc.Context.current());
   }
@@ -61,7 +61,7 @@ public class FutureExecutor implements Executor {
 
   private Runnable wrapWithTimer(Runnable r) {
     return () -> {
-      Long startTime = Context.current().get(EXECUTION_TIMER_KEY);
+      Long startTime = io.opentelemetry.context.Context.current().get(EXECUTION_TIMER_KEY);
       if (startTime == null) {
         r.run();
         return;

--- a/backend/common/src/main/java/ai/verta/modeldb/common/futures/FutureExecutor.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/futures/FutureExecutor.java
@@ -61,13 +61,11 @@ public class FutureExecutor implements Executor {
   private Runnable wrapWithTimer(Runnable r) {
     return () -> {
       Long startTime = io.opentelemetry.context.Context.current().get(EXECUTION_TIMER_KEY);
-      if (startTime == null) {
-        r.run();
-        return;
+      if (startTime != null) {
+        long endTime = System.nanoTime();
+        long microsDelay = (endTime - startTime) / 1_000L;
+        getSchedulingDelayHistogram().record(microsDelay);
       }
-      long endTime = System.nanoTime();
-      long millisDelay = (endTime - startTime) / 1_000L;
-      getSchedulingDelayHistogram().record(millisDelay);
       r.run();
     };
   }


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context
This will have zero impact unless the OpenTelemetry instance has been configured to have an active MeterProvider.

## Risks and Area of Effect

## Testing
- [ ] Unit test
- [x] Deployed to dev env
- [ ] Other (explain) 

## Reverting
- [ ] Contains Migration - _Do Not Revert_