### PR TITLE
chore: 2023_02 observability/stability backports

### DIFF
--- a/backend/common/src/main/java/ai/verta/modeldb/common/config/DatabaseConfig.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/config/DatabaseConfig.java
@@ -21,7 +21,7 @@ public class DatabaseConfig {
   @JsonProperty private String minConnectionPoolSize = "0";
   @JsonProperty private String maxConnectionPoolSize = "20";
   @JsonProperty private int threadCount = 8;
-  @JsonProperty private String connectionTimeout = "300";
+  @JsonProperty private String connectionTimeout = "5000"; // note: milliseconds
   @JsonProperty private Long leakDetectionThresholdMs = 3000L;
 
   @JsonProperty private RdbConfig RdbConfiguration;
@@ -38,5 +38,9 @@ public class DatabaseConfig {
     } else {
       throw new InvalidConfigException(base + ".DBType", "unknown type " + DBType);
     }
+  }
+
+  public long getConnectionTimeoutMillis() {
+    return Long.parseLong(connectionTimeout);
   }
 }

--- a/backend/common/src/main/java/ai/verta/modeldb/common/db/JdbiUtils.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/db/JdbiUtils.java
@@ -32,6 +32,7 @@ public class JdbiUtils {
     hikariDataSource.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory());
     hikariDataSource.setPoolName(poolName);
     hikariDataSource.setLeakDetectionThreshold(databaseConfig.getLeakDetectionThresholdMs());
+    hikariDataSource.setConnectionTimeout(databaseConfig.getConnectionTimeoutMillis());
     return hikariDataSource;
   }
 }

