### PR TITLE
chore: Explicitly add lower bound for urllib3

### DIFF
--- a/client/verta/requirements.txt
+++ b/client/verta/requirements.txt
@@ -5,3 +5,4 @@ protobuf >= 3.8, < 4.0
 pytimeparse >= 1.1.8, < 2.0
 pyyaml >= 5.1, < 7.0
 requests >= 2.25, < 3.0
+urllib3 >= 1.26.0


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

Follow-up to #3540.

`requests >= 2.25` still tolerates older versions of `urllib3`; we need to specify the lower bound ourselves.

## Risks and Area of Effect

> I'd consider this low risk; `urllib3==1.26.0` and `requests==2.25.0` were both released all the way back in Nov 2020. Simpler times...

## Testing
- [ ] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

—

## Reverting
- [ ] Contains Migration - _Do Not Revert_

Revert this PR.