### PR TITLE
docs: [VRD-689] Add model_test() to VertaModelBase

### DIFF
--- a/client/verta/verta/registry/_verta_model_base.py
+++ b/client/verta/verta/registry/_verta_model_base.py
@@ -143,7 +143,7 @@ class VertaModelBase(object):
                         [72.84132724180968, 0.0, 0.0, 40.0, 0.0, 0.0, 0.0, 0.0, 1.0],
                     ]
 
-                def test(self):
+                def model_test(self):
                     input = self.example()
                     expected_output = [0, 1, 0]
                     expected_logs = {"num_rows": len(input)}

--- a/client/verta/verta/registry/_verta_model_base.py
+++ b/client/verta/verta/registry/_verta_model_base.py
@@ -93,7 +93,7 @@ class VertaModelBase(object):
         """
         raise NotImplementedError
 
-    def test(self):
+    def model_test(self):
         """Test a model's behavior for correctness.
 
         :meth:`test` does nothing by default. Implement this method—with any

--- a/client/verta/verta/registry/_verta_model_base.py
+++ b/client/verta/verta/registry/_verta_model_base.py
@@ -99,10 +99,8 @@ class VertaModelBase(object):
         :meth:`model_test` does nothing by default. Implement this method—with
         any assertions you wish—to validate your model.
 
-        This method is called
+        This method is automatically called
 
-        - in :func:`verta.registry.test_model_build`
-        - when a self-contained model build is completed in the Verta platform
         - when an endpoint is initializing in the Verta platform
 
         .. note::

--- a/client/verta/verta/registry/_verta_model_base.py
+++ b/client/verta/verta/registry/_verta_model_base.py
@@ -102,7 +102,7 @@ class VertaModelBase(object):
         This method is called
 
         - in :func:`verta.registry.test_model_build`
-        - when a model build is completed in the Verta platform
+        - when a self-contained model build is completed in the Verta platform
         - when an endpoint is initializing in the Verta platform
 
         .. note::

--- a/client/verta/verta/registry/_verta_model_base.py
+++ b/client/verta/verta/registry/_verta_model_base.py
@@ -109,8 +109,8 @@ class VertaModelBase(object):
 
             If using model data logging (e.g. :func:`verta.runtime.log`), any
             calls here to the model's :meth:`predict` method must be wrapped
-            in a :class:`verta.runtime.context`. This incidentally also
-            enables assertions for expected logs.
+            in a :class:`verta.runtime.context`. This also allows testing of
+            expected logs.
 
         Returns
         -------

--- a/client/verta/verta/registry/_verta_model_base.py
+++ b/client/verta/verta/registry/_verta_model_base.py
@@ -92,3 +92,35 @@ class VertaModelBase(object):
 
         """
         raise NotImplementedError
+
+    def test(self):
+        """Test a model's behavior for correctness.
+
+        :meth:`test` does nothing by default. Implement this method—with any
+        assertions you wish—to validate your model.
+
+        This method is called
+
+        - in :func:`verta.registry.test_model_build`
+        - when a model build is completed in the Verta platform
+        - when an endpoint is initializing in the Verta platform
+
+        .. note::
+
+            If using model data logging (e.g. :func:`verta.runtime.log`), any
+            calls here to the model's :meth:`predict` method must be wrapped
+            in a :class:`verta.runtime.context`. This incidentally also
+            enables assertions for expected logs.
+
+        Returns
+        -------
+        None
+            Returned values will be unused and discarded.
+
+        Raises
+        ------
+        Any
+            Raised exceptions will be propagated.
+
+        """
+        pass

--- a/client/verta/verta/registry/_verta_model_base.py
+++ b/client/verta/verta/registry/_verta_model_base.py
@@ -122,5 +122,45 @@ class VertaModelBase(object):
         Any
             Raised exceptions will be propagated.
 
+        Examples
+        --------
+        .. code-block:: python
+
+            class MyModel(VertaModelBase):
+                def __init__(self, artifacts):
+                    with open(artifacts["sklearn_logreg"], "rb") as f:
+                        self.logreg = pickle.load(f)
+
+                @verify_io
+                def predict(self, input):
+                    verta.runtime.log("num_rows", len(input))
+                    return self.logreg.predict(input).tolist()
+
+                def example(self):
+                    return [
+                        [71.67822567370767, 0.0, 0.0, 99.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+                        [6.901547652701675, 0.0, 1887.0, 50.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+                        [72.84132724180968, 0.0, 0.0, 40.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+                    ]
+
+                def test(self):
+                    input = self.example()
+                    expected_output = [0, 1, 0]
+                    expected_logs = {"num_rows": len(input)}
+
+                    with verta.runtime.context() as ctx:
+                        output = self.predict(input)
+                    logs = ctx.logs()
+
+                    if logs != expected_logs:
+                        raise ValueError(
+                            f"expected logs {expected_logs}, got {logs}",
+                        )
+
+                    if output != expected_output:
+                        raise ValueError(
+                            f"expected output {expected_output}, got {output}",
+                        )
+
         """
         pass

--- a/client/verta/verta/registry/_verta_model_base.py
+++ b/client/verta/verta/registry/_verta_model_base.py
@@ -96,8 +96,8 @@ class VertaModelBase(object):
     def model_test(self):
         """Test a model's behavior for correctness.
 
-        :meth:`test` does nothing by default. Implement this method—with any
-        assertions you wish—to validate your model.
+        :meth:`model_test` does nothing by default. Implement this method—with
+        any assertions you wish—to validate your model.
 
         This method is called
 


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

Document new `model_test()` method support.

## Risks and Area of Effect

—

## Testing
- [x] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

See https://github.com/VertaAI/modeldb/pull/3611 for unit tests, and https://github.com/VertaAI/e2e-testing/pull/112 for integration tests.

Here is the rendered docstring:

![Screen Shot 2023-02-27 at 11 15 40 AM](https://user-images.githubusercontent.com/96442646/221660873-e3f01e17-9ff4-484b-b49f-fbbf3efba977.png)

## Reverting
- [ ] Contains Migration - _Do Not Revert_

Revert this PR.