### PR TITLE
test: [VRD-680] add test class for model dependency validation.

### DIFF
--- a/client/verta/tests/registry/conftest.py
+++ b/client/verta/tests/registry/conftest.py
@@ -1,8 +1,28 @@
 # -*- coding: utf-8 -*-
 
-import pytest
+import calendar
+import collections as collecs
+import datetime as dt
+import json
+from typing import Type, Union
 
-from verta.registry import DockerImage
+import boto3
+import click
+import cloudpickle as cp
+import numpy
+import pandas as pd
+import pytest
+import requests
+import sklearn
+import spacy
+import torch
+import urllib3
+import yaml
+from google.protobuf import message as msg
+from PIL import UnidentifiedImageError
+
+from verta import runtime
+from verta.registry import DockerImage, verify_io, VertaModelBase
 
 
 @pytest.fixture(scope="session")
@@ -15,3 +35,69 @@ def docker_image():
         tag="example",
         env_vars={"CUDA_VISIBLE_DEVICES": "0,1"},
     )
+
+
+class DependencyTestingModel(VertaModelBase):
+    """
+    Model class that imports and calls external dependencies in a variety of ways
+    for the purpose of testing our model environment validation logic.
+    """
+    def __init__(self, artifacts):
+        pass
+
+    # Note that wrapping in verify_io may have an impact on how modules are
+    # extracted, thus we explicitly test the same scenarios with and without.
+    @verify_io
+    def predict(
+            self,
+            w: calendar.Calendar,            # standard library in function arg
+            x: dt.datetime,                  # standard library in function arg via alias
+            y: numpy.ndarray,                # 3rd-party module in function arg
+            z: msg.Message,                  # 3rd-party module in function arg via alias
+    ) -> pd.DataFrame:                       # 3rd-party module in return type hint
+        hour = x.hour                        # standard library usage in function body
+        runtime.log('error', 'Error')        # 3rd-party module in function body (VERTA)
+        yaml_con = yaml.constructor          # 3rd party module in function body
+        spacy_error: spacy.Errors = self.make_spacy_error()
+                                             # 3rd-party module in function body as type hint
+        z = self.make_dataframe(y)           # 3rd party module called indirectly
+        return z
+
+
+    def unwrapped_predict(
+            self,
+            a: json.JSONEncoder,             # standard library in function arg
+            b: collecs.OrderedDict,          # standard library in function arg via alias
+            c: sklearn.base.BaseEstimator,   # 3rd-party module in function arg
+            d: cp.CellType,                  # 3rd-party module in function arg via alias
+    ) -> requests.Timeout:                   # 3rd-party module in return type hint
+        _json = a.encode({'x':'y'})          # standard library usage in function body
+        with runtime.context():              # 3rd-party module in function body (VERTA)
+            runtime.log('error', 'Error')    # 3rd-party module in function body (VERTA)
+        click_exc = click.ClickException     # 3rd party module in function body
+        boto_sesh: boto3.Session = self.make_boto_session()
+                                             # 3rd-party module in function body as type hint
+        z = self.make_timeout()              # 3rd party module called indirectly
+        return z
+
+    def make_dataframe(self, input):         # No modules in function signature
+        return pd.DataFrame(input)           # 3rd party module in function body
+
+    def make_timeout(self):                  # No modules in function signature
+        return requests.Timeout()            # 3rd party module in function body
+
+    def make_spacy_error(self):              # No modules in function signature
+        return spacy.Errors                  # 3rd party module in function body
+
+    @staticmethod
+    def make_boto_session():                 # No modules in function signature
+        return boto3.DEFAULT_SESSION         # 3rd-party module in function body
+
+    # 3rd-party modules nested inside type constructs should still be extracted
+    def nested_mulitple_returns_hint(self) -> Union[urllib3.Retry, UnidentifiedImageError]:
+        return urllib3.Retry or UnidentifiedImageError
+
+    # 3rd-party modules nested inside type constructs should still be extracted
+    @property
+    def nested_type_hint(self) -> Type[torch.NoneType]:
+        return torch.NoneType

