### PR TITLE
docs: Update DeployedModel._predict() docstring

### DIFF
--- a/client/verta/verta/deployment/_deployedmodel.py
+++ b/client/verta/verta/deployment/_deployedmodel.py
@@ -115,8 +115,7 @@ class DeployedModel(object):
             compress: bool=False,
             prediction_id: Optional[str]=None,
             ):
-        """This is like ``DeployedModel.predict()``, but returns the raw ``Response``
-         for debugging."""
+        """Make prediction, handling compression and error propagation."""
         request_headers = dict()
         if prediction_id:
             request_headers.update({'verta-request-id': prediction_id})


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

This used to simply return a `requests.Response` object, but #3332 moved our error propagation logic here.

Personally, I think this is fine as I haven't needed to debug predictions using the `Response` object from `_predict()` in years.

## Risks and Area of Effect

—

## Testing
- [ ] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

—

## Reverting
- [ ] Contains Migration - _Do Not Revert_

Revert this PR.