### PR TITLE
docs: Fix docstring typo

### DIFF
--- a/client/verta/verta/integrations/xgboost/__init__.py
+++ b/client/verta/verta/integrations/xgboost/__init__.py
@@ -12,7 +12,7 @@ class VertaCallback(xgb.callback.TrainingCallback):
     """
     XGBoost callback that automates logging to Verta during booster training.
 
-    This callback logs ``eval_metrics``\ s passed into ``xgb.train()``.
+    This callback logs ``eval_metric``\ s passed into ``xgb.train()``.
 
     See our `GitHub repository
     <https://github.com/VertaAI/examples/blob/main/experiment-management/xgboost/xgboost-integration.ipynb>`__


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

#3649 introduced an `s`, but

```
``eval_metric``\ s
```

already renders as

> `eval_metric`s

so the extra `s` is unnecessary.

## Risks and Area of Effect

—

## Testing
- [ ] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

—

## Reverting
- [ ] Contains Migration - _Do Not Revert_

Revert this PR.