--- a/client/verta/tests/registry/conftest.py
+++ b/client/verta/tests/registry/conftest.py
@@ -6,20 +6,13 @@ import datetime as dt
 import json
 from typing import Type, Union
 
-import boto3
 import click
 import cloudpickle as cp
-import numpy
-import pandas as pd
 import pytest
 import requests
-import sklearn
-import spacy
-import torch
 import urllib3
 import yaml
 from google.protobuf import message as msg
-from PIL import UnidentifiedImageError
 
 from verta import runtime
 from verta.registry import DockerImage, verify_io, VertaModelBase
@@ -37,67 +30,80 @@ def docker_image():
     )
 
 
-class DependencyTestingModel(VertaModelBase):
-    """
-    Model class that imports and calls external dependencies in a variety of ways
-    for the purpose of testing our model environment validation logic.
-    """
-    def __init__(self, artifacts):
-        pass
+@pytest.fixture(scope="session")
+def dependency_testing_model() -> Type[VertaModelBase]:
+    """Returns a model class that imports and calls external dependencies."""
+    boto3 = pytest.importorskip("boto3")
+    numpy = pytest.importorskip("numpy")
+    spacy = pytest.importorskip("spacy")
+    pd =pytest.importorskip("pandas")
+    sklearn = pytest.importorskip("sklearn")
+    torch = pytest.importorskip("torch")
+    PIL = pytest.importorskip("PIL")
 
-    # Note that wrapping in verify_io may have an impact on how modules are
-    # extracted, thus we explicitly test the same scenarios with and without.
-    @verify_io
-    def predict(
-            self,
-            w: calendar.Calendar,            # standard library in function arg
-            x: dt.datetime,                  # standard library in function arg via alias
-            y: numpy.ndarray,                # 3rd-party module in function arg
-            z: msg.Message,                  # 3rd-party module in function arg via alias
-    ) -> pd.DataFrame:                       # 3rd-party module in return type hint
-        hour = x.hour                        # standard library usage in function body
-        runtime.log('error', 'Error')        # 3rd-party module in function body (VERTA)
-        yaml_con = yaml.constructor          # 3rd party module in function body
-        spacy_error: spacy.Errors = self.make_spacy_error()
-                                             # 3rd-party module in function body as type hint
-        z = self.make_dataframe(y)           # 3rd party module called indirectly
-        return z
+    class DependencyTestingModel(VertaModelBase):
+        """
+        Model class that imports and calls external dependencies in a variety of ways
+        for the purpose of testing our model environment validation logic.
+        """
+        def __init__(self, artifacts):
+            pass
+
+        # Note that wrapping in verify_io may have an impact on how modules are
+        # extracted, thus we explicitly test the same scenarios with and without.
+        @verify_io
+        def predict(
+                self,
+                w: calendar.Calendar,            # standard library in function arg
+                x: dt.datetime,                  # standard library in function arg via alias
+                y: numpy.ndarray,                # 3rd-party module in function arg
+                z: msg.Message,                  # 3rd-party module in function arg via alias
+        ) -> pd.DataFrame:                       # 3rd-party module in return type hint
+            hour = x.hour                        # standard library usage in function body
+            runtime.log('error', 'Error')        # 3rd-party module in function body (VERTA)
+            yaml_con = yaml.constructor          # 3rd party module in function body
+            spacy_error: spacy.Errors = self.make_spacy_error()
+                                                 # 3rd-party module in function body as type hint
+            z = self.make_dataframe(y)           # 3rd party module called indirectly
+            return z
 
 
-    def unwrapped_predict(
-            self,
-            a: json.JSONEncoder,             # standard library in function arg
-            b: collecs.OrderedDict,          # standard library in function arg via alias
-            c: sklearn.base.BaseEstimator,   # 3rd-party module in function arg
-            d: cp.CellType,                  # 3rd-party module in function arg via alias
-    ) -> requests.Timeout:                   # 3rd-party module in return type hint
-        _json = a.encode({'x':'y'})          # standard library usage in function body
-        with runtime.context():              # 3rd-party module in function body (VERTA)
-            runtime.log('error', 'Error')    # 3rd-party module in function body (VERTA)
-        click_exc = click.ClickException     # 3rd party module in function body
-        boto_sesh: boto3.Session = self.make_boto_session()
-                                             # 3rd-party module in function body as type hint
-        z = self.make_timeout()              # 3rd party module called indirectly
-        return z
+        def unwrapped_predict(
+                self,
+                a: json.JSONEncoder,             # standard library in function arg
+                b: collecs.OrderedDict,          # standard library in function arg via alias
+                c: sklearn.base.BaseEstimator,   # 3rd-party module in function arg
+                d: cp.CellType,                  # 3rd-party module in function arg via alias
+        ) -> requests.Timeout:                   # 3rd-party module in return type hint
+            _json = a.encode({'x':'y'})          # standard library usage in function body
+            with runtime.context():              # 3rd-party module in function body (VERTA)
+                runtime.log('error', 'Error')    # 3rd-party module in function body (VERTA)
+            click_exc = click.ClickException     # 3rd party module in function body
+            boto_sesh: boto3.Session = self.make_boto_session()
+                                                 # 3rd-party module in function body as type hint
+            z = self.make_timeout()              # 3rd party module called indirectly
+            return z
 
