### PR TITLE
[FE-641] Fix fuzzy search using 'user_id' which doesn't exists

### DIFF
--- a/backend/common/src/main/java/ai/verta/modeldb/common/authservice/UACApisUtil.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/authservice/UACApisUtil.java
@@ -387,7 +387,7 @@ public class UACApisUtil {
                             executor)
                         .thenCompose(
                             resourceIds -> {
-                              if (resourceIds.isEmpty()){
+                              if (resourceIds.isEmpty()) {
                                 return InternalFuture.completedInternalFuture(
                                     String.format("%s.id = '-1'", alias));
                               }

--- a/backend/common/src/main/java/ai/verta/modeldb/common/authservice/UACApisUtil.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/authservice/UACApisUtil.java
@@ -387,6 +387,11 @@ public class UACApisUtil {
                             executor)
                         .thenCompose(
                             resourceIds -> {
+                              if (resourceIds.isEmpty()){
+                                return InternalFuture.completedInternalFuture(
+                                    String.format("%s.id = '-1'", alias));
+                              }
+
                               final var valueBindingName =
                                   String.format("fuzzy_id_%d", new Date().getTime());
                               String inClause;


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context
There was a bug when the user try to search resources based on owners which don't exist then the backend was throwing an `Internal Server` error instead of returning an empty resource list and it was a bug that I have fixed but that logic and code in a common module so I have created common module changes PR here with test cases.

## Risks and Area of Effect

## Testing
- [ ] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

## Reverting
- [ ] Contains Migration - _Do Not Revert_