### PR TITLE
chore: [CAT-218] Add docstrings for RMV I/O fields

### DIFF
--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -1573,7 +1573,7 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
 
     def set_hide_output_label(self, hide):
         """
-        Sets this whether to hide the model version's output label on the preview.
+        Sets whether to hide the model version's output label on the preview.
 
         Parameters
         ----------

--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -1530,7 +1530,7 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
 
     def get_hide_input_label(self):
         """
-        Gets this whether to hide the model version's input label on the preview.
+        Gets whether to hide the model version's input label on the preview.
 
         Returns
         -------

--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -1561,7 +1561,7 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
         Gets this description of the model version's output.
 
         This field helps users have a quick view of what type of data will be produced as a result of executing a model.
-        This field also helps non-tech users to understand model behavior in a glance.
+        This field also helps non-tech users to understand model behavior at a glance.
 
         Returns
         -------

--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -1485,38 +1485,114 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
             os.remove(tempf.name)
 
     def set_input_description(self, desc):
+        """
+        Sets this description of the model version's input.
+
+        This field helps users have a quick view of what type of data will be used as input for a model.
+        This field also helps non-tech users to understand model behavior in a glance.
+
+        Parameters
+        ----------
+        desc : str
+
+        """
         if not desc:
             raise ValueError("input description is not specified")
         self._update(self.ModelVersionMessage(input_description=desc))
 
     def get_input_description(self):
+        """
+        Gets this description of the model version's input.
+
+        This field helps users have a quick view of what type of data will be used as input for a model.
+        This field also helps non-tech users to understand model behavior in a glance.
+
+        Returns
+        -------
+        desc : str
+
+        """
         self._refresh_cache()
         return self._msg.input_description
 
     def set_hide_input_label(self, hide):
+        """
+        Sets this whether to hide the model version's input label on the preview.
+
+        Parameters
+        ----------
+        hide : bool
+
+        """
         if not hide:
             raise ValueError("hide input label is not specified")
         self._update(self.ModelVersionMessage(hide_input_label=hide))
 
     def get_hide_input_label(self):
+        """
+        Gets this whether to hide the model version's input label on the preview.
+
+        Returns
+        -------
+        hide : bool
+
+        """
         self._refresh_cache()
         return self._msg.hide_input_label
 
     def set_output_description(self, desc):
+        """
+        Sets this description of the model version's output.
+
+        This field helps users have a quick view of what type of data will be produced as a result of executing a model.
+        This field also helps non-tech users to understand model behavior in a glance.
+
+        Parameters
+        ----------
+        desc : str
+
+        """
         if not desc:
             raise ValueError("output description is not specified")
         self._update(self.ModelVersionMessage(output_description=desc))
 
     def get_output_description(self):
+        """
+        Gets this description of the model version's output.
+
+        This field helps users have a quick view of what type of data will be produced as a result of executing a model.
+        This field also helps non-tech users to understand model behavior in a glance.
+
+        Returns
+        -------
+        desc : str
+
+        """
         self._refresh_cache()
         return self._msg.output_description
 
     def set_hide_output_label(self, hide):
+        """
+        Sets this whether to hide the model version's output label on the preview.
+
+        Parameters
+        ----------
+        hide : bool
+
+        """
         if not hide:
             raise ValueError("hide output label is not specified")
         self._update(self.ModelVersionMessage(hide_output_label=hide))
 
     def get_hide_output_label(self):
+        """
+        Gets this whether to hide the model version's output label on the preview.
+
+        Returns
+        -------
+        hide : bool
+
+        """
         self._refresh_cache()
         return self._msg.hide_output_label
 

--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -1505,7 +1505,7 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
         Gets this description of the model version's input.
 
         This field helps users have a quick view of what type of data will be used as input for a model.
-        This field also helps non-tech users to understand model behavior in a glance.
+        This field also helps non-tech users to understand model behavior at a glance.
 
         Returns
         -------

--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -1517,7 +1517,7 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
 
     def set_hide_input_label(self, hide):
         """
-        Sets this whether to hide the model version's input label on the preview.
+        Sets whether to hide the model version's input label on the preview.
 
         Parameters
         ----------

--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -1545,7 +1545,7 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
         Sets this description of the model version's output.
 
         This field helps users have a quick view of what type of data will be produced as a result of executing a model.
-        This field also helps non-tech users to understand model behavior in a glance.
+        This field also helps non-tech users to understand model behavior at a glance.
 
         Parameters
         ----------

--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -1489,7 +1489,7 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
         Sets this description of the model version's input.
 
         This field helps users have a quick view of what type of data will be used as input for a model.
-        This field also helps non-tech users to understand model behavior in a glance.
+        This field also helps non-tech users to understand model behavior at a glance.
 
         Parameters
         ----------

--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -1586,7 +1586,7 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
 
     def get_hide_output_label(self):
         """
-        Gets this whether to hide the model version's output label on the preview.
+        Gets whether to hide the model version's output label on the preview.
 
         Returns
         -------


### PR DESCRIPTION
# Summary

Add docstrings for RMV functions input_description, hide_input_label, output_description, hide_output_label

# References

https://vertaai.atlassian.net/browse/CAT-218?atlOrigin=eyJpIjoiMTQ2YzM4YTE4NzVkNGRiOTg5ODc2MTczZTI0YTk3MmEiLCJwIjoiaiJ9

https://www.figma.com/file/DyBZMFOY2xPugQh2D27Aaj/Verta-Model-Catalog?node-id=1327%3A89247&t=0Auw4ECz6CyXE3Zp-0

![image](https://user-images.githubusercontent.com/108302696/210439650-add3d98f-0cd9-4582-9bf2-5411b3f2da11.png)


[CAT-218]: https://vertaai.atlassian.net/browse/CAT-218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