-    def make_dataframe(self, input):         # No modules in function signature
-        return pd.DataFrame(input)           # 3rd party module in function body
+        def make_dataframe(self, input):         # No modules in function signature
+            return pd.DataFrame(input)           # 3rd party module in function body
 
-    def make_timeout(self):                  # No modules in function signature
-        return requests.Timeout()            # 3rd party module in function body
+        def make_timeout(self):                  # No modules in function signature
+            return requests.Timeout()            # 3rd party module in function body
 
-    def make_spacy_error(self):              # No modules in function signature
-        return spacy.Errors                  # 3rd party module in function body
+        def make_spacy_error(self):              # No modules in function signature
+            return spacy.Errors                  # 3rd party module in function body
 
-    @staticmethod
-    def make_boto_session():                 # No modules in function signature
-        return boto3.DEFAULT_SESSION         # 3rd-party module in function body
+        @staticmethod
+        def make_boto_session():                 # No modules in function signature
+            return boto3.DEFAULT_SESSION         # 3rd-party module in function body
 
-    # 3rd-party modules nested inside type constructs should still be extracted
-    def nested_mulitple_returns_hint(self) -> Union[urllib3.Retry, UnidentifiedImageError]:
-        return urllib3.Retry or UnidentifiedImageError
+        # 3rd-party modules nested inside type constructs should still be extracted
+        def nested_mulitple_returns_hint(self) -> Union[urllib3.Retry, PIL.UnidentifiedImageError]:
+            return urllib3.Retry or PIL.UnidentifiedImageError
 
-    # 3rd-party modules nested inside type constructs should still be extracted
-    @property
-    def nested_type_hint(self) -> Type[torch.NoneType]:
-        return torch.NoneType
+        # 3rd-party modules nested inside type constructs should still be extracted
+        @property
+        def nested_type_hint(self) -> Type[torch.NoneType]:
+            return torch.NoneType
+
+    return DependencyTestingModel


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context
Adds a new test class for use in model env/dependency validation.  The idea is to import a bunch of 3rd party dependencies and use them in a variety of ways within the class and this will give us a resource we can use to test the forthcoming logic to extract dependencies from model classes written by customers.

This class attempts to cover the following ways in which dependencies _could_ be introduced:
* Direct usage of a module within the body of a function
* Type hints in function arguments
* Type hints in return type annotation
* Type hints for function-scoped variables
* All of the above wrapped in `verify_io` and not wrapped in `@verify_io`
* Class functions that are wrapped as `@staticmethod` and `@propery`
* Type hints that are nested within type constructs like `Type[things.Thingy]` or `Union[things.Thingy, stuff.Whatever]`

_All dependencies used were pulled from existing client dependencies, and this PR does not introduce net new ones._

## Risks and Area of Effect
Very low.  This only introduces a new test class and it doesn't actually use it.  Subsequent PRs will add the tooling and tests.

## Testing
- [ ] Unit test
- [ ] Deployed to dev env
- [X] Other (explain) - This IS a testing component.

## Reverting
- [ ] Contains Migration - _Do Not Revert_