### PR TITLE
chore: [VR-14202] remove the postgres driver and examples that show it being used

### DIFF
--- a/backend/CONFIG.md
+++ b/backend/CONFIG.md
@@ -72,11 +72,11 @@ database:
   liquibaseLockThreshold: 60 #time in second
   RdbConfiguration:
     RdbDatabaseName: modeldb
-    RdbDriver: "org.postgresql.Driver"
-    RdbDialect: "org.hibernate.dialect.PostgreSQLDialect"
-    RdbUrl: "jdbc:postgresql://localhost:5432"
-    RdbUsername: postgres
-    RdbPassword: root
+    RdbDriver: "org.mariadb.jdbc.Driver"
+    RdbDialect: "org.hibernate.dialect.MySQL5Dialect"
+    RdbUrl: "jdbc:mysql://localhost:3306"
+    RdbUsername: root
+    RdbPassword: root_password_here
 ```
 
 1. `DBType` provide the provision to configure different database like Relation DB, noSql DB. based on this type modeldb-backend initialize the database. (***Note:*** Currently modeldb-backend support only relational DB but you can extend it by writing your own database code)
@@ -97,11 +97,11 @@ test:
     liquibaseLockThreshold: 60 #time in second
     RdbConfiguration:
       RdbDatabaseName: modeldb_test
-      RdbDriver: "org.postgresql.Driver"
-      RdbDialect: "org.hibernate.dialect.PostgreSQLDialect"
-      RdbUrl: "jdbc:postgresql://localhost:5432"
-      RdbUsername: postgres
-      RdbPassword: root
+      RdbDriver: "org.mariadb.jdbc.Driver"
+      RdbDialect: "org.hibernate.dialect.MySQL5Dialect"
+      RdbUrl: "jdbc:mysql://localhost:3306"
+      RdbUsername: root
+      RdbPassword: root_password_here
   testUsers:
     primaryUser:
       email:

--- a/backend/README.md
+++ b/backend/README.md
@@ -62,11 +62,11 @@ test:
     DBType: relational
     RdbConfiguration:
       RdbDatabaseName: modeldb_test
-      RdbDriver: "org.postgresql.Driver"
-      RdbDialect: "org.hibernate.dialect.PostgreSQLDialect"
-      RdbUrl: "jdbc:postgresql://localhost:5432"
-      RdbUsername: postgres
-      RdbPassword: root
+      RdbDriver: "org.mariadb.jdbc.Driver"
+      RdbDialect: "org.hibernate.dialect.MySQL5Dialect"
+      RdbUrl: "jdbc:mysql://localhost:3306"
+      RdbUsername: root
+      RdbPassword: root_password_here
 ```
 
 Set the **VERTA_MODELDB_CONFIG** environment variable to point to config.yaml
@@ -102,11 +102,11 @@ database:
   liquibaseLockThreshold: 60 #time in second
   RdbConfiguration:
     RdbDatabaseName: modeldb
