### PR TITLE
chore: capture the callsite on ListenableFuture wrapping 

### DIFF
--- a/backend/common/src/main/java/ai/verta/modeldb/common/CommonUtils.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/CommonUtils.java
@@ -163,7 +163,7 @@ public class CommonUtils {
                 .build();
       } else {
         LOGGER.error(
-            "Stacktrace with {} elements for {} {}", stack.length, e.getClass(), e.getMessage());
+            "Stacktrace with {} elements for {}: {}", stack.length, e.getClass(), e.getMessage());
         status =
             Status.newBuilder()
                 .setCode(Code.INTERNAL_VALUE)

--- a/backend/common/src/main/java/ai/verta/modeldb/common/futures/FutureUtil.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/futures/FutureUtil.java
@@ -22,9 +22,11 @@ public final class FutureUtil {
   // Callback for a ListenableFuture to satisfy a promise
   static class Callback<T> implements FutureCallback<T> {
     final CompletableFuture<T> promise;
+    final Exception callSiteHolder;
 
     Callback(CompletableFuture<T> promise) {
       this.promise = promise;
+      this.callSiteHolder = new Exception("call site:");
     }
 
     @Override
@@ -34,6 +36,7 @@ public final class FutureUtil {
 
     @Override
     public void onFailure(@NonNull Throwable t) {
+      t.addSuppressed(callSiteHolder);
       promise.completeExceptionally(t);
     }
   }

--- a/backend/common/src/test/java/ai/verta/modeldb/common/futures/FutureTest.java
+++ b/backend/common/src/test/java/ai/verta/modeldb/common/futures/FutureTest.java
@@ -19,7 +19,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-
 import lombok.extern.log4j.Log4j2;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
@@ -74,7 +73,9 @@ class FutureTest {
                   return Future.failedStage(new RuntimeException("broken"));
                 });
 
-    assertThatThrownBy(testFuture::blockAndGet).isInstanceOf(RuntimeException.class).hasMessage("borken");
+    assertThatThrownBy(testFuture::blockAndGet)
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("borken");
   }
 
   @Test
@@ -364,16 +365,13 @@ class FutureTest {
     assertThat(Future.fromListenableFuture(b).blockAndGet()).isEqualTo("lemonade");
 
     ListenableFuture<String> c = Futures.immediateFailedFuture(new RuntimeException("oh no"));
-    assertThatThrownBy(() -> {
-        try {
-            Future.fromListenableFuture(c).blockAndGet();
-        } catch (Exception e) {
-            log.error("failed", e);
-            throw e;
-        }
-    })
+    assertThatThrownBy(() -> Future.fromListenableFuture(c).blockAndGet())
         .isInstanceOf(RuntimeException.class)
         .hasMessage("oh no")
-        .satisfies(throwable -> assertThat(throwable.getSuppressed()).hasSize(1));
+        .satisfies(
+            throwable -> {
+              Throwable[] suppressed = throwable.getSuppressed();
+              assertThat(suppressed).hasSize(1).allMatch(t -> t.getMessage().contains("call site"));
+            });
   }
 }

--- a/backend/common/src/test/java/ai/verta/modeldb/common/futures/FutureTest.java
+++ b/backend/common/src/test/java/ai/verta/modeldb/common/futures/FutureTest.java
@@ -365,8 +365,7 @@ class FutureTest {
     assertThat(Future.fromListenableFuture(b).blockAndGet()).isEqualTo("lemonade");
 
     ListenableFuture<String> c = Futures.immediateFailedFuture(new RuntimeException("oh no"));
-    assertThatThrownBy(
-            () -> Future.fromListenableFuture(c).blockAndGet())
+    assertThatThrownBy(() -> Future.fromListenableFuture(c).blockAndGet())
         .isInstanceOf(RuntimeException.class)
         .hasMessage("oh no")
         .satisfies(

--- a/backend/common/src/test/java/ai/verta/modeldb/common/futures/FutureTest.java
+++ b/backend/common/src/test/java/ai/verta/modeldb/common/futures/FutureTest.java
@@ -19,7 +19,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-
 import lombok.extern.log4j.Log4j2;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
@@ -74,7 +73,9 @@ class FutureTest {
                   return Future.failedStage(new RuntimeException("broken"));
                 });
 
-    assertThatThrownBy(testFuture::blockAndGet).isInstanceOf(RuntimeException.class).hasMessage("borken");
+    assertThatThrownBy(testFuture::blockAndGet)
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("borken");
   }
 
   @Test
@@ -364,14 +365,15 @@ class FutureTest {
     assertThat(Future.fromListenableFuture(b).blockAndGet()).isEqualTo("lemonade");
 
     ListenableFuture<String> c = Futures.immediateFailedFuture(new RuntimeException("oh no"));
-    assertThatThrownBy(() -> {
-        try {
-            Future.fromListenableFuture(c).blockAndGet();
-        } catch (Exception e) {
-            log.error("failed", e);
-            throw e;
-        }
-    })
+    assertThatThrownBy(
+            () -> {
+              try {
+                Future.fromListenableFuture(c).blockAndGet();
+              } catch (Exception e) {
+                log.error("failed", e);
+                throw e;
+              }
+            })
         .isInstanceOf(RuntimeException.class)
         .hasMessage("oh no")
         .satisfies(throwable -> assertThat(throwable.getSuppressed()).hasSize(1));


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context
This adds the callsite as an suppressed Exception to whatever causes the ListenableFuture to fail.

## Risks and Area of Effect

## Testing
- [x] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

## Reverting
- [ ] Contains Migration - _Do Not Revert_