### PR TITLE
fix: [VUMM-877] Make sure a failed migration results in the VM exiting

### DIFF
--- a/backend/common/src/main/java/ai/verta/modeldb/common/CommonDBUtil.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/CommonDBUtil.java
@@ -77,7 +77,7 @@ public abstract class CommonDBUtil {
   protected static boolean checkDBConnection(RdbConfig rdb, Integer timeout) {
     LOGGER.info("Checking DB connection with timeout [" + timeout + "]...");
     try (var con = getDBConnection(rdb)) {
-      LOGGER.info("Got connection: " + con);
+      LOGGER.debug("Got connection: " + con);
       boolean valid = con.isValid(timeout);
       LOGGER.info("DB Connection valid? " + valid);
       return valid;

--- a/backend/common/src/main/java/ai/verta/modeldb/common/CommonDBUtil.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/CommonDBUtil.java
@@ -75,8 +75,12 @@ public abstract class CommonDBUtil {
   }
 
   protected static boolean checkDBConnection(RdbConfig rdb, Integer timeout) {
+    LOGGER.info("Checking DB connection with timeout [" + timeout + "]...");
     try (var con = getDBConnection(rdb)) {
-      return con.isValid(timeout);
+      LOGGER.info("Got connection: " + con);
+      boolean valid = con.isValid(timeout);
+      LOGGER.info("DB Connection valid? " + valid);
+      return valid;
     } catch (Exception ex) {
       LOGGER.error("JdbiUtil checkDBConnection() got error ", ex);
       return false;
@@ -476,7 +480,7 @@ public abstract class CommonDBUtil {
   public static void createDBIfNotExists(RdbConfig rdbConfiguration) throws SQLException {
     final var databaseName = RdbConfig.buildDatabaseName(rdbConfiguration);
     final var dbUrl = RdbConfig.buildDatabaseServerConnectionString(rdbConfiguration);
-    LOGGER.debug("Connecting to DB URL " + dbUrl);
+    LOGGER.info("Connecting to DB URL " + dbUrl);
     Connection connection =
         DriverManager.getConnection(
             dbUrl, rdbConfiguration.getRdbUsername(), rdbConfiguration.getRdbPassword());

--- a/backend/common/src/main/java/ai/verta/modeldb/common/CommonUtils.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/CommonUtils.java
@@ -8,6 +8,7 @@ import ai.verta.modeldb.common.futures.Handle;
 import ai.verta.modeldb.common.query.OrderColumn;
 import ai.verta.modeldb.common.query.QueryFilterContext;
 import com.amazonaws.AmazonServiceException;
+import com.amazonaws.endpointdiscovery.DaemonThreadFactory;
 import com.google.protobuf.GeneratedMessageV3;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
@@ -76,7 +77,12 @@ public class CommonUtils {
 
   public static void scheduleTask(
       Runnable task, long initialDelay, long frequency, TimeUnit timeUnit) {
-    ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+    ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(r -> {
+      Thread t = new Thread(r);
+      t.setName(task.getClass().getSimpleName());
+      t.setDaemon(true);
+      return t;
+    });
     executor.scheduleAtFixedRate(task, initialDelay, frequency, timeUnit);
   }
 

--- a/backend/common/src/main/java/ai/verta/modeldb/common/CommonUtils.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/CommonUtils.java
@@ -8,7 +8,6 @@ import ai.verta.modeldb.common.futures.Handle;
 import ai.verta.modeldb.common.query.OrderColumn;
 import ai.verta.modeldb.common.query.QueryFilterContext;
 import com.amazonaws.AmazonServiceException;
-import com.amazonaws.endpointdiscovery.DaemonThreadFactory;
 import com.google.protobuf.GeneratedMessageV3;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
@@ -77,12 +76,14 @@ public class CommonUtils {
 
   public static void scheduleTask(
       Runnable task, long initialDelay, long frequency, TimeUnit timeUnit) {
-    ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(r -> {
-      Thread t = new Thread(r);
-      t.setName(task.getClass().getSimpleName());
-      t.setDaemon(true);
-      return t;
-    });
+    ScheduledExecutorService executor =
+        Executors.newSingleThreadScheduledExecutor(
+            r -> {
+              Thread t = new Thread(r);
+              t.setName(task.getClass().getSimpleName());
+              t.setDaemon(true);
+              return t;
+            });
     executor.scheduleAtFixedRate(task, initialDelay, frequency, timeUnit);
   }
 

--- a/backend/common/src/main/java/ai/verta/modeldb/common/config/DatabaseConfig.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/config/DatabaseConfig.java
@@ -22,7 +22,7 @@ public class DatabaseConfig {
   @JsonProperty private String maxConnectionPoolSize = "20";
   @JsonProperty private int threadCount = 8;
   @JsonProperty private String connectionTimeout = "5000"; // note: milliseconds
-  @JsonProperty private Long leakDetectionThresholdMs = 3000L;
+  @JsonProperty private Long leakDetectionThresholdMs = 10000L;
 
   @JsonProperty private RdbConfig RdbConfiguration;
 

--- a/backend/server/src/main/java/ai/verta/modeldb/configuration/AppConfigBeans.java
+++ b/backend/server/src/main/java/ai/verta/modeldb/configuration/AppConfigBeans.java
@@ -15,6 +15,7 @@ import ai.verta.modeldb.common.configuration.AppContext;
 import ai.verta.modeldb.common.configuration.EnabledMigration;
 import ai.verta.modeldb.common.configuration.RunLiquibaseSeparately;
 import ai.verta.modeldb.common.configuration.RunLiquibaseSeparately.RunLiquibaseWithMainService;
+import ai.verta.modeldb.common.configuration.ServerEnabled;
 import ai.verta.modeldb.common.connections.UAC;
 import ai.verta.modeldb.common.db.JdbiUtils;
 import ai.verta.modeldb.common.exceptions.ExceptionInterceptor;
@@ -181,6 +182,7 @@ public class AppConfigBeans {
   }
 
   @Bean
+  @Conditional(ServerEnabled.class)
   public ServerBuilder<?> serverBuilder(
       MDBConfig config,
       Executor grpcExecutor,
@@ -224,7 +226,8 @@ public class AppConfigBeans {
   }
 
   @Bean
-  public CommandLineRunner commandLineRunner(
+  @Conditional(ServerEnabled.class)
+  public CommandLineRunner serverCommandLineRunner(
       ServerBuilder<?> serverBuilder,
       HealthStatusManager healthStatusManager,
       MDBConfig config,
@@ -264,7 +267,7 @@ public class AppConfigBeans {
 
   @Bean
   @Conditional({RunLiquibaseSeparately.class})
-  public CommandLineRunner commandLineRunner() {
+  public CommandLineRunner migrationCommandLineRunner() {
     return args -> {
       LOGGER.trace("Liquibase run separate: done");
       LOGGER.info("System exiting");
@@ -331,7 +334,5 @@ public class AppConfigBeans {
     }
 
     appContext.initiateShutdown(0);
-
-    CommonUtils.cleanUpPIDFile();
   }
 }

--- a/backend/server/src/main/java/ai/verta/modeldb/configuration/CronJobUtils.java
+++ b/backend/server/src/main/java/ai/verta/modeldb/configuration/CronJobUtils.java
@@ -5,6 +5,7 @@ import ai.verta.modeldb.ServiceSet;
 import ai.verta.modeldb.common.CommonUtils;
 import ai.verta.modeldb.common.artifactStore.ArtifactStoreDAODisabled;
 import ai.verta.modeldb.common.config.CronJobConfig;
+import ai.verta.modeldb.common.configuration.ServerEnabled;
 import ai.verta.modeldb.config.MDBConfig;
 import ai.verta.modeldb.cron_jobs.CleanUpEntitiesCron;
 import ai.verta.modeldb.cron_jobs.DeleteEntitiesCron;
@@ -16,6 +17,7 @@ import lombok.NoArgsConstructor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 
 @NoArgsConstructor
@@ -24,6 +26,7 @@ public class CronJobUtils {
   private static final Logger LOGGER = LogManager.getLogger(CronJobUtils.class);
 
   @Bean
+  @Conditional(ServerEnabled.class)
   public CronJobUtils initializeCronJobs(MDBConfig mdbConfig, ServiceSet services) {
     LOGGER.info("Enter in CronJobUtils: initializeBasedOnConfig()");
     if (mdbConfig.getCron_job() != null) {

--- a/backend/server/src/main/java/ai/verta/modeldb/utils/CommonHibernateUtil.java
+++ b/backend/server/src/main/java/ai/verta/modeldb/utils/CommonHibernateUtil.java
@@ -97,7 +97,7 @@ public abstract class CommonHibernateUtil extends CommonDBUtil {
                   String.valueOf(20))
               .setProperty(
                   "hibernate.hikari.leakDetectionThreshold",
-                  String.valueOf(config.getLiquibaseLockThreshold()));
+                  String.valueOf(config.getLeakDetectionThresholdMs()));
 
       LOGGER.trace("connectionString {}", connectionString);
       // Create registry builder
@@ -109,7 +109,7 @@ public abstract class CommonHibernateUtil extends CommonDBUtil {
         metaDataSrc.addAnnotatedClass(entity);
       }
 
-      // Check DB is up or not
+      LOGGER.info("Checking DB Connection");
       boolean dbConnectionStatus = checkDBConnection(rdb, config.getTimeout());
       if (!dbConnectionStatus) {
         checkDBConnectionInLoop(config, true);


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context
We were seeing cases where the Migration work was failing, because the database server was not initialized yet. In those cases, the migration container would not exit properly due to non-daemon threads being started for "cronjob" type tasks in the application.

In addition to fixing the underlying issue, this PR also adds logging to the database connection initialization to make it easier to debug when things are going wrong.

## Risks and Area of Effect

## Testing
- [x] Unit test
- [x] Deployed to dev env
- [ ] Other (explain) 

## Reverting
- [ ] Contains Migration - _Do Not Revert_