### PR TITLE
chore: change the start of the future execution delay timer to right before submission

### DIFF
--- a/backend/common/src/main/java/ai/verta/modeldb/common/futures/FutureExecutor.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/futures/FutureExecutor.java
@@ -1,6 +1,6 @@
 package ai.verta.modeldb.common.futures;
 
-import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.metrics.LongHistogram;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.ContextKey;
@@ -21,25 +21,23 @@ public class FutureExecutor implements Executor {
   @With private final io.grpc.Context grpcContext;
 
   public FutureExecutor captureContext() {
-    // set the current nano time into the context, so we can measure how long it takes to actually
-    // execute the future.
     io.opentelemetry.context.Context otelContext = Context.current();
-    otelContext = otelContext.with(EXECUTION_TIMER_KEY, System.nanoTime());
     return withOtelContext(otelContext).withGrpcContext(io.grpc.Context.current());
   }
 
-  private static LongHistogram getSchedulingDelayHistogram() {
-    if (schedulingDelayHistogram != null) {
-      return schedulingDelayHistogram;
-    }
+  /**
+   * Allow the FutureExecutors to have instrumentation via OpenTelemetry. Set this as early as
+   * possible after creation, in order not to miss any metrics that might be recorded.
+   */
+  public static void setOpenTelemetry(OpenTelemetry openTelemetry) {
+    // it's ok to do this more than once, since creation of meters/instruments is idempotent in the OTel SDK.
     schedulingDelayHistogram =
-        GlobalOpenTelemetry.get()
+        openTelemetry
             .getMeter("verta.future")
             .histogramBuilder("future_exec_delay")
             .setDescription("The number of microseconds between creating and executing a Future")
             .ofLongs()
             .build();
-    return schedulingDelayHistogram;
   }
 
   // Wraps an Executor and make it compatible with grpc's context
@@ -62,12 +60,14 @@ public class FutureExecutor implements Executor {
 
   private Runnable wrapWithTimer(Runnable r) {
     return () -> {
-      // pull the start time out of the context, and record how much time has elapsed.
-      Long startTime = io.opentelemetry.context.Context.current().get(EXECUTION_TIMER_KEY);
-      if (startTime != null) {
-        long endTime = System.nanoTime();
-        long microsDelay = (endTime - startTime) / 1_000L;
-        getSchedulingDelayHistogram().record(microsDelay);
+      if (schedulingDelayHistogram != null) {
+        // pull the start time out of the context, and record how much time has elapsed.
+        Long startTime = io.opentelemetry.context.Context.current().get(EXECUTION_TIMER_KEY);
+        if (startTime != null) {
+          long endTime = System.nanoTime();
+          long microsDelay = (endTime - startTime) / 1_000L;
+          schedulingDelayHistogram.record(microsDelay);
+        }
       }
       r.run();
     };
@@ -78,7 +78,9 @@ public class FutureExecutor implements Executor {
     r = wrapWithTimer(r);
 
     if (otelContext != null) {
-      r = otelContext.wrap(r);
+      // set the current nano time into the context, so we can measure how long it takes to actually
+      // start the future execution after submission to the executor.
+      r = otelContext.with(EXECUTION_TIMER_KEY, System.nanoTime()).wrap(r);
     }
     if (grpcContext != null) {
       r = grpcContext.wrap(r);

--- a/backend/common/src/main/java/ai/verta/modeldb/common/futures/FutureExecutor.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/futures/FutureExecutor.java
@@ -30,7 +30,8 @@ public class FutureExecutor implements Executor {
    * possible after creation, in order not to miss any metrics that might be recorded.
    */
   public static void setOpenTelemetry(OpenTelemetry openTelemetry) {
-    // it's ok to do this more than once, since creation of meters/instruments is idempotent in the OTel SDK.
+    // it's ok to do this more than once, since creation of meters/instruments is idempotent in the
+    // OTel SDK.
     schedulingDelayHistogram =
         openTelemetry
             .getMeter("verta.future")


### PR DESCRIPTION
I believe this should remove the extra time that the future might have waiting for any futures that it depends on to finish.

Also: make it so that you assign the OpenTelemetry instance, rather than relying on the global.

<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

## Risks and Area of Effect

## Testing
- [ ] Unit test
- [x] Deployed to dev env
- [ ] Other (explain) 

## Reverting
- [ ] Contains Migration - _Do Not Revert_