### PR TITLE
docs: Fix parameter name in docstring example

### DIFF
--- a/client/verta/verta/registry/_check_model_dependencies.py
+++ b/client/verta/verta/registry/_check_model_dependencies.py
@@ -57,7 +57,7 @@ def _check_model_dependencies(
         from verta.environment import Python
 
         env = Python(["numpy", "pandas"])
-        check_model_dependencies(model=MyModelClass, environment=env)
+        check_model_dependencies(model_cls=MyModelClass, environment=env)
 
     """
     detected_modules: Set[str] = md.class_module_names(model_cls)


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

The parameter was renamed from `model` to `model_cls` during #3641's code review process.

## Risks and Area of Effect

—

## Testing
- [ ] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

—

## Reverting
- [ ] Contains Migration - _Do Not Revert_

Revert this PR.