### PR TITLE
fix: [VRD-620] Fix False Runtime Error on Nested Contexts

### DIFF
--- a/client/verta/tests/unit_tests/test_runtime.py
+++ b/client/verta/tests/unit_tests/test_runtime.py
@@ -77,8 +77,9 @@ def test_logs_are_clean_on_entry():
 
 def test_logs_attribute_removed_on_exit():
     """ Thread local var for logs is removed after exiting the context. """
-    with runtime.context():
+    with runtime.context() as ctx:
         runtime.log('fake_log', 'fake_value')
+        assert ctx.logs()
     assert not hasattr(runtime._THREAD, 'logs')  # outside the context
 
 

--- a/client/verta/tests/unit_tests/test_runtime.py
+++ b/client/verta/tests/unit_tests/test_runtime.py
@@ -49,13 +49,6 @@ def test_thread_safe_context_manager() -> None:
         )
 
 
-def test_init_thread_logs():
-    """
-    An empty dict is initialized by default.
-    """
-    assert runtime._get_thread_logs() == {}
-
-
 def test_set_thread_logs():
     runtime._set_thread_logs({'test_set': 'test_set'})
     assert runtime._THREAD.logs ==  {'test_set': 'test_set'}
@@ -64,13 +57,6 @@ def test_set_thread_logs():
 def test_get_thread_logs():
     runtime._set_thread_logs({'test_get': 'test_get'})
     assert runtime._get_thread_logs() ==  {'test_get': 'test_get'}
-
-
-def test_init_thread_validate():
-    """
-    A boolean defaulting to False is initialized by default.
-    """
-    assert runtime._get_validate_flag() == False
 
 
 def test_set_thread_validate():
@@ -89,15 +75,16 @@ def test_logs_are_clean_on_entry():
         assert ctx.logs() == {}
 
 
-def test_logs_are_clean_on_exit():
-    """ Thread local var for logs is a blank dict after exiting context. """
-    with runtime.context() as ctx:
+def test_logs_attribute_removed_on_exit():
+    """ Thread local var for logs is removed after exiting the context. """
+    with runtime.context():
         runtime.log('fake_log', 'fake_value')
-    assert runtime._get_thread_logs() == {}  # outside the context
+    assert not hasattr(runtime._THREAD, 'logs')  # outside the context
 
 
 def test_final_log_entry_instance_variable():
-    """ The instance of the context manager maintains the final log entry in logs(). """
+    """ The instance of the context manager maintains the final log entry in the
+    logs_dict instance attribute. """
     with runtime.context() as ctx:
         runtime.log('fake_log', 'fake_value')
     assert ctx.logs() == {'fake_log': 'fake_value'}  # outside the context
@@ -116,8 +103,8 @@ def test_validate_flag_false():
         runtime.log('obviously_not_jsonable', unittest.TestCase)
 
 
-def test_validate_reset_on_exit():
-    """ Thread local var for validate is reset to default (False) after exiting context. """
+def test_validate_variable_removed_on_exit():
+    """ Thread local attribute for validate is removed after exiting the context. """
     with runtime.context(validate=True):
         runtime.log('test', {'test_key': 'test_val'})
         assert runtime._get_validate_flag() == True  # inside the context

--- a/client/verta/tests/unit_tests/test_runtime.py
+++ b/client/verta/tests/unit_tests/test_runtime.py
@@ -90,6 +90,14 @@ def test_final_log_entry_instance_variable():
     assert ctx.logs() == {'fake_log': 'fake_value'}  # outside the context
 
 
+def test_empty_dict_returned_when_no_logs_added():
+    """ If no calls are made to runtime.log() within the context, calling for
+    context.logs() returns an empty dict."""
+    with runtime.context() as ctx:
+        pass
+    assert ctx.logs() == {}
+
+
 def test_validate_flag_true():
     """ The validate argument triggers json validation as expected. """
     with runtime.context(validate=True):

--- a/client/verta/verta/runtime.py
+++ b/client/verta/verta/runtime.py
@@ -16,10 +16,8 @@ _S3_REGEX = re.compile("[0-9a-zA-Z_-]+$")
 
 def _get_thread_logs() -> Dict[str, Any]:
     """
-    Return the current thread-local logs or initialize an empty dict.
+    Return the current thread-local logs.
     """
-    if not hasattr(_THREAD, 'logs'):
-        _set_thread_logs(dict())
     return _THREAD.logs
 
 
@@ -43,8 +41,6 @@ def _get_validate_flag() -> bool:
     Return the current thread-local variable for validate or initialize a
     new boolean.
     """
-    if not hasattr(_THREAD, 'validate'):
-        _set_validate_flag(False)
     return _THREAD.validate
 
 
@@ -209,7 +205,7 @@ class context:
     """
     def __init__(self, validate: Optional[bool] = False):
         self._validate = validate
-        self._logs_dict = dict()
+        self._logs_dict = {}
 
     def __enter__(self):
         """

--- a/client/verta/verta/runtime.py
+++ b/client/verta/verta/runtime.py
@@ -18,7 +18,9 @@ def _get_thread_logs() -> Dict[str, Any]:
     """
     Return the 'logs' attribute of the thread-local variable.
     """
-    return _THREAD.logs
+    if hasattr(_THREAD, 'logs'):
+        return _THREAD.logs
+    return {}
 
 
 def _set_thread_logs(logs: Dict[str, Any]) -> Dict[str, Any]:
@@ -40,7 +42,9 @@ def _get_validate_flag() -> bool:
     """
     Return the 'validate' attribute of the thread local variable.
     """
-    return _THREAD.validate
+    if hasattr(_THREAD, 'validate'):
+        return _THREAD.validate
+    return False
 
 
 def _set_validate_flag(flag: bool) -> bool:
@@ -204,7 +208,7 @@ class context:
     """
     def __init__(self, validate: Optional[bool] = False):
         self._validate = validate
-        self._logs_dict = {}
+        self._logs_dict = dict()
 
     def __enter__(self):
         """

--- a/client/verta/verta/runtime.py
+++ b/client/verta/verta/runtime.py
@@ -38,8 +38,7 @@ def _delete_thread_logs() -> None:
 
 def _get_validate_flag() -> bool:
     """
-    Return the current thread-local variable for validate or initialize a
-    new boolean.
+    Return the current thread-local variable for validate.
     """
     return _THREAD.validate
 

--- a/client/verta/verta/runtime.py
+++ b/client/verta/verta/runtime.py
@@ -16,7 +16,7 @@ _S3_REGEX = re.compile("[0-9a-zA-Z_-]+$")
 
 def _get_thread_logs() -> Dict[str, Any]:
     """
-    Return the current thread-local logs.
+    Return the 'logs' attribute of the thread-local variable.
     """
     return _THREAD.logs
 
@@ -38,7 +38,7 @@ def _delete_thread_logs() -> None:
 
 def _get_validate_flag() -> bool:
     """
-    Return the current thread-local variable for validate.
+    Return the 'validate' attribute of the thread local variable.
     """
     return _THREAD.validate
 


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context
Calling predict rapidly within a loop (as in many of our example notebooks) can cause a RuntimeError related to the `runtime.context()` class.  This minor refactor fixes that problem.

## Risks and Area of Effect
This is fairly low risk, and it fixes a bug currently in `main`. 

## Testing
- [X] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

## Reverting
- [ ] Contains Migration - _Do Not Revert_