### PR TITLE
fix: make SQL Server schema migration table initialization work regardless of db schema being used.

### DIFF
--- a/backend/common/src/main/java/ai/verta/modeldb/common/db/migration/SqlServerMigrationDatastore.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/db/migration/SqlServerMigrationDatastore.java
@@ -1,7 +1,10 @@
 package ai.verta.modeldb.common.db.migration;
 
+import lombok.extern.log4j.Log4j2;
+
 import java.sql.*;
 
+@Log4j2
 class SqlServerMigrationDatastore implements MigrationDatastore {
   private final Connection connection;
 
@@ -47,13 +50,18 @@ class SqlServerMigrationDatastore implements MigrationDatastore {
 
   @Override
   public void ensureMigrationTableExists() throws SQLException {
+    //the simplest way in sql server to see if a table exists is just to try to query it.
+    try (PreparedStatement ps =
+        connection.prepareStatement("select count(*) from " + SCHEMA_MIGRATIONS_TABLE)) {
+      ps.executeQuery().close();
+      return;
+    } catch (SQLException e) {
+      log.info(SCHEMA_MIGRATIONS_TABLE + " does not exist. Creating");
+      // this means the table doesn't already exist, so go ahead and created it below...
+    }
+
     String sql =
-        "IF NOT EXISTS"
-            + "(SELECT *  FROM sysobjects  WHERE id = object_id(N'[dbo].["
-            + SCHEMA_MIGRATIONS_TABLE
-            + "]') "
-            + " AND OBJECTPROPERTY(id, N'IsUserTable') = 1 )"
-            + "CREATE TABLE "
+        "CREATE TABLE "
             + SCHEMA_MIGRATIONS_TABLE
             + " ( version BIGINT PRIMARY KEY NOT NULL, dirty BIT NOT NULL );";
     try (PreparedStatement ps = connection.prepareStatement(sql)) {

--- a/backend/common/src/main/java/ai/verta/modeldb/common/db/migration/SqlServerMigrationDatastore.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/db/migration/SqlServerMigrationDatastore.java
@@ -1,8 +1,7 @@
 package ai.verta.modeldb.common.db.migration;
 
-import lombok.extern.log4j.Log4j2;
-
 import java.sql.*;
+import lombok.extern.log4j.Log4j2;
 
 @Log4j2
 class SqlServerMigrationDatastore implements MigrationDatastore {
@@ -50,7 +49,7 @@ class SqlServerMigrationDatastore implements MigrationDatastore {
 
   @Override
   public void ensureMigrationTableExists() throws SQLException {
-    //the simplest way in sql server to see if a table exists is just to try to query it.
+    // the simplest way in sql server to see if a table exists is just to try to query it.
     try (PreparedStatement ps =
         connection.prepareStatement("select count(*) from " + SCHEMA_MIGRATIONS_TABLE)) {
       ps.executeQuery().close();


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

## Risks and Area of Effect

## Testing
- [x] Unit test
- [x] Deployed to dev env
- [ ] Other (explain) 

## Reverting
- [ ] Contains Migration - _Do Not Revert_