### PR TITLE
chore: Tighten `requests` lower constraint

### DIFF
--- a/client/verta/requirements.txt
+++ b/client/verta/requirements.txt
@@ -4,4 +4,4 @@ googleapis-common-protos >= 1.5, < 2.0
 protobuf >= 3.8, < 4.0
 pytimeparse >= 1.1.8, < 2.0
 pyyaml >= 5.1, < 7.0
-requests >= 2.21, < 3.0
+requests >= 2.25, < 3.0


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

https://github.com/VertaAI/modeldb/pull/3332 added the use of `urllib3.util.Retry`’s `other` parameter, which [was introduced in `urllib3==1.26.0`](https://github.com/urllib3/urllib3/commit/caad948e02b24c9516da453b7411df13af357449). This means our client is no longer compatible with [`requests<2.25.0`, which only allowed older versions of `urllib3`](https://github.com/psf/requests/commit/03957eb1c2b9a1e5e6d61f5e930d7c5ed7cfe853).

## Risks and Area of Effect

I'd consider this low risk; `urllib3==1.26.0` and `requests==2.25.0` were both released all the way back in Nov 2020. Simpler times...

## Testing
- [ ] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

—

## Reverting
- [ ] Contains Migration - _Do Not Revert_

Revert this PR.