### PR TITLE
chore: Consolidate OpenTelemetry configuration and wire up to modeldb backend

### DIFF
--- a/backend/common/src/main/java/ai/verta/modeldb/common/authservice/AuthServiceChannel.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/authservice/AuthServiceChannel.java
@@ -73,7 +73,7 @@ public class AuthServiceChannel extends Connection implements AutoCloseable {
   private <T extends AbstractStub<T>> T attachInterceptorsWithRequestHeaders(
       io.grpc.stub.AbstractStub<T> stub, Metadata requestHeaders) {
     var clientInterceptor = MetadataUtils.newAttachHeadersInterceptor(requestHeaders);
-    stub = config.getTracingClientInterceptor().map(stub::withInterceptors).orElse((T) stub);
+    stub = super.getTracingClientInterceptor().map(stub::withInterceptors).orElse((T) stub);
     stub = stub.withInterceptors(clientInterceptor);
     return (T) stub;
   }
@@ -83,7 +83,7 @@ public class AuthServiceChannel extends Connection implements AutoCloseable {
 
     var clientInterceptor =
         MetadataUtils.newAttachHeadersInterceptor(getServiceUserMetadataHeaders());
-    stub = config.getTracingClientInterceptor().map(stub::withInterceptors).orElse((T) stub);
+    stub = super.getTracingClientInterceptor().map(stub::withInterceptors).orElse((T) stub);
     stub = stub.withInterceptors(clientInterceptor);
     return (T) stub;
   }

--- a/backend/common/src/main/java/ai/verta/modeldb/common/authservice/AuthServiceChannel.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/authservice/AuthServiceChannel.java
@@ -10,6 +10,7 @@ import ai.verta.uac.*;
 import io.grpc.*;
 import io.grpc.stub.AbstractStub;
 import io.grpc.stub.MetadataUtils;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -35,8 +36,8 @@ public class AuthServiceChannel extends Connection implements AutoCloseable {
   private final String serviceUserDevKey;
   private final Config config;
 
-  public AuthServiceChannel(Config config) {
-    super(config);
+  public AuthServiceChannel(Config config, Optional<ClientInterceptor> tracingClientInterceptor) {
+    super(tracingClientInterceptor);
     String host = config.getAuthService().getHost();
     int port = config.getAuthService().getPort();
     LOGGER.trace(CommonMessages.HOST_PORT_INFO_STR, host, port);

--- a/backend/common/src/main/java/ai/verta/modeldb/common/config/Config.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/config/Config.java
@@ -202,13 +202,10 @@ public abstract class Config {
   public FutureJdbi initializeFutureJdbi(DatabaseConfig databaseConfig, String poolName) {
     final var jdbi = initializeJdbi(databaseConfig, poolName);
     final var dbExecutor = FutureExecutor.initializeExecutor(databaseConfig.getThreadCount());
-    // wrap the executor in the OpenTelemetry context wrapper to make sure the context propagates
-    // into any jdbi threads.
     return new FutureJdbi(jdbi, dbExecutor);
   }
 
   public InternalJdbi initializeJdbi(DatabaseConfig databaseConfig, String poolName) {
-    initializeTracingInterceptors();
     final var hikariDataSource = new HikariDataSource();
     final var dbUrl = RdbConfig.buildDatabaseConnectionString(databaseConfig.getRdbConfiguration());
     hikariDataSource.setJdbcUrl(dbUrl);

--- a/backend/common/src/main/java/ai/verta/modeldb/common/config/OpenTelemetryConfig.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/config/OpenTelemetryConfig.java
@@ -33,6 +33,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -40,6 +41,7 @@ import org.springframework.context.annotation.Configuration;
 public class OpenTelemetryConfig {
 
   @Bean
+  @ConditionalOnMissingBean(Sampler.class) // allow to be overridden by service-specific config
   public Sampler openTelemetrySampler() {
     return Sampler.alwaysOn();
   }

--- a/backend/common/src/main/java/ai/verta/modeldb/common/config/OpenTelemetryConfig.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/config/OpenTelemetryConfig.java
@@ -1,0 +1,145 @@
+package ai.verta.modeldb.common.config;
+
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+
+import ai.verta.modeldb.common.metrics.otelprom.PrometheusCollector;
+import io.grpc.ClientInterceptor;
+import io.grpc.ServerInterceptor;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.exporter.jaeger.thrift.JaegerThriftSpanExporter;
+import io.opentelemetry.extension.trace.propagation.JaegerPropagator;
+import io.opentelemetry.instrumentation.grpc.v1_6.GrpcTelemetry;
+import io.opentelemetry.instrumentation.resources.ContainerResource;
+import io.opentelemetry.instrumentation.resources.HostResource;
+import io.opentelemetry.opentracingshim.OpenTracingShim;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.metrics.Aggregation;
+import io.opentelemetry.sdk.metrics.InstrumentSelector;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.View;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+import io.opentracing.Tracer;
+import io.opentracing.contrib.jdbc.TracingDriver;
+import io.opentracing.util.GlobalTracer;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenTelemetryConfig {
+
+  @Bean
+  public Sampler openTelemetrySampler() {
+    return Sampler.alwaysOn();
+  }
+
+  @Bean
+  @ConditionalOnBean(Config.class)
+  public OpenTelemetry openTelemetry(Config config, Sampler sampler, Resource resource) {
+    boolean tracingEnabled = config.tracingEnabled();
+
+    SdkTracerProvider tracerProvider;
+    if (!tracingEnabled) {
+      tracerProvider = SdkTracerProvider.builder().build();
+    } else {
+      JaegerThriftSpanExporter spanExporter =
+          JaegerThriftSpanExporter.builder().setEndpoint(System.getenv("JAEGER_ENDPOINT")).build();
+      tracerProvider =
+          SdkTracerProvider.builder()
+              .addSpanProcessor(BatchSpanProcessor.builder(spanExporter).build())
+              .setSampler(sampler)
+              .setResource(resource)
+              .build();
+    }
+    SdkMeterProvider sdkMeterProvider = initializeMetricSdk();
+
+    OpenTelemetrySdk openTelemetry =
+        OpenTelemetrySdk.builder()
+            .setMeterProvider(sdkMeterProvider)
+            .setTracerProvider(tracerProvider)
+            .setPropagators(
+                ContextPropagators.create(
+                    TextMapPropagator.composite(
+                        W3CTraceContextPropagator.getInstance(), JaegerPropagator.getInstance())))
+            .buildAndRegisterGlobal();
+    initializeOpenTracingShim(openTelemetry);
+    return openTelemetry;
+  }
+
+  private static SdkMeterProvider initializeMetricSdk() {
+    return SdkMeterProvider.builder()
+        .registerMetricReader(PrometheusCollector.create())
+        .registerView(
+            InstrumentSelector.builder().setName("future_exec_delay").build(),
+            View.builder()
+                .setAggregation(
+                    Aggregation.explicitBucketHistogram(generateExponentialBucketBoundaries(5)))
+                .build())
+        .registerView(
+            InstrumentSelector.builder().setName("thread_lateness").build(),
+            View.builder()
+                .setAggregation(
+                    Aggregation.explicitBucketHistogram(generateExponentialBucketBoundaries(5)))
+                .build())
+        .build();
+  }
+
+  @Bean
+  public Resource resource() {
+    return Resource.getDefault()
+        .merge(
+            Resource.create(
+                Attributes.of(
+                    stringKey("service.name"),
+                    System.getenv("JAEGER_SERVICE_NAME"),
+                    stringKey("kubernetes.namespace"),
+                    System.getenv("POD_NAMESPACE"))))
+        .merge(HostResource.get())
+        .merge(ContainerResource.get());
+  }
+
+  /**
+   * Generate some histogram bucket boundaries. Will generate 15 boundaries, doubling each time,
+   * starting with the requested power of 2.
+   */
+  private static List<Double> generateExponentialBucketBoundaries(int initialPowerOfTwo) {
+    AtomicInteger a = new AtomicInteger(initialPowerOfTwo);
+    return Stream.generate(() -> Math.pow(2, a.getAndIncrement()))
+        .limit(15)
+        .collect(Collectors.toList());
+  }
+
+  private void initializeOpenTracingShim(OpenTelemetry openTelemetry) {
+    Tracer tracerShim = OpenTracingShim.createTracerShim(openTelemetry);
+    GlobalTracer.registerIfAbsent(tracerShim);
+    TracingDriver.load();
+    TracingDriver.setInterceptorMode(true);
+    TracingDriver.setInterceptorProperty(true);
+  }
+
+  @Bean
+  public GrpcTelemetry grpcTelemetry(OpenTelemetry openTelemetry) {
+    return GrpcTelemetry.create(openTelemetry);
+  }
+
+  @Bean
+  public ServerInterceptor grpcServerInterceptor(GrpcTelemetry grpcTelemetry) {
+    return grpcTelemetry.newServerInterceptor();
+  }
+
+  @Bean
+  public ClientInterceptor grpcClientInterceptor(GrpcTelemetry grpcTelemetry) {
+    return grpcTelemetry.newClientInterceptor();
+  }
+}

--- a/backend/common/src/main/java/ai/verta/modeldb/common/connections/Connection.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/connections/Connection.java
@@ -1,6 +1,5 @@
 package ai.verta.modeldb.common.connections;
 
-import ai.verta.modeldb.common.config.Config;
 import ai.verta.modeldb.common.config.ServiceUserConfig;
 import ai.verta.modeldb.common.interceptors.MetadataForwarder;
 import io.grpc.ClientInterceptor;
@@ -13,8 +12,8 @@ import java.util.function.Supplier;
 public abstract class Connection {
   private final Optional<ClientInterceptor> tracingClientInterceptor;
 
-  protected Connection(Config config) {
-    tracingClientInterceptor = config.getTracingClientInterceptor();
+  protected Connection(Optional<ClientInterceptor> tracingClientInterceptor) {
+    this.tracingClientInterceptor = tracingClientInterceptor;
   }
 
   // Place the interceptors in the reverse order of their stacking (the ones attached later will be
@@ -66,5 +65,9 @@ public abstract class Connection {
 
     // Force using the ROOT context so that we must lose any context of the current execution
     return Context.ROOT.withValue(MetadataForwarder.METADATA_INFO, authHeaders).attach();
+  }
+
+  protected Optional<ClientInterceptor> getTracingClientInterceptor() {
+    return tracingClientInterceptor;
   }
 }

--- a/backend/common/src/main/java/ai/verta/modeldb/common/connections/UAC.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/connections/UAC.java
@@ -8,6 +8,7 @@ import ai.verta.modeldb.common.exceptions.UnavailableException;
 import ai.verta.uac.*;
 import io.grpc.*;
 import io.grpc.stub.MetadataUtils;
+import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -35,19 +36,32 @@ public class UAC extends Connection {
     return fromConfig(config);
   }
 
-  public static UAC fromConfig(Config config) {
+  public static UAC fromConfig(
+      Config config, Optional<ClientInterceptor> tracingClientInterceptor) {
     if (!config.hasAuth()) {
       return null;
     }
-    return new UAC(config);
+    return new UAC(config, tracingClientInterceptor);
   }
 
-  private UAC(Config config) {
-    this(config.getAuthService().getHost(), config.getAuthService().getPort(), config);
+  public static UAC fromConfig(Config config) {
+    return fromConfig(config, config.getTracingClientInterceptor());
   }
 
-  public UAC(String host, Integer port, Config config) {
-    super(config);
+  private UAC(Config config, Optional<ClientInterceptor> tracingClientInterceptor) {
+    this(
+        config.getAuthService().getHost(),
+        config.getAuthService().getPort(),
+        config,
+        tracingClientInterceptor);
+  }
+
+  private UAC(
+      String host,
+      Integer port,
+      Config config,
+      Optional<ClientInterceptor> tracingClientInterceptor) {
+    super(tracingClientInterceptor);
     this.config = config;
     LOGGER.trace(CommonMessages.HOST_PORT_INFO_STR, host, port);
     if (host != null && port != null) { // AuthService not available.
@@ -81,7 +95,7 @@ public class UAC extends Connection {
   }
 
   public AuthServiceChannel getBlockingAuthServiceChannel() {
-    return new AuthServiceChannel(config);
+    return new AuthServiceChannel(config, super.getTracingClientInterceptor());
   }
 
   private Metadata getServiceUserMetadata(Config config) {

--- a/backend/common/src/main/java/ai/verta/modeldb/common/connections/UAC.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/connections/UAC.java
@@ -36,16 +36,18 @@ public class UAC extends Connection {
     return fromConfig(config);
   }
 
+  /** @deprecated Use fromConfig(config, tracingClientInterceptor) instead. */
+  @Deprecated
+  public static UAC fromConfig(Config config) {
+    return fromConfig(config, config.getTracingClientInterceptor());
+  }
+
   public static UAC fromConfig(
       Config config, Optional<ClientInterceptor> tracingClientInterceptor) {
     if (!config.hasAuth()) {
       return null;
     }
     return new UAC(config, tracingClientInterceptor);
-  }
-
-  public static UAC fromConfig(Config config) {
-    return fromConfig(config, config.getTracingClientInterceptor());
   }
 
   private UAC(Config config, Optional<ClientInterceptor> tracingClientInterceptor) {

--- a/backend/common/src/main/java/ai/verta/modeldb/common/metrics/otelprom/MetricAdapter.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/metrics/otelprom/MetricAdapter.java
@@ -1,0 +1,318 @@
+/*
+ * Note: this code has been pulled in from the OpenTelemetry project.
+ *
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package ai.verta.modeldb.common.metrics.otelprom;
+
+import static io.prometheus.client.Collector.doubleToGoString;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.sdk.metrics.data.*;
+import io.prometheus.client.Collector;
+import io.prometheus.client.Collector.MetricFamilySamples;
+import io.prometheus.client.Collector.MetricFamilySamples.Sample;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+
+/**
+ * Util methods to convert OpenTelemetry Metrics data models to Prometheus data models.
+ *
+ * <p>Each OpenTelemetry {@link MetricData} will be converted to a Prometheus {@link
+ * MetricFamilySamples}, and each {@code Point} of the {@link MetricData} will be converted to
+ * Prometheus {@link Sample}s.
+ *
+ * <p>{@code DoublePoint}, {@code LongPoint} will be converted to a single {@link Sample}. {@code
+ * Summary} will be converted to two {@link Sample}s (sum and count) plus the number of Percentile
+ * values {@code Sample}s
+ *
+ * <p>Please note that Prometheus Metric and Label name can only have alphanumeric characters and
+ * underscore. All other characters will be sanitized by underscores.
+ */
+final class MetricAdapter {
+
+  static final String SAMPLE_SUFFIX_COUNT = "_count";
+  static final String SAMPLE_SUFFIX_SUM = "_sum";
+  static final String SAMPLE_SUFFIX_BUCKET = "_bucket";
+  static final String LABEL_NAME_QUANTILE = "quantile";
+  static final String LABEL_NAME_LE = "le";
+
+  // Converts a MetricData to a Prometheus MetricFamilySamples.
+  static MetricFamilySamples toMetricFamilySamples(MetricData metricData) {
+    String cleanMetricName = cleanMetricName(metricData.getName());
+    Collector.Type type = toMetricFamilyType(metricData);
+
+    return new MetricFamilySamples(
+        cleanMetricName,
+        type,
+        metricData.getDescription(),
+        toSamples(cleanMetricName, metricData.getType(), Serializer.getPoints(metricData)));
+  }
+
+  private static String cleanMetricName(String descriptorMetricName) {
+    return Collector.sanitizeMetricName(descriptorMetricName);
+  }
+
+  static Collector.Type toMetricFamilyType(MetricData metricData) {
+    switch (metricData.getType()) {
+      case LONG_GAUGE:
+      case DOUBLE_GAUGE:
+        return Collector.Type.GAUGE;
+      case LONG_SUM:
+        SumData<LongPointData> longSumData = metricData.getLongSumData();
+        if (longSumData.isMonotonic()
+            && longSumData.getAggregationTemporality() == AggregationTemporality.CUMULATIVE) {
+          return Collector.Type.COUNTER;
+        }
+        return Collector.Type.GAUGE;
+      case DOUBLE_SUM:
+        SumData<DoublePointData> doubleSumData = metricData.getDoubleSumData();
+        if (doubleSumData.isMonotonic()
+            && doubleSumData.getAggregationTemporality() == AggregationTemporality.CUMULATIVE) {
+          return Collector.Type.COUNTER;
+        }
+        return Collector.Type.GAUGE;
+      case SUMMARY:
+        return Collector.Type.SUMMARY;
+      case HISTOGRAM:
+        return Collector.Type.HISTOGRAM;
+      case EXPONENTIAL_HISTOGRAM:
+        return Collector.Type.UNKNOWN; // todo exporter for exponential histogram
+    }
+    return Collector.Type.UNKNOWN;
+  }
+
+  static final Function<String, String> sanitizer = new NameSanitizer();
+
+  // Converts a list of points from MetricData to a list of Prometheus Samples.
+  static List<Sample> toSamples(
+      String name, MetricDataType type, Collection<? extends PointData> points) {
+    List<Sample> samples = new ArrayList<>(estimateNumSamples(points.size(), type));
+
+    for (PointData pointData : points) {
+      Attributes attributes = pointData.getAttributes();
+      List<String> labelNames = new ArrayList<>(attributes.size());
+      List<String> labelValues = new ArrayList<>(attributes.size());
+      attributes.forEach(
+          (key, value) -> {
+            String sanitizedLabelName = sanitizer.apply(key.getKey());
+            labelNames.add(sanitizedLabelName);
+            // TODO: We want to create an error-log if there is overlap in toString of attribute
+            // values for the same key name.
+            labelValues.add(value == null ? "" : value.toString());
+          });
+
+      switch (type) {
+        case DOUBLE_SUM:
+        case DOUBLE_GAUGE:
+          DoublePointData doublePoint = (DoublePointData) pointData;
+          samples.add(
+              createSample(
+                  name,
+                  labelNames,
+                  labelValues,
+                  doublePoint.getValue(),
+                  // Prometheus doesn't support exemplars on SUM/GAUGE
+                  null,
+                  doublePoint.getEpochNanos()));
+          break;
+        case LONG_SUM:
+        case LONG_GAUGE:
+          LongPointData longPoint = (LongPointData) pointData;
+          samples.add(
+              createSample(
+                  name,
+                  labelNames,
+                  labelValues,
+                  (double) longPoint.getValue(),
+                  // Prometheus doesn't support exemplars on SUM/GAUGE
+                  null,
+                  longPoint.getEpochNanos()));
+          break;
+        case SUMMARY:
+          addSummarySamples((SummaryPointData) pointData, name, labelNames, labelValues, samples);
+          break;
+        case HISTOGRAM:
+          addHistogramSamples(
+              (HistogramPointData) pointData, name, labelNames, labelValues, samples);
+          break;
+        case EXPONENTIAL_HISTOGRAM:
+          break; // todo
+      }
+    }
+    return samples;
+  }
+
+  private static void addSummarySamples(
+      SummaryPointData doubleSummaryPoint,
+      String name,
+      List<String> labelNames,
+      List<String> labelValues,
+      List<Sample> samples) {
+    samples.add(
+        createSample(
+            name + SAMPLE_SUFFIX_COUNT,
+            labelNames,
+            labelValues,
+            (double) doubleSummaryPoint.getCount(),
+            null,
+            doubleSummaryPoint.getEpochNanos()));
+
+    samples.add(
+        createSample(
+            name + SAMPLE_SUFFIX_SUM,
+            labelNames,
+            labelValues,
+            doubleSummaryPoint.getSum(),
+            null,
+            doubleSummaryPoint.getEpochNanos()));
+
+    List<ValueAtQuantile> valueAtQuantiles = doubleSummaryPoint.getValues();
+    List<String> labelNamesWithQuantile = new ArrayList<>(labelNames.size());
+    labelNamesWithQuantile.addAll(labelNames);
+    labelNamesWithQuantile.add(LABEL_NAME_QUANTILE);
+    for (ValueAtQuantile valueAtQuantile : valueAtQuantiles) {
+      List<String> labelValuesWithQuantile = new ArrayList<>(labelValues.size());
+      labelValuesWithQuantile.addAll(labelValues);
+      labelValuesWithQuantile.add(doubleToGoString(valueAtQuantile.getQuantile()));
+      samples.add(
+          createSample(
+              name,
+              labelNamesWithQuantile,
+              labelValuesWithQuantile,
+              valueAtQuantile.getValue(),
+              null,
+              doubleSummaryPoint.getEpochNanos()));
+    }
+  }
+
+  private static void addHistogramSamples(
+      HistogramPointData histogramPointData,
+      String name,
+      List<String> labelNames,
+      List<String> labelValues,
+      List<Sample> samples) {
+    samples.add(
+        createSample(
+            name + SAMPLE_SUFFIX_COUNT,
+            labelNames,
+            labelValues,
+            (double) histogramPointData.getCount(),
+            null,
+            histogramPointData.getEpochNanos()));
+
+    samples.add(
+        createSample(
+            name + SAMPLE_SUFFIX_SUM,
+            labelNames,
+            labelValues,
+            histogramPointData.getSum(),
+            null,
+            histogramPointData.getEpochNanos()));
+
+    List<String> labelNamesWithLe = new ArrayList<>(labelNames.size() + 1);
+    labelNamesWithLe.addAll(labelNames);
+    labelNamesWithLe.add(LABEL_NAME_LE);
+
+    long cumulativeCount = 0;
+    List<Long> counts = histogramPointData.getCounts();
+    for (int i = 0; i < counts.size(); i++) {
+      List<String> labelValuesWithLe = new ArrayList<>(labelValues.size() + 1);
+      // This is the upper boundary (inclusive). I.e. all values should be < this value (LE -
+      // Less-then-or-Equal).
+      double boundary = Serializer.getBucketUpperBound(histogramPointData, i);
+      labelValuesWithLe.addAll(labelValues);
+      labelValuesWithLe.add(doubleToGoString(boundary));
+
+      cumulativeCount += counts.get(i);
+      samples.add(
+          createSample(
+              name + SAMPLE_SUFFIX_BUCKET,
+              labelNamesWithLe,
+              labelValuesWithLe,
+              (double) cumulativeCount,
+              filterExemplars(
+                  histogramPointData.getExemplars(),
+                  Serializer.getBucketLowerBound(histogramPointData, i),
+                  boundary),
+              histogramPointData.getEpochNanos()));
+    }
+  }
+
+  @Nullable
+  private static ExemplarData filterExemplars(
+      Collection<? extends ExemplarData> exemplars, double min, double max) {
+    ExemplarData result = null;
+    for (ExemplarData e : exemplars) {
+      double value = getExemplarValue(e);
+      if (value <= max && value > min) {
+        result = e;
+      }
+    }
+    return result;
+  }
+
+  private static int estimateNumSamples(int numPoints, MetricDataType type) {
+    if (type == MetricDataType.SUMMARY) {
+      // count + sum + estimated 2 percentiles
+      return numPoints * 4;
+    }
+    return numPoints;
+  }
+
+  private static Sample createSample(
+      String name,
+      List<String> labelNames,
+      List<String> labelValues,
+      double value,
+      @Nullable ExemplarData exemplar,
+      long timestampNanos) {
+    if (exemplar != null) {
+      return new Sample(
+          name,
+          labelNames,
+          labelValues,
+          value,
+          toPrometheusExemplar(exemplar),
+          TimeUnit.MILLISECONDS.convert(timestampNanos, TimeUnit.NANOSECONDS));
+    }
+    return new Sample(
+        name,
+        labelNames,
+        labelValues,
+        value,
+        null,
+        TimeUnit.MILLISECONDS.convert(timestampNanos, TimeUnit.NANOSECONDS));
+  }
+
+  private static io.prometheus.client.exemplars.Exemplar toPrometheusExemplar(
+      ExemplarData exemplar) {
+    SpanContext spanContext = exemplar.getSpanContext();
+    if (spanContext.isValid()) {
+      return new io.prometheus.client.exemplars.Exemplar(
+          getExemplarValue(exemplar),
+          // Convert to ms for prometheus, truncate nanosecond precision.
+          TimeUnit.NANOSECONDS.toMillis(exemplar.getEpochNanos()),
+          "trace_id",
+          spanContext.getTraceId(),
+          "span_id",
+          spanContext.getSpanId());
+    }
+    return new io.prometheus.client.exemplars.Exemplar(getExemplarValue(exemplar));
+  }
+
+  private static double getExemplarValue(ExemplarData exemplar) {
+    return exemplar instanceof DoubleExemplarData
+        ? ((DoubleExemplarData) exemplar).getValue()
+        : (double) ((LongExemplarData) exemplar).getValue();
+  }
+
+  private MetricAdapter() {}
+}

--- a/backend/common/src/main/java/ai/verta/modeldb/common/metrics/otelprom/NameSanitizer.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/metrics/otelprom/NameSanitizer.java
@@ -1,0 +1,45 @@
+/*
+ * Note: this code has been pulled in from the OpenTelemetry project.
+ *
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package ai.verta.modeldb.common.metrics.otelprom;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+
+/** Sanitizes a metric or label name. */
+class NameSanitizer implements Function<String, String> {
+
+  static final NameSanitizer INSTANCE = new NameSanitizer();
+
+  private static final Pattern SANITIZE_PREFIX_PATTERN = Pattern.compile("^[^a-zA-Z_:]");
+  private static final Pattern SANITIZE_BODY_PATTERN = Pattern.compile("[^a-zA-Z0-9_:]");
+
+  private final Function<String, String> delegate;
+  private final Map<String, String> cache = new ConcurrentHashMap<>();
+
+  NameSanitizer() {
+    this(NameSanitizer::sanitizeMetricName);
+  }
+
+  // visible for testing
+  NameSanitizer(Function<String, String> delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public String apply(String labelName) {
+    return cache.computeIfAbsent(labelName, delegate);
+  }
+
+  private static String sanitizeMetricName(String metricName) {
+    return SANITIZE_BODY_PATTERN
+        .matcher(SANITIZE_PREFIX_PATTERN.matcher(metricName).replaceFirst("_"))
+        .replaceAll("_");
+  }
+}

--- a/backend/common/src/main/java/ai/verta/modeldb/common/metrics/otelprom/PrometheusCollector.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/metrics/otelprom/PrometheusCollector.java
@@ -1,0 +1,87 @@
+/*
+ * Note: this code has been pulled in from the OpenTelemetry project.
+ *
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package ai.verta.modeldb.common.metrics.otelprom;
+
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.metrics.InstrumentType;
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.export.CollectionRegistration;
+import io.opentelemetry.sdk.metrics.export.MetricReader;
+import io.opentelemetry.sdk.metrics.internal.export.MetricProducer;
+import io.prometheus.client.Collector;
+import io.prometheus.client.CollectorRegistry;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Supplier;
+
+public class PrometheusCollector implements MetricReader {
+
+  private final Collector collector;
+  private volatile MetricProducer metricProducer = MetricProducer.noop();
+
+  PrometheusCollector() {
+    this.collector = new CollectorImpl(() -> getMetricProducer().collectAllMetrics());
+    this.collector.register();
+  }
+
+  /**
+   * Returns a new {@link PrometheusCollector} to be registered with a {@link
+   * io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder}.
+   */
+  public static PrometheusCollector create() {
+    return new PrometheusCollector();
+  }
+
+  private MetricProducer getMetricProducer() {
+    return metricProducer;
+  }
+
+  @Override
+  public void register(CollectionRegistration registration) {
+    this.metricProducer = MetricProducer.asMetricProducer(registration);
+  }
+
+  @Override
+  public AggregationTemporality getAggregationTemporality(InstrumentType instrumentType) {
+    return AggregationTemporality.CUMULATIVE;
+  }
+
+  // Prometheus cannot flush.
+  @Override
+  public CompletableResultCode forceFlush() {
+    return CompletableResultCode.ofSuccess();
+  }
+
+  @Override
+  public CompletableResultCode shutdown() {
+    CollectorRegistry.defaultRegistry.unregister(collector);
+    return CompletableResultCode.ofSuccess();
+  }
+
+  private static class CollectorImpl extends Collector {
+
+    private final Supplier<Collection<MetricData>> metricSupplier;
+
+    private CollectorImpl(Supplier<Collection<MetricData>> metricSupplier) {
+      this.metricSupplier = metricSupplier;
+    }
+
+    @Override
+    public List<MetricFamilySamples> collect() {
+      Collection<MetricData> allMetrics = metricSupplier.get();
+      List<MetricFamilySamples> allSamples = new ArrayList<>(allMetrics.size());
+      for (MetricData metricData : allMetrics) {
+        allSamples.add(MetricAdapter.toMetricFamilySamples(metricData));
+      }
+      return Collections.unmodifiableList(allSamples);
+    }
+  }
+}

--- a/backend/common/src/main/java/ai/verta/modeldb/common/metrics/otelprom/PrometheusType.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/metrics/otelprom/PrometheusType.java
@@ -1,0 +1,64 @@
+/*
+ * Note: this code has been pulled in from the OpenTelemetry project.
+ *
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*
+ * Note: this code has been pulled in from the OpenTelemetry project.
+ *
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package ai.verta.modeldb.common.metrics.otelprom;
+
+import io.opentelemetry.sdk.metrics.data.*;
+
+// Four types we use are same in prometheus and openmetrics format
+enum PrometheusType {
+  GAUGE("gauge"),
+  COUNTER("counter"),
+  SUMMARY("summary"),
+  HISTOGRAM("histogram");
+
+  private final String typeString;
+
+  PrometheusType(String typeString) {
+    this.typeString = typeString;
+  }
+
+  static PrometheusType forMetric(MetricData metric) {
+    switch (metric.getType()) {
+      case LONG_GAUGE:
+      case DOUBLE_GAUGE:
+        return GAUGE;
+      case LONG_SUM:
+        SumData<LongPointData> longSumData = metric.getLongSumData();
+        if (longSumData.isMonotonic()
+            && longSumData.getAggregationTemporality() == AggregationTemporality.CUMULATIVE) {
+          return COUNTER;
+        }
+        return GAUGE;
+      case DOUBLE_SUM:
+        SumData<DoublePointData> doubleSumData = metric.getDoubleSumData();
+        if (doubleSumData.isMonotonic()
+            && doubleSumData.getAggregationTemporality() == AggregationTemporality.CUMULATIVE) {
+          return COUNTER;
+        }
+        return GAUGE;
+      case SUMMARY:
+        return SUMMARY;
+      case HISTOGRAM:
+      case EXPONENTIAL_HISTOGRAM:
+        return HISTOGRAM;
+    }
+    throw new IllegalArgumentException(
+        "Unsupported metric type, this generally indicates version misalignment "
+            + "among opentelemetry dependencies. Please make sure to use opentelemetry-bom.");
+  }
+
+  String getTypeString() {
+    return typeString;
+  }
+}

--- a/backend/common/src/main/java/ai/verta/modeldb/common/metrics/otelprom/Serializer.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/metrics/otelprom/Serializer.java
@@ -1,0 +1,510 @@
+/*
+ * Note: this code has been pulled in from the OpenTelemetry project.
+ *
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package ai.verta.modeldb.common.metrics.otelprom;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.sdk.metrics.data.*;
+import io.opentelemetry.sdk.metrics.internal.data.exponentialhistogram.ExponentialHistogramData;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+
+/** Serializes metrics into Prometheus exposition formats. */
+// Adapted from
+// https://github.com/prometheus/client_java/blob/master/simpleclient_common/src/main/java/io/prometheus/client/exporter/common/TextFormat.java
+abstract class Serializer {
+
+  static Serializer create(@Nullable String acceptHeader, Predicate<String> filter) {
+    if (acceptHeader == null) {
+      return new Prometheus004Serializer(filter);
+    }
+
+    for (String accepts : acceptHeader.split(",")) {
+      if ("application/openmetrics-text".equals(accepts.split(";")[0].trim())) {
+        return new OpenMetrics100Serializer(filter);
+      }
+    }
+
+    return new Prometheus004Serializer(filter);
+  }
+
+  private final Predicate<String> metricNameFilter;
+
+  Serializer(Predicate<String> metricNameFilter) {
+    this.metricNameFilter = metricNameFilter;
+  }
+
+  abstract String contentType();
+
+  abstract String headerName(String name, PrometheusType type);
+
+  abstract void writeHelp(Writer writer, String description) throws IOException;
+
+  abstract void writeTimestamp(Writer writer, long timestampNanos) throws IOException;
+
+  abstract void writeExemplar(
+      Writer writer,
+      Collection<? extends ExemplarData> exemplars,
+      double minExemplar,
+      double maxExemplar)
+      throws IOException;
+
+  abstract void writeEof(Writer writer) throws IOException;
+
+  final void write(Collection<MetricData> metrics, OutputStream output) throws IOException {
+    // Prometheus requires all metrics with the same name to be serialized together, so we need to
+    // group them.
+    // In particular, it is common for OpenTelemetry to report metrics with the same name from
+    // different libraries
+    // separately.
+    Map<String, List<MetricData>> metricsByName =
+        metrics.stream()
+            // Not supported in specification yet.
+            .filter(metric -> metric.getType() != MetricDataType.EXPONENTIAL_HISTOGRAM)
+            .filter(metric -> metricNameFilter.test(metricName(metric)))
+            .collect(
+                Collectors.groupingBy(
+                    metric ->
+                        headerName(
+                            NameSanitizer.INSTANCE.apply(metric.getName()),
+                            PrometheusType.forMetric(metric)),
+                    LinkedHashMap::new,
+                    Collectors.toList()));
+    try (Writer writer =
+        new BufferedWriter(new OutputStreamWriter(output, StandardCharsets.UTF_8))) {
+      for (Map.Entry<String, List<MetricData>> entry : metricsByName.entrySet()) {
+        write(entry.getValue(), entry.getKey(), writer);
+      }
+      writeEof(writer);
+    }
+  }
+
+  private void write(List<MetricData> metrics, String headerName, Writer writer)
+      throws IOException {
+    // Write header based on first metric
+    PrometheusType type = PrometheusType.forMetric(metrics.get(0));
+    String description = metrics.get(0).getDescription();
+
+    writer.write("# TYPE ");
+    writer.write(headerName);
+    writer.write(' ');
+    writer.write(type.getTypeString());
+    writer.write('\n');
+
+    writer.write("# HELP ");
+    writer.write(headerName);
+    writer.write(' ');
+    writeHelp(writer, description);
+    writer.write('\n');
+
+    // Then write the metrics.
+    for (MetricData metric : metrics) {
+      write(metric, writer);
+    }
+  }
+
+  private void write(MetricData metric, Writer writer) throws IOException {
+    String name = metricName(metric);
+
+    for (PointData point : getPoints(metric)) {
+      switch (metric.getType()) {
+        case DOUBLE_SUM:
+        case DOUBLE_GAUGE:
+          writePoint(
+              writer,
+              name,
+              ((DoublePointData) point).getValue(),
+              point.getAttributes(),
+              point.getEpochNanos());
+          break;
+        case LONG_SUM:
+        case LONG_GAUGE:
+          writePoint(
+              writer,
+              name,
+              (double) ((LongPointData) point).getValue(),
+              point.getAttributes(),
+              point.getEpochNanos());
+          break;
+        case HISTOGRAM:
+          writeHistogram(writer, name, (HistogramPointData) point);
+          break;
+        case SUMMARY:
+          writeSummary(writer, name, (SummaryPointData) point);
+          break;
+        case EXPONENTIAL_HISTOGRAM:
+          throw new IllegalArgumentException("Can't happen");
+      }
+    }
+  }
+
+  private void writeHistogram(Writer writer, String name, HistogramPointData point)
+      throws IOException {
+    writePoint(
+        writer,
+        name + "_count",
+        (double) point.getCount(),
+        point.getAttributes(),
+        point.getEpochNanos());
+    writePoint(writer, name + "_sum", point.getSum(), point.getAttributes(), point.getEpochNanos());
+
+    long cumulativeCount = 0;
+    List<Long> counts = point.getCounts();
+    for (int i = 0; i < counts.size(); i++) {
+      // This is the upper boundary (inclusive). I.e. all values should be < this value (LE -
+      // Less-then-or-Equal).
+      double boundary = getBucketUpperBound(point, i);
+
+      cumulativeCount += counts.get(i);
+      writePoint(
+          writer,
+          name + "_bucket",
+          (double) cumulativeCount,
+          point.getAttributes(),
+          point.getEpochNanos(),
+          "le",
+          boundary,
+          point.getExemplars(),
+          getBucketLowerBound(point, i),
+          boundary);
+    }
+  }
+
+  /**
+   * Returns the lower bound of a bucket (all values would have been greater than).
+   *
+   * @param bucketIndex The bucket index, should match {@link HistogramPointData#getCounts()} index.
+   */
+  static double getBucketLowerBound(HistogramPointData point, int bucketIndex) {
+    return bucketIndex > 0 ? point.getBoundaries().get(bucketIndex - 1) : Double.NEGATIVE_INFINITY;
+  }
+
+  /**
+   * Returns the upper inclusive bound of a bucket (all values would have been less then or equal).
+   *
+   * @param bucketIndex The bucket index, should match {@link HistogramPointData#getCounts()} index.
+   */
+  static double getBucketUpperBound(HistogramPointData point, int bucketIndex) {
+    List<Double> boundaries = point.getBoundaries();
+    return (bucketIndex < boundaries.size())
+        ? boundaries.get(bucketIndex)
+        : Double.POSITIVE_INFINITY;
+  }
+
+  private void writeSummary(Writer writer, String name, SummaryPointData point) throws IOException {
+    writePoint(
+        writer,
+        name + "_count",
+        (double) point.getCount(),
+        point.getAttributes(),
+        point.getEpochNanos());
+    writePoint(writer, name + "_sum", point.getSum(), point.getAttributes(), point.getEpochNanos());
+
+    List<ValueAtQuantile> valueAtQuantiles = point.getValues();
+    for (ValueAtQuantile valueAtQuantile : valueAtQuantiles) {
+      writePoint(
+          writer,
+          name,
+          valueAtQuantile.getValue(),
+          point.getAttributes(),
+          point.getEpochNanos(),
+          "quantile",
+          valueAtQuantile.getQuantile(),
+          Collections.emptyList(),
+          0,
+          0);
+    }
+  }
+
+  private void writePoint(
+      Writer writer, String name, double value, Attributes attributes, long epochNanos)
+      throws IOException {
+    writer.write(name);
+    writeAttributes(writer, attributes);
+    writer.write(' ');
+    writeDouble(writer, value);
+    writer.write(' ');
+    writeTimestamp(writer, epochNanos);
+    writer.write('\n');
+  }
+
+  private void writePoint(
+      Writer writer,
+      String name,
+      double value,
+      Attributes attributes,
+      long epochNanos,
+      String additionalAttrKey,
+      double additionalAttrValue,
+      Collection<? extends ExemplarData> exemplars,
+      double minExemplar,
+      double maxExemplar)
+      throws IOException {
+    writer.write(name);
+    writeAttributes(writer, attributes, additionalAttrKey, additionalAttrValue);
+    writer.write(' ');
+    writeDouble(writer, value);
+    writer.write(' ');
+    writeTimestamp(writer, epochNanos);
+    writeExemplar(writer, exemplars, minExemplar, maxExemplar);
+    writer.write('\n');
+  }
+
+  private static void writeAttributes(Writer writer, Attributes attributes) throws IOException {
+    if (attributes.isEmpty()) {
+      return;
+    }
+    writer.write('{');
+    writeAttributePairs(writer, attributes);
+    writer.write('}');
+  }
+
+  private static void writeAttributes(
+      Writer writer, Attributes attributes, String additionalAttrKey, double additionalAttrValue)
+      throws IOException {
+    writer.write('{');
+    if (!attributes.isEmpty()) {
+      writeAttributePairs(writer, attributes);
+      writer.write(',');
+    }
+    writer.write(additionalAttrKey);
+    writer.write("=\"");
+    writeDouble(writer, additionalAttrValue);
+    writer.write('"');
+    writer.write('}');
+  }
+
+  private static void writeAttributePairs(Writer writer, Attributes attributes) throws IOException {
+    try {
+      attributes.forEach(
+          new BiConsumer<AttributeKey<?>, Object>() {
+            private boolean wroteOne;
+
+            @Override
+            public void accept(AttributeKey<?> key, Object value) {
+              try {
+                if (wroteOne) {
+                  writer.write(',');
+                } else {
+                  wroteOne = true;
+                }
+                writer.write(NameSanitizer.INSTANCE.apply(key.getKey()));
+                writer.write("=\"");
+                writeEscapedLabelValue(writer, value.toString());
+                writer.write('"');
+              } catch (IOException e) {
+                throw new UncheckedIOException(e);
+              }
+            }
+          });
+    } catch (UncheckedIOException e) {
+      throw e.getCause();
+    }
+  }
+
+  private static void writeDouble(Writer writer, double d) throws IOException {
+    if (d == Double.POSITIVE_INFINITY) {
+      writer.write("+Inf");
+    } else if (d == Double.NEGATIVE_INFINITY) {
+      writer.write("-Inf");
+    } else {
+      writer.write(Double.toString(d));
+    }
+  }
+
+  static void writeEscapedLabelValue(Writer writer, String s) throws IOException {
+    for (int i = 0; i < s.length(); i++) {
+      char c = s.charAt(i);
+      switch (c) {
+        case '\\':
+          writer.write("\\\\");
+          break;
+        case '\"':
+          writer.write("\\\"");
+          break;
+        case '\n':
+          writer.write("\\n");
+          break;
+        default:
+          writer.write(c);
+      }
+    }
+  }
+
+  static class Prometheus004Serializer extends Serializer {
+
+    Prometheus004Serializer(Predicate<String> metricNameFilter) {
+      super(metricNameFilter);
+    }
+
+    @Override
+    String contentType() {
+      return "text/plain; version=0.0.4; charset=utf-8";
+    }
+
+    @Override
+    String headerName(String name, PrometheusType type) {
+      if (type == PrometheusType.COUNTER) {
+        return name + "_total";
+      }
+      return name;
+    }
+
+    @Override
+    void writeHelp(Writer writer, String help) throws IOException {
+      for (int i = 0; i < help.length(); i++) {
+        char c = help.charAt(i);
+        switch (c) {
+          case '\\':
+            writer.write("\\\\");
+            break;
+          case '\n':
+            writer.write("\\n");
+            break;
+          default:
+            writer.write(c);
+        }
+      }
+    }
+
+    @Override
+    void writeTimestamp(Writer writer, long timestampNanos) throws IOException {
+      writer.write(Long.toString(TimeUnit.NANOSECONDS.toMillis(timestampNanos)));
+    }
+
+    @Override
+    void writeExemplar(
+        Writer writer,
+        Collection<? extends ExemplarData> exemplars,
+        double minExemplar,
+        double maxExemplar) {
+      // Don't write exemplars
+    }
+
+    @Override
+    void writeEof(Writer writer) {
+      // Don't write EOF
+    }
+  }
+
+  static class OpenMetrics100Serializer extends Serializer {
+
+    OpenMetrics100Serializer(Predicate<String> metricNameFilter) {
+      super(metricNameFilter);
+    }
+
+    @Override
+    String contentType() {
+      return "application/openmetrics-text; version=1.0.0; charset=utf-8";
+    }
+
+    @Override
+    String headerName(String name, PrometheusType type) {
+      return name;
+    }
+
+    @Override
+    void writeHelp(Writer writer, String description) throws IOException {
+      writeEscapedLabelValue(writer, description);
+    }
+
+    @Override
+    void writeTimestamp(Writer writer, long timestampNanos) throws IOException {
+      long timestampMillis = TimeUnit.NANOSECONDS.toMillis(timestampNanos);
+      writer.write(Long.toString(timestampMillis / 1000));
+      writer.write(".");
+      long millis = timestampMillis % 1000;
+      if (millis < 100) {
+        writer.write('0');
+      }
+      if (millis < 10) {
+        writer.write('0');
+      }
+      writer.write(Long.toString(millis));
+    }
+
+    @Override
+    void writeExemplar(
+        Writer writer,
+        Collection<? extends ExemplarData> exemplars,
+        double minExemplar,
+        double maxExemplar)
+        throws IOException {
+      for (ExemplarData exemplar : exemplars) {
+        double value = getExemplarValue(exemplar);
+        if (value > minExemplar && value <= maxExemplar) {
+          writer.write(" # {");
+          SpanContext spanContext = exemplar.getSpanContext();
+          if (spanContext.isValid()) {
+            // NB: Output sorted to match prometheus client library even though it shouldn't matter.
+            // OTel generally outputs in trace_id span_id order though so we can consider breaking
+            // from reference implementation if it makes sense.
+            writer.write("span_id=\"");
+            writer.write(spanContext.getSpanId());
+            writer.write("\",trace_id=\"");
+            writer.write(spanContext.getTraceId());
+            writer.write('"');
+          }
+          writer.write("} ");
+          writeDouble(writer, value);
+          writer.write(' ');
+          writeTimestamp(writer, exemplar.getEpochNanos());
+          // Only write one exemplar.
+          return;
+        }
+      }
+    }
+
+    @Override
+    void writeEof(Writer writer) throws IOException {
+      writer.write("# EOF\n");
+    }
+  }
+
+  static Collection<? extends PointData> getPoints(MetricData metricData) {
+    switch (metricData.getType()) {
+      case DOUBLE_GAUGE:
+        return metricData.getDoubleGaugeData().getPoints();
+      case DOUBLE_SUM:
+        return metricData.getDoubleSumData().getPoints();
+      case LONG_GAUGE:
+        return metricData.getLongGaugeData().getPoints();
+      case LONG_SUM:
+        return metricData.getLongSumData().getPoints();
+      case SUMMARY:
+        return metricData.getSummaryData().getPoints();
+      case HISTOGRAM:
+        return metricData.getHistogramData().getPoints();
+      case EXPONENTIAL_HISTOGRAM:
+        return ExponentialHistogramData.fromMetricData(metricData).getPoints();
+    }
+    return Collections.emptyList();
+  }
+
+  private static String metricName(MetricData metric) {
+    PrometheusType type = PrometheusType.forMetric(metric);
+    String name = NameSanitizer.INSTANCE.apply(metric.getName());
+    if (type == PrometheusType.COUNTER) {
+      name = name + "_total";
+    }
+    return name;
+  }
+
+  private static double getExemplarValue(ExemplarData exemplar) {
+    return exemplar instanceof DoubleExemplarData
+        ? ((DoubleExemplarData) exemplar).getValue()
+        : (double) ((LongExemplarData) exemplar).getValue();
+  }
+}

--- a/backend/server/src/main/java/ai/verta/modeldb/App.java
+++ b/backend/server/src/main/java/ai/verta/modeldb/App.java
@@ -17,7 +17,8 @@ import org.springframework.context.annotation.ComponentScan;
   "ai.verta.modeldb.config",
   "ai.verta.modeldb.health",
   "ai.verta.modeldb.configuration",
-  "ai.verta.modeldb.common.configuration"
+  "ai.verta.modeldb.common.configuration",
+  "ai.verta.modeldb.common.config"
 })
 public class App {
 

--- a/backend/server/src/main/java/ai/verta/modeldb/batchProcess/CollaboratorResourceMigration.java
+++ b/backend/server/src/main/java/ai/verta/modeldb/batchProcess/CollaboratorResourceMigration.java
@@ -50,7 +50,7 @@ public class CollaboratorResourceMigration {
     var config = App.getInstance().mdbConfig;
     CollaboratorResourceMigration.paginationSize = 100;
     if (config.hasAuth()) {
-      uac = UAC.FromConfig(config);
+      uac = UAC.fromConfig(config);
       authService = MDBAuthServiceUtils.FromConfig(config, uac);
       mdbRoleService = MDBRoleServiceUtils.FromConfig(config, authService, uac);
     } else {

--- a/backend/server/src/main/java/ai/verta/modeldb/batchProcess/CollaboratorResourceMigration.java
+++ b/backend/server/src/main/java/ai/verta/modeldb/batchProcess/CollaboratorResourceMigration.java
@@ -50,7 +50,7 @@ public class CollaboratorResourceMigration {
     var config = App.getInstance().mdbConfig;
     CollaboratorResourceMigration.paginationSize = 100;
     if (config.hasAuth()) {
-      uac = UAC.fromConfig(config);
+      uac = UAC.fromConfig(config, Optional.empty());
       authService = MDBAuthServiceUtils.FromConfig(config, uac);
       mdbRoleService = MDBRoleServiceUtils.FromConfig(config, authService, uac);
     } else {

--- a/backend/server/src/main/java/ai/verta/modeldb/batchProcess/DatasetToRepositoryMigration.java
+++ b/backend/server/src/main/java/ai/verta/modeldb/batchProcess/DatasetToRepositoryMigration.java
@@ -71,7 +71,7 @@ public class DatasetToRepositoryMigration {
   public static void execute(int recordUpdateLimit) {
     DatasetToRepositoryMigration.recordUpdateLimit = recordUpdateLimit;
     config = App.getInstance().mdbConfig;
-    uac = UAC.FromConfig(config);
+    uac = UAC.fromConfig(config);
     authService = MDBAuthServiceUtils.FromConfig(config, uac);
     mdbRoleService = MDBRoleServiceUtils.FromConfig(config, authService, uac);
 

--- a/backend/server/src/main/java/ai/verta/modeldb/batchProcess/DatasetToRepositoryMigration.java
+++ b/backend/server/src/main/java/ai/verta/modeldb/batchProcess/DatasetToRepositoryMigration.java
@@ -71,7 +71,7 @@ public class DatasetToRepositoryMigration {
   public static void execute(int recordUpdateLimit) {
     DatasetToRepositoryMigration.recordUpdateLimit = recordUpdateLimit;
     config = App.getInstance().mdbConfig;
-    uac = UAC.fromConfig(config);
+    uac = UAC.fromConfig(config, Optional.empty());
     authService = MDBAuthServiceUtils.FromConfig(config, uac);
     mdbRoleService = MDBRoleServiceUtils.FromConfig(config, authService, uac);
 

--- a/backend/server/src/main/java/ai/verta/modeldb/batchProcess/OwnerRoleBindingRepositoryUtils.java
+++ b/backend/server/src/main/java/ai/verta/modeldb/batchProcess/OwnerRoleBindingRepositoryUtils.java
@@ -35,7 +35,7 @@ public class OwnerRoleBindingRepositoryUtils {
   public static void execute() {
     var config = App.getInstance().mdbConfig;
     if (config.hasAuth()) {
-      uac = UAC.FromConfig(config);
+      uac = UAC.fromConfig(config);
       authService = MDBAuthServiceUtils.FromConfig(config, uac);
       mdbRoleService = MDBRoleServiceUtils.FromConfig(config, authService, uac);
     } else {

--- a/backend/server/src/main/java/ai/verta/modeldb/batchProcess/OwnerRoleBindingRepositoryUtils.java
+++ b/backend/server/src/main/java/ai/verta/modeldb/batchProcess/OwnerRoleBindingRepositoryUtils.java
@@ -12,10 +12,7 @@ import ai.verta.modeldb.entities.versioning.RepositoryEntity;
 import ai.verta.modeldb.utils.ModelDBHibernateUtil;
 import ai.verta.modeldb.utils.ModelDBUtils;
 import ai.verta.uac.UserInfo;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import javax.persistence.TypedQuery;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Root;
@@ -35,7 +32,7 @@ public class OwnerRoleBindingRepositoryUtils {
   public static void execute() {
     var config = App.getInstance().mdbConfig;
     if (config.hasAuth()) {
-      uac = UAC.fromConfig(config);
+      uac = UAC.fromConfig(config, Optional.empty());
       authService = MDBAuthServiceUtils.FromConfig(config, uac);
       mdbRoleService = MDBRoleServiceUtils.FromConfig(config, authService, uac);
     } else {

--- a/backend/server/src/main/java/ai/verta/modeldb/batchProcess/OwnerRoleBindingUtils.java
+++ b/backend/server/src/main/java/ai/verta/modeldb/batchProcess/OwnerRoleBindingUtils.java
@@ -16,10 +16,7 @@ import ai.verta.modeldb.entities.versioning.RepositoryEntity;
 import ai.verta.modeldb.utils.ModelDBHibernateUtil;
 import ai.verta.modeldb.utils.ModelDBUtils;
 import ai.verta.uac.UserInfo;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import javax.persistence.TypedQuery;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Root;
@@ -39,7 +36,7 @@ public class OwnerRoleBindingUtils {
   public static void execute() {
     var config = App.getInstance().mdbConfig;
     if (config.hasAuth()) {
-      uac = UAC.fromConfig(config);
+      uac = UAC.fromConfig(config, Optional.empty());
       authService = MDBAuthServiceUtils.FromConfig(config, uac);
       mdbRoleService = MDBRoleServiceUtils.FromConfig(config, authService, uac);
     } else {

--- a/backend/server/src/main/java/ai/verta/modeldb/batchProcess/OwnerRoleBindingUtils.java
+++ b/backend/server/src/main/java/ai/verta/modeldb/batchProcess/OwnerRoleBindingUtils.java
@@ -39,7 +39,7 @@ public class OwnerRoleBindingUtils {
   public static void execute() {
     var config = App.getInstance().mdbConfig;
     if (config.hasAuth()) {
-      uac = UAC.FromConfig(config);
+      uac = UAC.fromConfig(config);
       authService = MDBAuthServiceUtils.FromConfig(config, uac);
       mdbRoleService = MDBRoleServiceUtils.FromConfig(config, authService, uac);
     } else {

--- a/backend/server/src/main/java/ai/verta/modeldb/configuration/AppConfigBeans.java
+++ b/backend/server/src/main/java/ai/verta/modeldb/configuration/AppConfigBeans.java
@@ -104,7 +104,8 @@ public class AppConfigBeans {
   }
 
   @Bean
-  FutureExecutor grpcExecutor(Config config) {
+  FutureExecutor grpcExecutor(Config config, OpenTelemetry openTelemetry) {
+    FutureExecutor.setOpenTelemetry(openTelemetry);
     // Initialize executor so we don't lose context using Futures
     FutureExecutor futureExecutor =
         FutureExecutor.initializeExecutor(config.getGrpcServer().getThreadCount());

--- a/backend/server/src/main/java/ai/verta/modeldb/configuration/AppConfigBeans.java
+++ b/backend/server/src/main/java/ai/verta/modeldb/configuration/AppConfigBeans.java
@@ -34,6 +34,7 @@ import ai.verta.modeldb.project.FutureProjectServiceImpl;
 import ai.verta.modeldb.utils.ModelDBHibernateUtil;
 import ai.verta.modeldb.versioning.FileHasher;
 import ai.verta.modeldb.versioning.VersioningServiceImpl;
+import io.grpc.ClientInterceptor;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.ServerInterceptor;
@@ -115,8 +116,8 @@ public class AppConfigBeans {
   }
 
   @Bean
-  UAC uac(Config config) {
-    return UAC.FromConfig(config);
+  UAC uac(Config config, ClientInterceptor tracingClientInterceptor) {
+    return UAC.fromConfig(config, Optional.of(tracingClientInterceptor));
   }
 
   @Bean

--- a/backend/server/src/test/java/ai/verta/modeldb/ModeldbTestConfigurationBeans.java
+++ b/backend/server/src/test/java/ai/verta/modeldb/ModeldbTestConfigurationBeans.java
@@ -9,6 +9,7 @@ import ai.verta.modeldb.common.config.ServiceConfig;
 import ai.verta.modeldb.common.config.SpringServerConfig;
 import ai.verta.modeldb.common.connections.UAC;
 import ai.verta.modeldb.config.TestConfig;
+import java.util.Optional;
 import java.util.Random;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -31,7 +32,9 @@ public class ModeldbTestConfigurationBeans {
 
   @Bean
   UAC uac(Config config, boolean runningIsolated) {
-    return runningIsolated ? mock(UAC.class, RETURNS_DEEP_STUBS) : UAC.fromConfig(config);
+    return runningIsolated
+        ? mock(UAC.class, RETURNS_DEEP_STUBS)
+        : UAC.fromConfig(config, Optional.empty());
   }
 
   private static TestConfig initializeTestConfig() {

--- a/backend/server/src/test/java/ai/verta/modeldb/ModeldbTestConfigurationBeans.java
+++ b/backend/server/src/test/java/ai/verta/modeldb/ModeldbTestConfigurationBeans.java
@@ -31,7 +31,7 @@ public class ModeldbTestConfigurationBeans {
 
   @Bean
   UAC uac(Config config, boolean runningIsolated) {
-    return runningIsolated ? mock(UAC.class, RETURNS_DEEP_STUBS) : UAC.FromConfig(config);
+    return runningIsolated ? mock(UAC.class, RETURNS_DEEP_STUBS) : UAC.fromConfig(config);
   }
 
   private static TestConfig initializeTestConfig() {

--- a/backend/server/src/test/java/ai/verta/modeldb/TestsInit.java
+++ b/backend/server/src/test/java/ai/verta/modeldb/TestsInit.java
@@ -111,7 +111,7 @@ public class TestsInit {
     ArtifactStoreService artifactStoreService =
         new ArtifactStoreInitBeans().artifactStoreService(testConfig, appContext);
     //  Initialize services that we depend on
-    services = ServiceSet.fromConfig(testConfig, artifactStoreService, UAC.FromConfig(testConfig));
+    services = ServiceSet.fromConfig(testConfig, artifactStoreService, UAC.fromConfig(testConfig));
     authService = services.getAuthService();
     // Initialize data access
     daos =

--- a/backend/server/src/test/java/ai/verta/modeldb/TestsInit.java
+++ b/backend/server/src/test/java/ai/verta/modeldb/TestsInit.java
@@ -31,6 +31,7 @@ import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -111,7 +112,9 @@ public class TestsInit {
     ArtifactStoreService artifactStoreService =
         new ArtifactStoreInitBeans().artifactStoreService(testConfig, appContext);
     //  Initialize services that we depend on
-    services = ServiceSet.fromConfig(testConfig, artifactStoreService, UAC.fromConfig(testConfig));
+    services =
+        ServiceSet.fromConfig(
+            testConfig, artifactStoreService, UAC.fromConfig(testConfig, Optional.empty()));
     authService = services.getAuthService();
     // Initialize data access
     daos =


### PR DESCRIPTION
In order to have the modeldb backend use the new OpenTelemetry configuration beans, I needed to remove the usages of getting the OpenTelemetry instance from the Config object, which unfortunately was called in a significant number of places.


<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

## Risks and Area of Effect

## Testing
- [x] Unit test
- [x] Deployed to dev env
- [ ] Other (explain) 

## Reverting
- [ ] Contains Migration - _Do Not Revert_