--- a/backend/common/src/main/java/ai/verta/modeldb/common/db/JdbiUtils.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/db/JdbiUtils.java
@@ -14,7 +14,8 @@ public class JdbiUtils {
   public static FutureJdbi initializeFutureJdbi(
       DatabaseConfig databaseConfig, DataSource dataSource) {
     final var jdbi = new InternalJdbi(Jdbi.create(dataSource));
-    final var dbExecutor = FutureExecutor.initializeExecutor(databaseConfig.getThreadCount());
+    final var dbExecutor =
+        FutureExecutor.initializeExecutor(databaseConfig.getThreadCount(), "jdbi");
     return new FutureJdbi(jdbi, dbExecutor);
   }
 

--- a/backend/common/src/main/java/ai/verta/modeldb/common/futures/Future.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/futures/Future.java
@@ -376,7 +376,8 @@ public class Future<T> {
                 delayedExecutor =
                     FutureExecutor.makeCompatibleExecutor(
                         CompletableFuture.delayedExecutor(
-                            retry.getAmountToDelay(), retry.getTimeUnit(), futureExecutor));
+                            retry.getAmountToDelay(), retry.getTimeUnit(), futureExecutor),
+                        futureExecutor.getName());
               }
 
               retrying(

--- a/backend/common/src/main/java/ai/verta/modeldb/common/futures/FutureExecutor.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/futures/FutureExecutor.java
@@ -1,7 +1,11 @@
 package ai.verta.modeldb.common.futures;
 
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.LongHistogram;
+import io.opentelemetry.api.metrics.LongUpDownCounter;
+import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.ContextKey;
 import java.util.concurrent.Executor;
@@ -16,9 +20,21 @@ import org.springframework.lang.NonNull;
 public class FutureExecutor implements Executor {
   private static final ContextKey<Long> EXECUTION_TIMER_KEY = ContextKey.named("execution timer");
   private static volatile LongHistogram schedulingDelayHistogram;
+  private static volatile LongUpDownCounter activeFutureCounter;
   private final Executor delegate;
+  private final String name;
   @With private final io.opentelemetry.context.Context otelContext;
   @With private final io.grpc.Context grpcContext;
+  private final Attributes metricAttributes;
+
+  public FutureExecutor(
+      Executor delegate, String name, Context otelContext, io.grpc.Context grpcContext) {
+    this.delegate = delegate;
+    this.name = name;
+    this.otelContext = otelContext;
+    this.grpcContext = grpcContext;
+    metricAttributes = Attributes.of(AttributeKey.stringKey("executor_name"), this.name);
+  }
 
   public FutureExecutor captureContext() {
     io.opentelemetry.context.Context otelContext = Context.current();
@@ -32,31 +48,57 @@ public class FutureExecutor implements Executor {
   public static void setOpenTelemetry(OpenTelemetry openTelemetry) {
     // it's ok to do this more than once, since creation of meters/instruments is idempotent in the
     // OTel SDK.
+    Meter meter = openTelemetry.getMeter("verta.future");
     schedulingDelayHistogram =
-        openTelemetry
-            .getMeter("verta.future")
+        meter
             .histogramBuilder("future_exec_delay")
             .setDescription("The number of microseconds between creating and executing a Future")
             .ofLongs()
             .build();
+
+    activeFutureCounter =
+        meter
+            .upDownCounterBuilder("active_futures")
+            .setDescription("The number of currently active Futures")
+            .build();
   }
 
-  // Wraps an Executor and make it compatible with grpc's context
+  /**
+   * Wraps an Executor and make it compatible with grpc's context
+   *
+   * @deprecated Please use {@link #makeCompatibleExecutor(Executor, String)} to provide better
+   *     metrics.
+   */
+  @Deprecated(forRemoval = true)
   public static FutureExecutor makeCompatibleExecutor(Executor ex) {
-    return new FutureExecutor(ex, null, null);
+    return makeCompatibleExecutor(ex, "unknown");
   }
 
+  /** Wraps an Executor and make it compatible with grpc's context */
+  public static FutureExecutor makeCompatibleExecutor(Executor ex, String name) {
+    return new FutureExecutor(ex, name, null, null);
+  }
+
+  /**
+   * @deprecated Please use {@link #initializeExecutor(Integer, String)} to provide better metrics.
+   */
+  @Deprecated(forRemoval = true)
   public static FutureExecutor initializeExecutor(Integer threadCount) {
+    return initializeExecutor(threadCount, "unknown");
+  }
+
+  public static FutureExecutor initializeExecutor(Integer threadCount, String name) {
     return makeCompatibleExecutor(
         new ForkJoinPool(
             threadCount,
             ForkJoinPool.defaultForkJoinWorkerThreadFactory,
             Thread.getDefaultUncaughtExceptionHandler(),
-            true));
+            true),
+        name);
   }
 
   public static FutureExecutor newSingleThreadExecutor() {
-    return makeCompatibleExecutor(Executors.newSingleThreadExecutor());
+    return makeCompatibleExecutor(Executors.newSingleThreadExecutor(), "unknown");
   }
 
   private Runnable wrapWithTimer(Runnable r) {
@@ -67,15 +109,24 @@ public class FutureExecutor implements Executor {
         if (startTime != null) {
           long endTime = System.nanoTime();
           long microsDelay = (endTime - startTime) / 1_000L;
-          schedulingDelayHistogram.record(microsDelay);
+          schedulingDelayHistogram.record(microsDelay, metricAttributes);
         }
       }
-      r.run();
+      try {
+        r.run();
+      } finally {
+        if (activeFutureCounter != null) {
+          activeFutureCounter.add(-1, metricAttributes);
+        }
+      }
     };
   }
 
   @Override
   public void execute(@NonNull Runnable r) {
+    if (activeFutureCounter != null) {
+      activeFutureCounter.add(1, metricAttributes);
+    }
     r = wrapWithTimer(r);
 
     if (otelContext != null) {
@@ -88,5 +139,9 @@ public class FutureExecutor implements Executor {
     }
 
     delegate.execute(r);
+  }
+
+  public String getName() {
+    return name;
   }
 }

--- a/backend/common/src/test/java/ai/verta/modeldb/common/futures/InternalFutureTest.java
+++ b/backend/common/src/test/java/ai/verta/modeldb/common/futures/InternalFutureTest.java
@@ -168,7 +168,7 @@ class InternalFutureTest {
 
   @Test
   void trace() throws Exception {
-    FutureExecutor executor = FutureExecutor.initializeExecutor(2);
+    FutureExecutor executor = FutureExecutor.initializeExecutor(2, "testing");
 
     Tracer tracer = otelTesting.getOpenTelemetry().getTracer("testTracer");
     Span outside = tracer.spanBuilder("outer").startSpan();
@@ -216,7 +216,7 @@ class InternalFutureTest {
   @Test
   public void context() throws Exception {
     final var rootContext = Context.ROOT;
-    final var executor = FutureExecutor.initializeExecutor(10);
+    final var executor = FutureExecutor.initializeExecutor(10, "testing");
     final Context.Key<String> key = Context.key("key");
     rootContext.call(
         () -> {

--- a/backend/server/src/main/java/ai/verta/modeldb/batchProcess/OwnerRoleBindingRepositoryUtils.java
+++ b/backend/server/src/main/java/ai/verta/modeldb/batchProcess/OwnerRoleBindingRepositoryUtils.java
@@ -38,7 +38,9 @@ public class OwnerRoleBindingRepositoryUtils {
     var config = App.getInstance().mdbConfig;
     if (config.hasAuth()) {
       uac = UAC.fromConfig(config, Optional.empty());
-      var executor = FutureExecutor.initializeExecutor(config.getGrpcServer().getThreadCount());
+      var executor =
+          FutureExecutor.initializeExecutor(
+              config.getGrpcServer().getThreadCount(), "OwnerRoleBindingRepositoryUtils");
       uacApisUtil = new UACApisUtil(executor, uac);
       mdbRoleService = MDBRoleServiceUtils.FromConfig(config, uacApisUtil, uac);
     } else {

--- a/backend/server/src/main/java/ai/verta/modeldb/batchProcess/OwnerRoleBindingUtils.java
+++ b/backend/server/src/main/java/ai/verta/modeldb/batchProcess/OwnerRoleBindingUtils.java
@@ -38,7 +38,9 @@ public class OwnerRoleBindingUtils {
     var config = App.getInstance().mdbConfig;
     if (config.hasAuth()) {
       uac = UAC.fromConfig(config, Optional.empty());
-      var executor = FutureExecutor.initializeExecutor(config.getGrpcServer().getThreadCount());
+      var executor =
+          FutureExecutor.initializeExecutor(
+              config.getGrpcServer().getThreadCount(), "OwnerRoleBindingUtils");
       uacApisUtil = new UACApisUtil(executor, uac);
       mdbRoleService = MDBRoleServiceUtils.FromConfig(config, uacApisUtil, uac);
     } else {

--- a/backend/server/src/main/java/ai/verta/modeldb/configuration/AppConfigBeans.java
+++ b/backend/server/src/main/java/ai/verta/modeldb/configuration/AppConfigBeans.java
@@ -116,7 +116,7 @@ public class AppConfigBeans {
     FutureExecutor.setOpenTelemetry(openTelemetry);
     // Initialize executor so we don't lose context using Futures
     FutureExecutor futureExecutor =
-        FutureExecutor.initializeExecutor(config.getGrpcServer().getThreadCount());
+        FutureExecutor.initializeExecutor(config.getGrpcServer().getThreadCount(), "grpc");
     // assign the executor to all new Future instances.
     Future.setFutureExecutor(futureExecutor);
     // set the OpenTelemetry instance, in case deep future tracing is enabled.

--- a/backend/server/src/main/java/ai/verta/modeldb/utils/CommonHibernateUtil.java
+++ b/backend/server/src/main/java/ai/verta/modeldb/utils/CommonHibernateUtil.java
@@ -62,9 +62,9 @@ public abstract class CommonHibernateUtil extends CommonDBUtil {
 
       final var rdb = config.getRdbConfiguration();
       final var connectionString = RdbConfig.buildDatabaseConnectionString(rdb);
-      final var idleTimeoutMillis = Integer.parseInt(config.getConnectionTimeout()) * 1000;
-      final var connectionTimeoutMillis = 30000;
-      final var connectionMaxLifetimeMillis = idleTimeoutMillis - 5000;
+      final var idleTimeoutMillis = 90_000L;
+      final var connectionTimeoutMillis = config.getConnectionTimeoutMillis();
+      final var connectionMaxLifetimeMillis = 300_000L;
       final var url = RdbConfig.buildDatabaseConnectionString(rdb);
       final var connectionProviderClass = HikariCPConnectionProvider.class.getName();
       final var datasourceClass = getDatasourceClass(rdb);

--- a/backend/server/src/test/java/ai/verta/modeldb/TestsInit.java
+++ b/backend/server/src/test/java/ai/verta/modeldb/TestsInit.java
@@ -104,7 +104,9 @@ public class TestsInit {
     testConfig = TestConfig.getInstance();
     var app = App.getInstance();
     app.mdbConfig = testConfig;
-    handleExecutor = FutureExecutor.initializeExecutor(testConfig.getGrpcServer().getThreadCount());
+    handleExecutor =
+        FutureExecutor.initializeExecutor(
+            testConfig.getGrpcServer().getThreadCount(), "int_testing");
 
     // TODO: FIXME: fix init flow as per spring bean initialization
 


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

2 backports:
1) Tracking in-flight futures with a new metric (`active_futures`)
2) Fixing our connection timeout usages 

Both of these will require backporting to uac and the registry

## Risks and Area of Effect

## Testing
- [x] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

## Reverting
- [ ] Contains Migration - _Do Not Revert_