### PR TITLE
fix: [VUMM-629] Update client's XGBoost callback (and test_integrations.py::TestXGBoost::test_callback)

### DIFF
--- a/client/verta/tests/test_integrations.py
+++ b/client/verta/tests/test_integrations.py
@@ -359,10 +359,9 @@ class TestTensorFlow:
 
 
 class TestXGBoost:
-    @pytest.mark.skip(reason="need to update the callback for xgboost>=1.6 (VUMM-629)")
     def test_callback(self, experiment_run):
         verta_integrations_xgboost = pytest.importorskip("verta.integrations.xgboost")
-        verta_callback = verta_integrations_xgboost.verta_callback
+        verta_callback = verta_integrations_xgboost.VertaCallback
 
         xgb = pytest.importorskip("xgboost")
         np = pytest.importorskip("numpy")

--- a/client/verta/verta/integrations/xgboost/__init__.py
+++ b/client/verta/verta/integrations/xgboost/__init__.py
@@ -8,7 +8,7 @@ import xgboost as xgb  # pylint: disable=import-error
 from ..._internal_utils import _utils
 
 
-def verta_callback(run):
+class VertaCallback(xgb.callback.TrainingCallback):
     """
     XGBoost callback that automates logging to Verta during booster training.
 
@@ -39,13 +39,14 @@ def verta_callback(run):
         )
 
     """
+    def __init__(self, run):
+        self.run = run
 
-    def callback(env):
-        for metric, val in env.evaluation_result_list:
-            try:
-                run.log_observation(metric, val)
-            except:
-                pass  # don't halt execution
+    def after_iteration(self, model, epoch, evals_log):
+        for data, metric in evals_log.items():
+            for metric_name, log in metric.items():
+                try:
+                    self.run.log_observation(f"{data}-{metric_name}", log[-1])  # don't halt execution
+                except:
+                    pass
         # TODO: support `xgb.cv()`, which gives `(metric, val, std_dev)` across folds
-
-    return callback

--- a/client/verta/verta/integrations/xgboost/__init__.py
+++ b/client/verta/verta/integrations/xgboost/__init__.py
@@ -12,7 +12,7 @@ class VertaCallback(xgb.callback.TrainingCallback):
     """
     XGBoost callback that automates logging to Verta during booster training.
 
-    This callback logs ``eval_metric``\ s passed into ``xgb.train()``.
+    This callback logs ``eval_metrics``\ s passed into ``xgb.train()``.
 
     See our `GitHub repository
     <https://github.com/VertaAI/examples/blob/main/experiment-management/xgboost/xgboost-integration.ipynb>`__
@@ -29,13 +29,13 @@ class VertaCallback(xgb.callback.TrainingCallback):
     --------
     .. code-block:: python
 
-        from verta.integrations.xgboost import verta_callback
+        from verta.integrations.xgboost import VertaCallback
         run = client.set_experiment_run()
         run.log_hyperparameters(params)
         bst = xgb.train(
             params, dtrain,
             evals=[(dtrain, "train")],
-            callbacks=[verta_callback(run)],
+            callbacks=[VertaCallback(run)],
         )
 
     """


### PR DESCRIPTION


<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

(https://verta.readthedocs.io/en/main/_autogen/verta.integrations.xgboost.verta_callback.html#verta.integrations.xgboost.verta_callback)

```
bst = xgb.train(
            params, dtrain,
            num_boost_round=num_rounds,
            evals=[(dtrain, train_dataset_name)],
bq.           callbacks=[verta_callback(experiment_run)],
        )
E           ValueError: Old style callback was removed in version 1.6.  See: [https://xgboost.readthedocs.io/en/latest/python/callbacks.html].
```

## Risks and Area of Effect

XGBoost Integration with ModelDB

## Testing
- [x] Unit test - test_integrations.py
```
=================================================================== test session starts ====================================================================
platform darwin -- Python 3.9.13, pytest-7.1.2, pluggy-1.0.0
rootdir: /Users/baasitsharief/code/VertaAI/modeldb/client/verta/tests, configfile: pytest.ini
plugins: anyio-3.5.0, hypothesis-6.68.2
collected 10 items                                                                                                                                         

tests/test_integrations.py ..........                                                                                                                [100%]

===================================================================== warnings summary =====================================================================
test_integrations.py: 10 warnings
  /Users/baasitsharief/code/VertaAI/modeldb/client/verta/verta/_internal_utils/_utils.py:89: DeprecationWarning: Using 'method_whitelist' with Retry is deprecated and will be removed in v2.0. Use 'allowed_methods' instead
    self.retry = Retry(

test_integrations.py::TestScikitLearn::test_patch_log
  /Users/baasitsharief/.pyenv/versions/anaconda3-2022.10/lib/python3.9/site-packages/sklearn/linear_model/_ridge.py:157: DeprecationWarning: The 'sym_pos' keyword is deprecated and should be replaced by using 'assume_a = "pos"'. 'sym_pos' will be removed in SciPy 1.11.0.
    return linalg.solve(A, Xy, sym_pos=True, overwrite_a=True).T

test_integrations.py::TestScikitLearn::test_patch_log
  /Users/baasitsharief/.pyenv/versions/anaconda3-2022.10/lib/python3.9/site-packages/sklearn/neural_network/_multilayer_perceptron.py:692: ConvergenceWarning: Stochastic Optimizer: Maximum iterations (200) reached and the optimization hasn't converged yet.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================= 10 passed, 12 warnings in 47.63s =============================================================

```
- [ ] Deployed to dev env
- [ ] Other (explain) 

## Reverting
- [ ] Contains Migration - _Do Not Revert_