-    RdbDriver: "org.postgresql.Driver"
-    RdbDialect: "org.hibernate.dialect.PostgreSQLDialect"
-    RdbUrl: "jdbc:postgresql://localhost:5432"
-    RdbUsername: postgres
-    RdbPassword: root
+    RdbDriver: "org.mariadb.jdbc.Driver"
+    RdbDialect: "org.hibernate.dialect.MySQL5Dialect"
+    RdbUrl: "jdbc:mysql://localhost:3306"
+    RdbUsername: root
+    RdbPassword: root_password_here
 ```
 
 1. If you are connecting to postgres, the database needs to be already created.

--- a/backend/common/pom.xml
+++ b/backend/common/pom.xml
@@ -139,12 +139,6 @@
             <version>${otel.instrumentation.version}</version>
         </dependency>
 
-        <!-- https://mvnrepository.com/artifact/org.postgresql/postgresql -->
-        <dependency>
-            <groupId>org.postgresql</groupId>
-            <artifactId>postgresql</artifactId>
-        </dependency>
-
         <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-slf4j-impl -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/backend/common/src/main/java/ai/verta/modeldb/common/CommonDBUtil.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/CommonDBUtil.java
@@ -169,12 +169,7 @@ public abstract class CommonDBUtil {
 
   private static ResultSet getTableBasedOnDialect(Connection conn, String tableName, RdbConfig rdb)
       throws SQLException {
-    if (rdb.isPostgres()) {
-      // TODO: make postgres implementation multitenant as well.
-      return conn.getMetaData().getTables(null, null, tableName, null);
-    } else {
-      return conn.getMetaData().getTables(RdbConfig.buildDatabaseName(rdb), null, tableName, null);
-    }
+    return conn.getMetaData().getTables(RdbConfig.buildDatabaseName(rdb), null, tableName, null);
   }
 
   protected void createTablesLiquibaseMigration(

--- a/backend/common/src/main/java/ai/verta/modeldb/common/config/RdbConfig.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/config/RdbConfig.java
@@ -40,7 +40,7 @@ public class RdbConfig {
     if (RdbUsername == null || RdbUsername.isEmpty()) {
       throw new InvalidConfigException(base + ".RdbUsername", CommonMessages.MISSING_REQUIRED);
     }
-    if (!isPostgres() && !isMysql() && !isMssql() && !isH2()) {
+    if (!isMysql() && !isMssql() && !isH2()) {
       throw new InvalidConfigException(base + ".RdbDialect", "Unknown or unsupported dialect.");
     }
 
@@ -56,10 +56,6 @@ public class RdbConfig {
         throw new InvalidConfigException(base + ".sslMode", CommonMessages.MISSING_REQUIRED);
       }
     }
-  }
-
-  public boolean isPostgres() {
-    return RdbDialect.equals("org.hibernate.dialect.PostgreSQL82Dialect");
   }
 
   public boolean isMysql() {
@@ -128,9 +124,6 @@ public class RdbConfig {
     }
 
     if (dbName.contains("-")) {
-      if (rdb.isPostgres()) {
-        throw new ModelDBException("Postgres does not support database names containing -");
-      }
       if (rdb.isMysql()) {
         return String.format("`%s`", dbName);
       }
@@ -146,9 +139,6 @@ public class RdbConfig {
     if (rdb.isMssql()) {
       // Regex reference: https://regex101.com/r/yaU0DY/1
       regex = ";databaseName=([^;]*)";
-    } else if (rdb.isPostgres()) {
-      // Regex reference: https://regex101.com/r/Ez1xre/1
-      regex = "^jdbc:postgresql:(?://[^/]+/)?(\\w+)";
     } else {
       regex = "^jdbc:mysql:(?://[^/]+/)?(\\w+)";
     }

--- a/backend/config.example.yaml
+++ b/backend/config.example.yaml
@@ -51,12 +51,12 @@ database:
   idleTimeout: "60000"
   maxLifetime: "300000"
   RdbConfiguration:
-    RdbDatabaseName:
-    RdbDriver: "org.postgresql.Driver"
-    RdbDialect: "org.hibernate.dialect.PostgreSQLDialect"
-    RdbUrl: "jdbc:postgresql://localhost:5432"
-    RdbUsername:
-    RdbPassword:
+    RdbDatabaseName: modeldb
+    RdbDriver: "org.mariadb.jdbc.Driver"
+    RdbDialect: "org.hibernate.dialect.MySQL5Dialect"
+    RdbUrl: "jdbc:mysql://localhost:3306"
+    RdbUsername: root
+    RdbPassword: root_password_here
     sslMode: DISABLED
     sslEnabled: false
 
@@ -72,11 +72,11 @@ test:
     connectionTimeout: 300
     RdbConfiguration:
       RdbDatabaseName: test
-      RdbDriver: "org.postgresql.Driver"
-      RdbDialect: "org.hibernate.dialect.PostgreSQLDialect"
-      RdbUrl: "jdbc:postgresql://localhost:5432"
-      RdbUsername:
-      RdbPassword:
+      RdbDriver: "org.mariadb.jdbc.Driver"
+      RdbDialect: "org.hibernate.dialect.MySQL5Dialect"
+      RdbUrl: "jdbc:mysql://localhost:3306"
+      RdbUsername: root
+      RdbPassword: root_password_here
       sslMode: DISABLED
   testUsers:
     primaryUser:

--- a/backend/config/config.yaml
+++ b/backend/config/config.yaml
@@ -22,12 +22,12 @@ database:
   timeout: 4
   liquibaseLockThreshold: 60 #time in second
   RdbConfiguration:
-    RdbDatabaseName: postgres
-    RdbDriver: "org.postgresql.Driver"
-    RdbDialect: "org.hibernate.dialect.PostgreSQLDialect"
-    RdbUrl: "jdbc:postgresql://modeldb-postgres:5432"
-    RdbUsername: postgres
-    RdbPassword: root
+    RdbDatabaseName: modeldb
+    RdbDriver: "org.mariadb.jdbc.Driver"
+    RdbDialect: "org.hibernate.dialect.MySQL5Dialect"
+    RdbUrl: "jdbc:mysql://localhost:3306"
+    RdbUsername: root
+    RdbPassword: root_password_here
 
 # Test Database settings (type mongodb, couchbasedb etc..)
 test:
@@ -36,12 +36,12 @@ test:
     timeout: 4
     liquibaseLockThreshold: 60 #time in second
     RdbConfiguration:
-      RdbDatabaseName: postgres
-      RdbDriver: "org.postgresql.Driver"
-      RdbDialect: "org.hibernate.dialect.PostgreSQLDialect"
-      RdbUrl: "jdbc:postgresql://modeldb-postgres:5432"
-      RdbUsername: postgres
-      RdbPassword: root
+      RdbDatabaseName: modeldb-test
+      RdbDriver: "org.mariadb.jdbc.Driver"
+      RdbDialect: "org.hibernate.dialect.MySQL5Dialect"
+      RdbUrl: "jdbc:mysql://localhost:3306"
+      RdbUsername: root
+      RdbPassword: root_password_here
 
 #ArtifactStore Properties
 artifactStore_grpcServer:

--- a/backend/server/pom.xml
+++ b/backend/server/pom.xml
@@ -113,12 +113,6 @@
             <artifactId>jdbi3-core</artifactId>
         </dependency>
 
-        <!-- https://mvnrepository.com/artifact/org.postgresql/postgresql -->
-        <dependency>
-            <groupId>org.postgresql</groupId>
-            <artifactId>postgresql</artifactId>
-        </dependency>
-
         <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-s3 -->
         <dependency>
             <groupId>com.amazonaws</groupId>

--- a/backend/server/src/main/java/ai/verta/modeldb/experimentRun/subtypes/HyperparameterPredicatesHandler.java
+++ b/backend/server/src/main/java/ai/verta/modeldb/experimentRun/subtypes/HyperparameterPredicatesHandler.java
@@ -35,7 +35,7 @@ public class HyperparameterPredicatesHandler extends PredicateHandlerUtils {
     try {
       switch (value.getKindCase()) {
         case NUMBER_VALUE:
-          sql += applyOperator(operator, columnAsNumber(colValue, true), ":" + valueBindingName);
+          sql += applyOperator(operator, columnAsNumber(colValue), ":" + valueBindingName);
           queryContext =
               queryContext.addBind(q -> q.bind(valueBindingName, value.getNumberValue()));
           break;

--- a/backend/server/src/main/java/ai/verta/modeldb/experimentRun/subtypes/PredicateHandlerUtils.java
+++ b/backend/server/src/main/java/ai/verta/modeldb/experimentRun/subtypes/PredicateHandlerUtils.java
@@ -8,20 +8,12 @@ import java.util.regex.Pattern;
 public class PredicateHandlerUtils {
   private static final MDBConfig mdbConfig = App.getInstance().mdbConfig;
 
-  protected String columnAsNumber(String colName, boolean isString) {
+  protected String columnAsNumber(String colName) {
     if (mdbConfig.getDatabase().getRdbConfiguration().isH2()) {
       return String.format("cast(trim('\"' from %s) as double precision)", colName);
     }
 
-    if (mdbConfig.getDatabase().getRdbConfiguration().isPostgres()) {
-      if (isString) {
-        return String.format("cast(trim('\"' from %s) as double precision)", colName);
-      } else {
-        return String.format("cast(%s as double precision)", colName);
-      }
-    } else {
-      return String.format("cast(%s as decimal(16, 8))", colName);
-    }
+    return String.format("cast(%s as decimal(16, 8))", colName);
   }
 
   protected String applyOperator(

--- a/backend/server/src/main/java/ai/verta/modeldb/experimentRun/subtypes/PredicatesHandler.java
+++ b/backend/server/src/main/java/ai/verta/modeldb/experimentRun/subtypes/PredicatesHandler.java
@@ -394,7 +394,7 @@ public class PredicatesHandler extends PredicateHandlerUtils {
 
     switch (value.getKindCase()) {
       case NUMBER_VALUE:
-        sql += applyOperator(operator, columnAsNumber(colValue, true), ":" + valueBindingName);
+        sql += applyOperator(operator, columnAsNumber(colValue), ":" + valueBindingName);
         queryContext = queryContext.addBind(q -> q.bind(valueBindingName, value.getNumberValue()));
         break;
       case STRING_VALUE:
@@ -462,7 +462,7 @@ public class PredicatesHandler extends PredicateHandlerUtils {
 
       switch (value.getKindCase()) {
         case NUMBER_VALUE:
-          sql += applyOperator(operator, columnAsNumber(colValue, true), ":" + valueBindingName);
+          sql += applyOperator(operator, columnAsNumber(colValue), ":" + valueBindingName);
           queryContext =
               queryContext.addBind(q -> q.bind(valueBindingName, value.getNumberValue()));
           break;
@@ -551,7 +551,7 @@ public class PredicatesHandler extends PredicateHandlerUtils {
 
       switch (value.getKindCase()) {
         case NUMBER_VALUE:
-          sql += applyOperator(operator, columnAsNumber(colValue, true), ":" + valueBindingName);
+          sql += applyOperator(operator, columnAsNumber(colValue), ":" + valueBindingName);
           queryContext =
               queryContext.addBind(q -> q.bind(valueBindingName, value.getNumberValue()));
           break;

--- a/backend/server/src/main/java/ai/verta/modeldb/utils/CommonHibernateUtil.java
+++ b/backend/server/src/main/java/ai/verta/modeldb/utils/CommonHibernateUtil.java
@@ -32,7 +32,6 @@ import org.hibernate.hikaricp.internal.HikariCPConnectionProvider;
 import org.hibernate.tool.hbm2ddl.SchemaExport;
 import org.hibernate.tool.schema.TargetType;
 import org.mariadb.jdbc.MariaDbDataSource;
-import org.postgresql.ds.PGSimpleDataSource;
 
 public abstract class CommonHibernateUtil extends CommonDBUtil {
   private static final Logger LOGGER = LogManager.getLogger(CommonHibernateUtil.class);
@@ -156,9 +155,6 @@ public abstract class CommonHibernateUtil extends CommonDBUtil {
     }
     if (rdbConfiguration.isMysql()) {
       return MariaDbDataSource.class.getName();
-    }
-    if (rdbConfiguration.isPostgres()) {
-      return PGSimpleDataSource.class.getName();
     }
     if (rdbConfiguration.isH2()) {
       return JdbcDataSource.class.getName();

--- a/backend/server/src/main/java/ai/verta/modeldb/utils/RdbmsUtils.java
+++ b/backend/server/src/main/java/ai/verta/modeldb/utils/RdbmsUtils.java
@@ -722,17 +722,9 @@ public class RdbmsUtils {
     var operator = keyValueQuery.getOperator();
     switch (value.getKindCase()) {
       case NUMBER_VALUE:
-        LOGGER.debug("Called switch case : number_value");
-        //        return getOperatorPredicate(
-        //            builder,
-        //            builder.function("CAST", BigDecimal.class, valueExpression,
-        //            		builder.function("DECIMAL", BigDecimal.class,
-        // builder.literal(10),builder.literal(10))),
-        //            operator, value.getNumberValue());
         var dbConfig = App.getInstance().mdbConfig.getDatabase().getRdbConfiguration();
-        if (dbConfig.isPostgres() || dbConfig.isMssql() || dbConfig.isH2()) {
+        if (dbConfig.isMssql() || dbConfig.isH2()) {
           if (stringColumn) {
-
             return getOperatorPredicate(
                 builder,
                 builder
@@ -749,9 +741,7 @@ public class RdbmsUtils {
               builder, builder.toBigDecimal(valueExpression), operator, value.getNumberValue());
         }
       case STRING_VALUE:
-        LOGGER.debug("Called switch case : string_value");
         if (!value.getStringValue().isEmpty()) {
-          LOGGER.debug("Called switch case : string value exist");
           if (fieldName.equals(ModelDBConstants.ATTRIBUTES)
               && !(operator.equals(Operator.CONTAIN) || operator.equals(Operator.NOT_CONTAIN))) {
             return getOperatorPredicate(
@@ -769,7 +759,6 @@ public class RdbmsUtils {
           throw new InvalidArgumentException("Predicate does not contain string value in request");
         }
       case BOOL_VALUE:
-        LOGGER.debug("Called switch case : bool_value");
         return getOperatorPredicate(builder, valueExpression, operator, value.getBoolValue());
       case LIST_VALUE:
         List<Object> valueList = new ArrayList<>();

--- a/chart/modeldb/charts/backend/values.yaml
+++ b/chart/modeldb/charts/backend/values.yaml
@@ -69,12 +69,12 @@ config:
     timeout: 4
     liquibaseLockThreshold: 60 #time in second
     RdbConfiguration:
-      RdbDatabaseName: postgres
-      RdbDriver: "org.postgresql.Driver"
-      RdbDialect: "org.hibernate.dialect.PostgreSQLDialect"
-      RdbUrl: "jdbc:postgresql://modeldb-postgresql:5432"
-      RdbUsername: postgres
-      RdbPassword: postgres
+      RdbDatabaseName: modeldb
+      RdbDriver: "org.mariadb.jdbc.Driver"
+      RdbDialect: "org.hibernate.dialect.MySQL5Dialect"
+      RdbUrl: "jdbc:mysql://localhost:3306"
+      RdbUsername: root
+      RdbPassword: root_password_here
 
   # Test Database settings (type mongodb, couchbasedb etc..)
   test:
@@ -83,12 +83,12 @@ config:
       timeout: 4
       liquibaseLockThreshold: 60 #time in second
       RdbConfiguration:
-        RdbDatabaseName: postgres
-        RdbDriver: "org.postgresql.Driver"
-        RdbDialect: "org.hibernate.dialect.PostgreSQLDialect"
-        RdbUrl: "jdbc:postgresql://modeldb-postgresql:5432"
-        RdbUsername: postgres
-        RdbPassword: postgres
+        RdbDatabaseName: modeldb-test
+        RdbDriver: "org.mariadb.jdbc.Driver"
+        RdbDialect: "org.hibernate.dialect.MySQL5Dialect"
+        RdbUrl: "jdbc:mysql://localhost:3306"
+        RdbUsername: root
+        RdbPassword: root_password_here
 
   #ArtifactStore Properties
   artifactStore_grpcServer:

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,6 @@
         <hibernate.version>5.6.11.Final</hibernate.version>
         <log4j.version>2.19.0</log4j.version>
         <grpc.version>1.49.0</grpc.version>
-        <postgres.version>42.5.0</postgres.version>
         <liquibase.version>4.9.1</liquibase.version>
         <prometheus.version>0.16.0</prometheus.version>
         <protobuf.version>3.21.5</protobuf.version>
@@ -208,13 +207,6 @@
                 <groupId>org.jdbi</groupId>
                 <artifactId>jdbi3-core</artifactId>
                 <version>3.32.0</version>
-            </dependency>
-
-            <!-- https://mvnrepository.com/artifact/org.postgresql/postgresql -->
-            <dependency>
-                <groupId>org.postgresql</groupId>
-                <artifactId>postgresql</artifactId>
-                <version>${postgres.version}</version>
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-s3 -->


### PR DESCRIPTION
Note: does not include removal of the docker-compose setup that uses postgres (but doesn't currently work, due to having no postgres migrations)

<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

## Risks and Area of Effect

## Testing
- [x] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

## Reverting
- [ ] Contains Migration - _Do Not Revert_