### PR TITLE
Fix issues with integration test mocking by extracting one layer of mocks

### DIFF
--- a/backend/common/src/main/java/ai/verta/modeldb/common/authservice/AuthServiceChannel.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/authservice/AuthServiceChannel.java
@@ -34,7 +34,6 @@ public class AuthServiceChannel extends Connection implements AutoCloseable {
       collaboratorServiceBlockingStubForServiceUser;
   private final String serviceUserEmail;
   private final String serviceUserDevKey;
-  private final Config config;
 
   public AuthServiceChannel(Config config, Optional<ClientInterceptor> tracingClientInterceptor) {
     super(tracingClientInterceptor);
@@ -53,7 +52,6 @@ public class AuthServiceChannel extends Connection implements AutoCloseable {
       throw new UnavailableException(
           "Host OR Port not found for contacting authentication service");
     }
-    this.config = config;
   }
 
   private Metadata getServiceUserMetadataHeaders() {

--- a/backend/server/src/test/java/ai/verta/modeldb/BranchTest.java
+++ b/backend/server/src/test/java/ai/verta/modeldb/BranchTest.java
@@ -68,6 +68,7 @@ public class BranchTest extends ModeldbTestSetup {
 
   @BeforeEach
   public void createEntities() {
+    super.setUp();
     initializeChannelBuilderAndExternalServiceStubs();
 
     if (isRunningIsolated()) {
@@ -91,6 +92,7 @@ public class BranchTest extends ModeldbTestSetup {
       repository = null;
       parentCommit = null;
     }
+    super.tearDown();
   }
 
   private void createRepositoryEntities() {

--- a/backend/server/src/test/java/ai/verta/modeldb/CommentTest.java
+++ b/backend/server/src/test/java/ai/verta/modeldb/CommentTest.java
@@ -50,6 +50,7 @@ public class CommentTest extends ModeldbTestSetup {
 
   @BeforeEach
   public void createEntities() {
+    super.setUp();
     initializeChannelBuilderAndExternalServiceStubs();
 
     if (isRunningIsolated()) {
@@ -94,6 +95,7 @@ public class CommentTest extends ModeldbTestSetup {
     assertTrue(deleteProjectResponse.getStatus());
     project = null;
     commentList = new ArrayList<>();
+    super.tearDown();
   }
 
   private void createProjectEntities() {

--- a/backend/server/src/test/java/ai/verta/modeldb/CommitTest.java
+++ b/backend/server/src/test/java/ai/verta/modeldb/CommitTest.java
@@ -99,15 +99,15 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = App.class, webEnvironment = DEFINED_PORT)
 @ContextConfiguration(classes = {ModeldbTestConfigurationBeans.class})
 public class CommitTest extends ModeldbTestSetup {
@@ -117,8 +117,10 @@ public class CommitTest extends ModeldbTestSetup {
   private static Repository repository;
   private static Commit initialCommit;
 
-  @Before
-  public void createEntities() {
+  @BeforeEach
+  @Override
+  public void setUp() {
+    super.setUp();
     initializeChannelBuilderAndExternalServiceStubs();
 
     if (isRunningIsolated()) {
@@ -2366,7 +2368,7 @@ public class CommitTest extends ModeldbTestSetup {
   }
 
   @Test
-  @Ignore
+  @Disabled
   public void getURLForVersionedBlob() throws IOException {
     LOGGER.info("Get Url for VersionedBlob test start................................");
 

--- a/backend/server/src/test/java/ai/verta/modeldb/DatasetTest.java
+++ b/backend/server/src/test/java/ai/verta/modeldb/DatasetTest.java
@@ -57,14 +57,16 @@ public class DatasetTest extends ModeldbTestSetup {
   private static final Logger LOGGER = LogManager.getLogger(DatasetTest.class);
 
   // Dataset Entities
-  private static Dataset dataset1;
-  private static Dataset dataset2;
-  private static Dataset dataset3;
-  private static Dataset dataset4;
-  private static Map<String, Dataset> datasetMap = new HashMap<>();
+  private Dataset dataset1;
+  private Dataset dataset2;
+  private Dataset dataset3;
+  private Dataset dataset4;
+  private final Map<String, Dataset> datasetMap = new HashMap<>();
 
   @BeforeEach
-  public void createEntities() {
+  @Override
+  public void setUp() {
+    super.setUp();
     initializeChannelBuilderAndExternalServiceStubs();
 
     if (isRunningIsolated()) {
@@ -76,24 +78,18 @@ public class DatasetTest extends ModeldbTestSetup {
   }
 
   @AfterEach
-  public void removeEntities() {
+  @Override
+  public void tearDown() {
     if (isRunningIsolated()) {
       when(uacBlockingMock.getCurrentUser(any())).thenReturn(testUser1);
       mockGetResourcesForAllDatasets(datasetMap, testUser1);
     }
     DeleteDatasets deleteDatasets =
         DeleteDatasets.newBuilder().addAllIds(datasetMap.keySet()).build();
-    DeleteDatasets.Response deleteDatasetsResponse =
-        datasetServiceStub.deleteDatasets(deleteDatasets);
+    datasetServiceStub.deleteDatasets(deleteDatasets);
     LOGGER.info("Datasets deleted successfully");
-    LOGGER.info(deleteDatasetsResponse.toString());
-    assertTrue(deleteDatasetsResponse.getStatus());
 
-    dataset1 = null;
-    dataset2 = null;
-    dataset3 = null;
-    dataset4 = null;
-    datasetMap = new HashMap<>();
+    super.tearDown();
   }
 
   private void createDatasetEntities() {

--- a/backend/server/src/test/java/ai/verta/modeldb/DatasetVersionTest.java
+++ b/backend/server/src/test/java/ai/verta/modeldb/DatasetVersionTest.java
@@ -60,6 +60,7 @@ public class DatasetVersionTest extends ModeldbTestSetup {
 
   @BeforeEach
   public void createEntities() {
+    super.setUp();
     initializeChannelBuilderAndExternalServiceStubs();
 
     if (isRunningIsolated()) {
@@ -94,6 +95,7 @@ public class DatasetVersionTest extends ModeldbTestSetup {
     datasetVersion2 = null;
     datasetVersion3 = null;
     datasetVersionMap = new HashMap<>();
+    super.tearDown();
   }
 
   private void createDatasetEntities() {

--- a/backend/server/src/test/java/ai/verta/modeldb/DiffTest.java
+++ b/backend/server/src/test/java/ai/verta/modeldb/DiffTest.java
@@ -91,6 +91,7 @@ public class DiffTest extends ModeldbTestSetup {
 
   @BeforeEach
   public void createEntities() {
+    super.setUp();
     initializeChannelBuilderAndExternalServiceStubs();
 
     if (isRunningIsolated()) {
@@ -112,6 +113,7 @@ public class DiffTest extends ModeldbTestSetup {
     DeleteRepositoryRequest.Response response =
         versioningServiceBlockingStub.deleteRepository(deleteRepository);
     assertTrue("Repository not deleted", response.getStatus());
+    super.tearDown();
   }
 
   private void createRepositoryEntities() {

--- a/backend/server/src/test/java/ai/verta/modeldb/ExperimentRunTest.java
+++ b/backend/server/src/test/java/ai/verta/modeldb/ExperimentRunTest.java
@@ -102,6 +102,7 @@ public class ExperimentRunTest extends ModeldbTestSetup {
 
   @BeforeEach
   public void createEntities() {
+    super.setUp();
     initializeChannelBuilderAndExternalServiceStubs();
 
     if (isRunningIsolated()) {
@@ -150,6 +151,7 @@ public class ExperimentRunTest extends ModeldbTestSetup {
     experimentRun2 = null;
 
     experimentRunMap = new HashMap<>();
+    super.tearDown();
   }
 
   private void createProjectEntities() {

--- a/backend/server/src/test/java/ai/verta/modeldb/ExperimentTest.java
+++ b/backend/server/src/test/java/ai/verta/modeldb/ExperimentTest.java
@@ -53,7 +53,9 @@ public class ExperimentTest extends ModeldbTestSetup {
   private static Experiment experiment;
 
   @BeforeEach
-  public void createEntities() {
+  @Override
+  public void setUp() {
+    super.setUp();
     initializeChannelBuilderAndExternalServiceStubs();
 
     if (isRunningIsolated()) {
@@ -65,7 +67,8 @@ public class ExperimentTest extends ModeldbTestSetup {
   }
 
   @AfterEach
-  public void removeEntities() {
+  @Override
+  public void tearDown() {
     if (isRunningIsolated()) {
       when(uacBlockingMock.getCurrentUser(any())).thenReturn(testUser1);
       mockGetSelfAllowedResources(
@@ -83,6 +86,7 @@ public class ExperimentTest extends ModeldbTestSetup {
 
     // Experiment Entities
     experiment = null;
+    super.tearDown();
   }
 
   private void createProjectEntities() {

--- a/backend/server/src/test/java/ai/verta/modeldb/FindDatasetEntitiesTest.java
+++ b/backend/server/src/test/java/ai/verta/modeldb/FindDatasetEntitiesTest.java
@@ -55,7 +55,9 @@ public class FindDatasetEntitiesTest extends ModeldbTestSetup {
   private static Map<String, DatasetVersion> datasetVersionMap = new HashMap<>();
 
   @BeforeEach
-  public void createEntities() {
+  @Override
+  public void setUp() {
+    super.setUp();
     initializeChannelBuilderAndExternalServiceStubs();
 
     if (isRunningIsolated()) {
@@ -68,7 +70,8 @@ public class FindDatasetEntitiesTest extends ModeldbTestSetup {
   }
 
   @AfterEach
-  public void removeEntities() {
+  @Override
+  public void tearDown() {
     for (DatasetVersion datasetVersion : datasetVersionMap.values()) {
       DeleteDatasetVersion deleteDatasetVersion =
           DeleteDatasetVersion.newBuilder()
@@ -100,6 +103,7 @@ public class FindDatasetEntitiesTest extends ModeldbTestSetup {
     datasetVersion3 = null;
     datasetVersion4 = null;
     datasetVersionMap = new HashMap<>();
+    super.tearDown();
   }
 
   private void createDatasetEntities() {

--- a/backend/server/src/test/java/ai/verta/modeldb/FindProjectEntitiesTest.java
+++ b/backend/server/src/test/java/ai/verta/modeldb/FindProjectEntitiesTest.java
@@ -68,6 +68,7 @@ public class FindProjectEntitiesTest extends ModeldbTestSetup {
 
   @BeforeEach
   public void createEntities() {
+    super.setUp();
     initializeChannelBuilderAndExternalServiceStubs();
 
     if (isRunningIsolated()) {
@@ -99,6 +100,7 @@ public class FindProjectEntitiesTest extends ModeldbTestSetup {
     projectMap = new HashMap<>();
     experimentMap = new HashMap<>();
     experimentRunMap = new HashMap<>();
+    super.tearDown();
   }
 
   private void createProjectEntities() {

--- a/backend/server/src/test/java/ai/verta/modeldb/GlobalSharingTest.java
+++ b/backend/server/src/test/java/ai/verta/modeldb/GlobalSharingTest.java
@@ -45,14 +45,14 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = App.class, webEnvironment = DEFINED_PORT)
 @ContextConfiguration(classes = {ModeldbTestConfigurationBeans.class})
 class GlobalSharingTest extends ModeldbTestSetup {
@@ -122,6 +122,7 @@ class GlobalSharingTest extends ModeldbTestSetup {
 
   @BeforeEach
   public void createEntities() {
+    super.setUp();
     initializeChannelBuilderAndExternalServiceStubs();
 
     if (isRunningIsolated()) {
@@ -267,6 +268,8 @@ class GlobalSharingTest extends ModeldbTestSetup {
                     IsSelfAllowed.Response.newBuilder().setAllowed(true).build()));
         when(authzBlockingMock.isSelfAllowed(any()))
             .thenReturn(IsSelfAllowed.Response.newBuilder().setAllowed(true).build());
+        when(uac.getWorkspaceService().getWorkspaceById(any()))
+            .thenReturn(Futures.immediateFuture(Workspace.newBuilder().build()));
         if (!isReadAllowed) {
           mockGetResourcesForAllProjects(Map.of(), testUser2);
           mockGetResourcesForAllDatasets(Map.of(), testUser2);

--- a/backend/server/src/test/java/ai/verta/modeldb/LineageTest.java
+++ b/backend/server/src/test/java/ai/verta/modeldb/LineageTest.java
@@ -57,6 +57,7 @@ public class LineageTest extends ModeldbTestSetup {
 
   @BeforeEach
   public void createEntities() {
+    super.setUp();
     initializeChannelBuilderAndExternalServiceStubs();
 
     if (isRunningIsolated()) {

--- a/backend/server/src/test/java/ai/verta/modeldb/MergeTest.java
+++ b/backend/server/src/test/java/ai/verta/modeldb/MergeTest.java
@@ -45,18 +45,18 @@ import org.apache.logging.log4j.Logger;
 import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /**
  * Tests diffs after commit creation with diff or blob description and checks resulting diff. Tests
  * 2 modified cases: same type and different type.
  */
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = App.class, webEnvironment = DEFINED_PORT)
 @ContextConfiguration(classes = {ModeldbTestConfigurationBeans.class})
 class MergeTest extends ModeldbTestSetup {
@@ -80,6 +80,7 @@ class MergeTest extends ModeldbTestSetup {
 
   @BeforeEach
   public void createEntities() {
+    super.setUp();
     initializeChannelBuilderAndExternalServiceStubs();
 
     if (isRunningIsolated()) {
@@ -103,6 +104,7 @@ class MergeTest extends ModeldbTestSetup {
     }
 
     repository = null;
+    super.tearDown();
   }
 
   private void createRepositoryEntities() {

--- a/backend/server/src/test/java/ai/verta/modeldb/ModeldbTestSetup.java
+++ b/backend/server/src/test/java/ai/verta/modeldb/ModeldbTestSetup.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.*;
 import ai.verta.common.ModelDBResourceEnum.ModelDBServiceResourceTypes;
 import ai.verta.modeldb.DatasetServiceGrpc.DatasetServiceBlockingStub;
 import ai.verta.modeldb.ProjectServiceGrpc.ProjectServiceBlockingStub;
-import ai.verta.modeldb.common.authservice.AuthServiceChannel;
 import ai.verta.modeldb.common.connections.UAC;
 import ai.verta.modeldb.common.interceptors.MetadataForwarder;
 import ai.verta.modeldb.config.TestConfig;
@@ -85,6 +84,7 @@ import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 
@@ -133,26 +133,20 @@ public abstract class ModeldbTestSetup {
   protected CollaboratorServiceGrpc.CollaboratorServiceBlockingStub collaboratorServiceStubClient1;
   protected CollaboratorServiceGrpc.CollaboratorServiceBlockingStub collaboratorServiceStubClient2;
   protected OrganizationServiceGrpc.OrganizationServiceBlockingStub organizationServiceBlockingStub;
-  private static OrganizationServiceV2Grpc.OrganizationServiceV2BlockingStub
+  private OrganizationServiceV2Grpc.OrganizationServiceV2BlockingStub
       organizationServiceV2BlockingStub;
 
   protected AuthClientInterceptor authClientInterceptor;
   protected final String random = String.valueOf((long) (Math.random() * 1_000_000));
   private static boolean runningIsolated;
-  protected static ManagedChannel authServiceChannelServiceUser;
+  protected ManagedChannel authServiceChannelServiceUser;
 
-  protected CollaboratorServiceGrpc.CollaboratorServiceBlockingStub collaboratorBlockingMock =
-      mock(CollaboratorServiceGrpc.CollaboratorServiceBlockingStub.class);
-  protected AuthzServiceGrpc.AuthzServiceBlockingStub authzBlockingMock =
-      mock(AuthzServiceGrpc.AuthzServiceBlockingStub.class);
-  protected UACServiceGrpc.UACServiceBlockingStub uacBlockingMock =
-      mock(UACServiceGrpc.UACServiceBlockingStub.class);
-  protected WorkspaceServiceGrpc.WorkspaceServiceBlockingStub workspaceBlockingMock =
-      mock(WorkspaceServiceGrpc.WorkspaceServiceBlockingStub.class);
-  protected RoleServiceGrpc.RoleServiceBlockingStub roleServiceBlockingMock =
-      mock(RoleServiceGrpc.RoleServiceBlockingStub.class);
-  protected OrganizationServiceGrpc.OrganizationServiceBlockingStub organizationBlockingMock =
-      mock(OrganizationServiceGrpc.OrganizationServiceBlockingStub.class);
+  protected CollaboratorServiceGrpc.CollaboratorServiceBlockingStub collaboratorBlockingMock;
+  protected AuthzServiceGrpc.AuthzServiceBlockingStub authzBlockingMock;
+  protected UACServiceGrpc.UACServiceBlockingStub uacBlockingMock;
+  protected WorkspaceServiceGrpc.WorkspaceServiceBlockingStub workspaceBlockingMock;
+  protected RoleServiceGrpc.RoleServiceBlockingStub roleServiceBlockingMock;
+  protected OrganizationServiceGrpc.OrganizationServiceBlockingStub organizationBlockingMock;
   private ManagedChannel channel;
   private ManagedChannel channelUser2;
   private ManagedChannel channelServiceUser;
@@ -167,6 +161,23 @@ public abstract class ModeldbTestSetup {
     return runningIsolated;
   }
 
+  @BeforeEach
+  void setUp() {
+    runningIsolated = testConfig.testsShouldRunIsolatedFromDependencies();
+
+    if (runningIsolated) {
+      ModeldbTestConfigurationBeans.resetUacMocks(uac);
+      collaboratorBlockingMock =
+          uac.getBlockingAuthServiceChannel().getCollaboratorServiceBlockingStub();
+      authzBlockingMock = uac.getBlockingAuthServiceChannel().getAuthzServiceBlockingStub();
+      uacBlockingMock = uac.getBlockingAuthServiceChannel().getUacServiceBlockingStub();
+      workspaceBlockingMock = uac.getBlockingAuthServiceChannel().getWorkspaceServiceBlockingStub();
+      roleServiceBlockingMock = uac.getBlockingAuthServiceChannel().getRoleServiceBlockingStub();
+      organizationBlockingMock =
+          uac.getBlockingAuthServiceChannel().getOrganizationServiceBlockingStub();
+    }
+  }
+
   @AfterEach
   public void tearDown() {
     channel.shutdown();
@@ -175,7 +186,6 @@ public abstract class ModeldbTestSetup {
   }
 
   public void initializeChannelBuilderAndExternalServiceStubs() {
-    runningIsolated = testConfig.testsShouldRunIsolatedFromDependencies();
     authClientInterceptor = new AuthClientInterceptor(testConfig);
     channel =
         ManagedChannelBuilder.forAddress("localhost", testConfig.getGrpcServer().getPort())
@@ -448,16 +458,6 @@ public abstract class ModeldbTestSetup {
 
   protected void setupMockUacEndpoints(UAC uac) {
     Context.current().withValue(MetadataForwarder.METADATA_INFO, new Metadata()).attach();
-    AuthServiceChannel authChannelMock = uac.getBlockingAuthServiceChannel();
-    when(authChannelMock.getAuthzServiceBlockingStub()).thenReturn(authzBlockingMock);
-    when(authChannelMock.getUacServiceBlockingStub()).thenReturn(uacBlockingMock);
-    when(authChannelMock.getWorkspaceServiceBlockingStub()).thenReturn(workspaceBlockingMock);
-    when(authChannelMock.getCollaboratorServiceBlockingStub()).thenReturn(collaboratorBlockingMock);
-    when(authChannelMock.getRoleServiceBlockingStubForServiceUser())
-        .thenReturn(roleServiceBlockingMock);
-    when(authChannelMock.getOrganizationServiceBlockingStub()).thenReturn(organizationBlockingMock);
-    when(authChannelMock.getCollaboratorServiceBlockingStubForServiceUser())
-        .thenReturn(collaboratorBlockingMock);
 
     UACServiceGrpc.UACServiceFutureStub uacMock = uac.getUACService();
     when(uacMock.getCurrentUser(any())).thenReturn(Futures.immediateFuture(testUser1));
@@ -471,7 +471,7 @@ public abstract class ModeldbTestSetup {
     when(uac.getAuthzService().isSelfAllowed(any()))
         .thenReturn(
             Futures.immediateFuture(IsSelfAllowed.Response.newBuilder().setAllowed(true).build()));
-    when(authzBlockingMock.isSelfAllowed(any()))
+    when(authzBlockingMock.isSelfAllowed(any(IsSelfAllowed.class)))
         .thenReturn(IsSelfAllowed.Response.newBuilder().setAllowed(true).build());
     when(authzBlockingMock.getSelfAllowedActionsBatch(any()))
         .thenReturn(

--- a/backend/server/src/test/java/ai/verta/modeldb/ProjectTest.java
+++ b/backend/server/src/test/java/ai/verta/modeldb/ProjectTest.java
@@ -73,7 +73,9 @@ public class ProjectTest extends ModeldbTestSetup {
   private Dataset dataset;
 
   @BeforeEach
-  public void createEntities() {
+  @Override
+  public void setUp() {
+    super.setUp();
     initializeChannelBuilderAndExternalServiceStubs();
 
     if (isRunningIsolated()) {
@@ -87,7 +89,8 @@ public class ProjectTest extends ModeldbTestSetup {
   }
 
   @AfterEach
-  public void removeEntities() {
+  @Override
+  public void tearDown() {
     if (!projectMap.isEmpty()) {
       if (isRunningIsolated()) {
         mockGetResourcesForAllProjects(projectMap, testUser1);
@@ -104,19 +107,23 @@ public class ProjectTest extends ModeldbTestSetup {
       assertTrue(deleteProjectsResponse.getStatus());
     }
 
-    if (isRunningIsolated()) {
-      mockGetResourcesForAllDatasets(Map.of(dataset.getId(), dataset), testUser1);
-    }
+    if (dataset != null) {
+      if (isRunningIsolated()) {
+        mockGetResourcesForAllDatasets(Map.of(dataset.getId(), dataset), testUser1);
+      }
 
-    DeleteDataset deleteDataset = DeleteDataset.newBuilder().setId(dataset.getId()).build();
-    DeleteDataset.Response deleteDatasetResponse = datasetServiceStub.deleteDataset(deleteDataset);
-    LOGGER.info("Dataset deleted successfully");
-    LOGGER.info(deleteDatasetResponse.toString());
-    assertTrue(deleteDatasetResponse.getStatus());
+      DeleteDataset deleteDataset = DeleteDataset.newBuilder().setId(dataset.getId()).build();
+      DeleteDataset.Response deleteDatasetResponse =
+          datasetServiceStub.deleteDataset(deleteDataset);
+      LOGGER.info("Dataset deleted successfully");
+      LOGGER.info(deleteDatasetResponse.toString());
+      assertTrue(deleteDatasetResponse.getStatus());
+    }
 
     projectMap.clear();
 
     cleanUpResources();
+    super.tearDown();
   }
 
   private void createProjectEntities() {

--- a/backend/server/src/test/java/ai/verta/modeldb/RepositoryTest.java
+++ b/backend/server/src/test/java/ai/verta/modeldb/RepositoryTest.java
@@ -78,6 +78,7 @@ public class RepositoryTest extends ModeldbTestSetup {
 
   @BeforeEach
   public void createEntities() {
+    super.setUp();
     initializeChannelBuilderAndExternalServiceStubs();
 
     if (isRunningIsolated()) {
@@ -104,6 +105,7 @@ public class RepositoryTest extends ModeldbTestSetup {
     repository2 = null;
     repository3 = null;
     repositoryMap = new HashMap<>();
+    super.tearDown();
   }
 
   private void createRepositoryEntities() {


### PR DESCRIPTION
and cleaning up tests to use the new structure.

Note: there are still 5 legitimate, non-mockito-related test failures that I didn't try to address.

<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

## Risks and Area of Effect

## Testing
- [ ] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

## Reverting
- [ ] Contains Migration - _Do Not Revert_