### PR TITLE
chore: make sure the overload monitor is in a daemon thread

### DIFF
--- a/backend/common/src/main/java/ai/verta/modeldb/common/metrics/ThreadSchedulingMonitor.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/metrics/ThreadSchedulingMonitor.java
@@ -16,7 +16,8 @@ public class ThreadSchedulingMonitor {
             .setUnit("ms")
             .build();
 
-    new Thread(
+    Thread monitoringThread =
+        new Thread(
             () -> {
               while (true) {
                 try {
@@ -32,7 +33,8 @@ public class ThreadSchedulingMonitor {
                   break;
                 }
               }
-            })
-        .start();
+            });
+    monitoringThread.setDaemon(true);
+    monitoringThread.start();
   }
 }


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

## Risks and Area of Effect

## Testing
- [x] Unit test
- [ ] Deployed to dev env
- [x] Other (explain) - ran locally and verified that lack of DB makes the app crash and stop properly during migrations 

## Reverting
- [ ] Contains Migration - _Do Not Revert_