### PR TITLE
chore: Restore get_personal_workspace()

### DIFF
--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -339,6 +339,14 @@ class Connection(object):
             return self.get_personal_workspace()
 
     def get_personal_workspace(self):
+        """
+        Return username, for use as one's personal workspace in permission v1.
+
+        This has been irrelevant for normal users since 2021, but is still
+        necessary for bootstrapped internal accounts in permission v1 as they
+        are not assigned a ``default_workspace_id`` on creation (VUMM-872).
+
+        """
         email = self.auth.get("Grpc-Metadata-email")
         if email is not None:
             msg = UACService_pb2.GetUser(email=email)


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

This internal method was removed in https://github.com/VertaAI/modeldb/pull/3404, but unfortunately is still necessary for our integration tests against permission v1.

## Risks and Area of Effect

Low; I've added a warning so that this fallback doesn't just silently mask legitimate issues with `default_workspace_id`.

## Testing
- [ ] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

https://jenkins.dev.verta.ai/job/test/job/python-models/job/python-models-3.7/547/console using mainline client fails quite catastrophically with

```
RuntimeError: default workspace is not set
```

https://jenkins.dev.verta.ai/job/test/job/python-models/job/python-models-3.7/548/console using this PR's branch actually starts passing.

## Reverting
- [ ] Contains Migration - _Do Not Revert_

Revert this PR.