### PR TITLE
refactor: Deprecate ModelDBException constructors in favor of strong types

### DIFF
--- a/backend/common/src/main/java/ai/verta/modeldb/common/exceptions/ModelDBException.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/exceptions/ModelDBException.java
@@ -12,11 +12,13 @@ public class ModelDBException extends RuntimeException {
 
   private final Code code;
 
+  @Deprecated(forRemoval = true)
   public ModelDBException() {
     super();
     code = Code.INTERNAL;
   }
 
+  @Deprecated(forRemoval = true)
   public ModelDBException(String message) {
     super(message);
     code = Code.INTERNAL;
@@ -27,21 +29,25 @@ public class ModelDBException extends RuntimeException {
     code = Code.INTERNAL;
   }
 
+  @Deprecated(forRemoval = true)
   public ModelDBException(Throwable cause) {
     super(cause);
     code = Code.INTERNAL;
   }
 
+  @Deprecated(forRemoval = true)
   public ModelDBException(String message, Code code) {
     super(message);
     this.code = code;
   }
 
+  @Deprecated(forRemoval = true)
   public ModelDBException(String message, com.google.rpc.Code code, Throwable cause) {
     super(message, cause);
     this.code = Code.valueOf(code.name());
   }
 
+  @Deprecated(forRemoval = true)
   public ModelDBException(String message, com.google.rpc.Code code) {
     super(message);
     this.code = Code.valueOf(code.name());


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context
Instead of passing `Code.INTERNAL` to an argument, we should use the strong type `InternalErrorException`. This makes it easier to catch just some specific scenarios.

## Risks and Area of Effect

## Testing
- [ ] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

## Reverting
- [ ] Contains Migration - _Do Not Revert_