### PR TITLE
fix: make the S3Client reference swap thread-safe

### DIFF
--- a/backend/common/src/main/java/ai/verta/modeldb/common/artifactStore/storageservice/s3/RefreshS3ClientCron.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/artifactStore/storageservice/s3/RefreshS3ClientCron.java
@@ -36,7 +36,7 @@ public class RefreshS3ClientCron implements Runnable {
   /** The action to be performed by this timer task. */
   @Override
   public void run() {
-    LOGGER.debug("Refreshing S3Client cron wakeup");
+    LOGGER.info("Refreshing S3Client");
     try {
       var awsCredentials = getBasicSessionCredentials();
       createAndRefreshNewClient(awsCredentials);
@@ -44,7 +44,7 @@ public class RefreshS3ClientCron implements Runnable {
       LOGGER.error("Failed to refresh S3 Client: " + ex.getMessage(), ex);
       throw new RuntimeException(ex);
     }
-    LOGGER.debug("Refreshing S3Client finish tasks and reschedule");
+    LOGGER.info("Refreshing S3Client complete");
   }
 
   private void createAndRefreshNewClient(BasicSessionCredentials awsCredentials) {

--- a/backend/common/src/main/java/ai/verta/modeldb/common/artifactStore/storageservice/s3/S3Client.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/artifactStore/storageservice/s3/S3Client.java
@@ -56,7 +56,7 @@ public class S3Client {
       initializeWithWebIdentity(awsRegion);
     } else {
       LOGGER.debug("environment credentials based s3 client");
-      // reads credential from OS Environment
+      // reads credentials from OS Environment
       initializeWithEnvironment(awsRegion);
     }
   }

--- a/backend/common/src/main/java/ai/verta/modeldb/common/artifactStore/storageservice/s3/S3Client.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/artifactStore/storageservice/s3/S3Client.java
@@ -28,9 +28,9 @@ public class S3Client {
 
   private final String bucketName;
 
-  private AmazonS3 s3Client;
-  private AtomicInteger referenceCounter;
-  private AWSCredentials awsCredentials;
+  private volatile AmazonS3 s3Client;
+  private volatile AtomicInteger referenceCounter;
+  private volatile AWSCredentials awsCredentials;
 
   public S3Client(S3Config s3Config) throws IOException, ModelDBException {
     String cloudAccessKey = s3Config.getCloudAccessKey();
@@ -126,8 +126,7 @@ public class S3Client {
       this.s3Client = s3Client;
       LOGGER.debug("S3 Client replaced");
       // At the end of the try, the reference counter will be decremented again and shutdown will
-      // be
-      // called
+      // be called
     }
   }
 }


### PR DESCRIPTION
And add some logging around the periodic refresh job.

<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

## Risks and Area of Effect

## Testing
- [x] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

## Reverting
- [ ] Contains Migration - _Do Not Revert_