### PR TITLE
feature: [VRD-682] Client utility function to translate import module names into distribution package names

### DIFF
--- a/client/verta/requirements.txt
+++ b/client/verta/requirements.txt
@@ -1,6 +1,7 @@
 click >= 7.0, < 9.0
 cloudpickle >= 1.0, < 3.0
 googleapis-common-protos >= 1.5, < 2.0
+importlib_metadata >= 3.7.0
 protobuf >= 3.8, < 4.0
 pytimeparse >= 1.1.8, < 2.0
 pyyaml >= 5.1, < 7.0

--- a/client/verta/tests/unit_tests/registry/test_check_model_dependencies.py
+++ b/client/verta/tests/unit_tests/registry/test_check_model_dependencies.py
@@ -41,8 +41,8 @@ def test_check_model_dependencies_complete(dependency_testing_model, complete_en
 
 
 def test_check_model_dependencies_missing_raise(dependency_testing_model, complete_env) -> None:
-    """ Verify that check_model_dependencies raises an exception for missing
-    packages when `raise_for_missing` is True.
+    """ Verify that check_model_dependencies raises an exception, with the
+    correct message, for missing packages when `raise_for_missing` is True.
     """
     incomplete_env = Python(
         [r for r in complete_env.requirements if r != 'click==0.0.1']
@@ -53,16 +53,18 @@ def test_check_model_dependencies_missing_raise(dependency_testing_model, comple
             environment=incomplete_env,
             raise_for_missing=True,
         )
-    assert err.value.args[0] == "the following packages are required by the model " \
-                                "but missing from the environment: {'click'}"
+    assert err.value.args[0] == "the following import modules are required by the model " \
+                                "but missing any corresponding distribution package in the" \
+                                " environment:\n{'import_module': 'click', " \
+                                "'distribution_packages': ['click']}"
 
 
 def test_check_model_dependencies_missing_warning(dependency_testing_model, complete_env) -> None:
-    """ Verify that check_model_dependencies defaults to raising a warning for
-    missing packages when `raise_for_missing` is False.
+    """ Verify that check_model_dependencies defaults to raising a warning, with
+    the correct message, for missing packages when `raise_for_missing` is False.
     """
     incomplete_env = Python(
-        [r for r in complete_env.requirements if r != 'pandas==0.0.1']
+        [r for r in complete_env.requirements if r not in ['pandas==0.0.1', 'PyYAML==0.0.1']]
     )  # drop a single dependency to be caught
     with warnings.catch_warnings(record=True) as caught_warnings:
         assert not _check_model_dependencies(
@@ -71,5 +73,8 @@ def test_check_model_dependencies_missing_warning(dependency_testing_model, comp
             raise_for_missing=False,
         )
     warn_msg = caught_warnings[0].message.args[0]
-    assert warn_msg == "the following packages are required by the model but " \
-                       "missing from the environment: {'pandas'}"
+    assert warn_msg == "the following import modules are required by the model " \
+                       "but missing any corresponding distribution package in the" \
+                       " environment:\n{'import_module': 'pandas', 'distribution_packages':" \
+                       " ['pandas']}\n{'import_module': 'yaml', 'distribution_packages': " \
+                       "['PyYAML']}"

--- a/client/verta/tests/unit_tests/registry/test_check_model_dependencies.py
+++ b/client/verta/tests/unit_tests/registry/test_check_model_dependencies.py
@@ -16,7 +16,7 @@ def complete_env() -> Python:
     """
     return Python([
         'click==0.0.1',
-        'google==0.0.1',
+        'googleapis-common-protos==0.0.1',
         'numpy==0.0.1',
         'pandas==0.0.1',
         'Pillow==0.0.1',

--- a/client/verta/tests/unit_tests/registry/test_check_model_dependencies.py
+++ b/client/verta/tests/unit_tests/registry/test_check_model_dependencies.py
@@ -53,10 +53,8 @@ def test_check_model_dependencies_missing_raise(dependency_testing_model, comple
             environment=incomplete_env,
             raise_for_missing=True,
         )
-    assert err.value.args[0] == "the following import modules are required by the model " \
-                                "but missing any corresponding distribution package in the" \
-                                " environment:\n{'import_module': 'click', " \
-                                "'distribution_packages': ['click']}"
+    assert err.value.args[0] == "the following packages are required by the model but missing " \
+                                "from the environment:\nclick (installed via ['click'])"
 
 
 def test_check_model_dependencies_missing_warning(dependency_testing_model, complete_env) -> None:
@@ -64,7 +62,7 @@ def test_check_model_dependencies_missing_warning(dependency_testing_model, comp
     the correct message, for missing packages when `raise_for_missing` is False.
     """
     incomplete_env = Python(
-        [r for r in complete_env.requirements if r not in ['pandas==0.0.1', 'PyYAML==0.0.1']]
+        [r for r in complete_env.requirements if r not in ['pandas==0.0.1']]
     )  # drop a single dependency to be caught
     with warnings.catch_warnings(record=True) as caught_warnings:
         assert not _check_model_dependencies(
@@ -73,8 +71,5 @@ def test_check_model_dependencies_missing_warning(dependency_testing_model, comp
             raise_for_missing=False,
         )
     warn_msg = caught_warnings[0].message.args[0]
-    assert warn_msg == "the following import modules are required by the model " \
-                       "but missing any corresponding distribution package in the" \
-                       " environment:\n{'import_module': 'pandas', 'distribution_packages':" \
-                       " ['pandas']}\n{'import_module': 'yaml', 'distribution_packages': " \
-                       "['PyYAML']}"
+    assert warn_msg == "the following packages are required by the model but missing " \
+                       "from the environment:\npandas (installed via ['pandas'])"

--- a/client/verta/tests/unit_tests/registry/test_check_model_dependencies.py
+++ b/client/verta/tests/unit_tests/registry/test_check_model_dependencies.py
@@ -62,7 +62,7 @@ def test_check_model_dependencies_missing_warning(dependency_testing_model, comp
     the correct message, for missing packages when `raise_for_missing` is False.
     """
     incomplete_env = Python(
-        [r for r in complete_env.requirements if r not in ['PyYAML==0.0.1']]
+        [r for r in complete_env.requirements if r not in ['PyYAML==0.0.1', 'pandas==0.0.1']]
     )  # drop a single dependency to be caught
     with warnings.catch_warnings(record=True) as caught_warnings:
         assert not _check_model_dependencies(
@@ -72,4 +72,5 @@ def test_check_model_dependencies_missing_warning(dependency_testing_model, comp
         )
     warn_msg = caught_warnings[0].message.args[0]
     assert warn_msg == "the following packages are required by the model but missing " \
-                       "from the environment:\nyaml (installed via ['PyYAML'])"
+                       "from the environment:\npandas (installed via ['pandas'])" \
+                       "\nyaml (installed via ['PyYAML'])"

--- a/client/verta/tests/unit_tests/registry/test_check_model_dependencies.py
+++ b/client/verta/tests/unit_tests/registry/test_check_model_dependencies.py
@@ -62,7 +62,7 @@ def test_check_model_dependencies_missing_warning(dependency_testing_model, comp
     the correct message, for missing packages when `raise_for_missing` is False.
     """
     incomplete_env = Python(
-        [r for r in complete_env.requirements if r not in ['pandas==0.0.1']]
+        [r for r in complete_env.requirements if r not in ['PyYAML==0.0.1']]
     )  # drop a single dependency to be caught
     with warnings.catch_warnings(record=True) as caught_warnings:
         assert not _check_model_dependencies(
@@ -72,4 +72,4 @@ def test_check_model_dependencies_missing_warning(dependency_testing_model, comp
         )
     warn_msg = caught_warnings[0].message.args[0]
     assert warn_msg == "the following packages are required by the model but missing " \
-                       "from the environment:\npandas (installed via ['pandas'])"
+                       "from the environment:\nyaml (installed via ['PyYAML'])"

--- a/client/verta/tests/unit_tests/registry/test_check_model_dependencies.py
+++ b/client/verta/tests/unit_tests/registry/test_check_model_dependencies.py
@@ -45,7 +45,7 @@ def test_check_model_dependencies_missing_raise(dependency_testing_model, comple
     packages when `raise_for_missing` is True.
     """
     incomplete_env = Python(
-        [ r for r in complete_env.requirements if r != 'click==0.0.1' ]
+        [r for r in complete_env.requirements if r != 'click==0.0.1']
     )  # drop a single dependency to be caught
     with pytest.raises(RuntimeError) as err:
         _check_model_dependencies(
@@ -62,7 +62,7 @@ def test_check_model_dependencies_missing_warning(dependency_testing_model, comp
     missing packages when `raise_for_missing` is False.
     """
     incomplete_env = Python(
-        [ r for r in complete_env.requirements if r != 'pandas==0.0.1' ]
+        [r for r in complete_env.requirements if r != 'pandas==0.0.1']
     )  # drop a single dependency to be caught
     with warnings.catch_warnings(record=True) as caught_warnings:
         assert not _check_model_dependencies(

--- a/client/verta/tests/unit_tests/registry/test_check_model_dependencies.py
+++ b/client/verta/tests/unit_tests/registry/test_check_model_dependencies.py
@@ -9,31 +9,23 @@ from verta.environment import Python
 from verta.registry import _check_model_dependencies
 
 
-# TODO VRD-682 convert module names to pkg names and update this
 @pytest.fixture(scope='session')
 def complete_env() -> Python:
-    """ Environment with all expected packages from dependency_testing_model
-    fixture.
+    """ Environment with all 3rd-party packages expected to be extracted
+    from the dependency_testing_model fixture.
     """
     return Python([
-        'calendar==0.0.1',
         'click==0.0.1',
-        'cloudpickle==0.0.1',
-        'collections==0.0.1',
-        'datetime==0.0.1',
         'google==0.0.1',
-        'json==0.0.1',
         'numpy==0.0.1',
         'pandas==0.0.1',
-        'PIL==0.0.1',
+        'Pillow==0.0.1',
         'requests==0.0.1',
-        'requests==0.0.1',
-        'sklearn==0.0.1',
+        'scikit-learn==0.0.1',
         'torch==0.0.1',
         'urllib3==0.0.1',
-        'verta==0.0.1',
-        'yaml==0.0.1',
-    ])
+        'PyYAML==0.0.1',
+    ])  # `verta` and `cloudpickle` included by default
 
 
 def test_check_model_dependencies_complete(dependency_testing_model, complete_env) -> None:

--- a/client/verta/tests/unit_tests/registry/test_model_dependencies.py
+++ b/client/verta/tests/unit_tests/registry/test_model_dependencies.py
@@ -138,7 +138,7 @@ def test_package_names(dependency_testing_model) -> None:
     """
     expected_packages = {
         'sklearn': ['scikit-learn'],
-        'PIL': ['Pillow', ],
+        'PIL': ['Pillow'],
         'yaml': ['PyYAML'],
     }
     extracted_packages: Dict[str, List[str]] = md.package_names(

--- a/client/verta/tests/unit_tests/registry/test_model_dependencies.py
+++ b/client/verta/tests/unit_tests/registry/test_model_dependencies.py
@@ -128,3 +128,24 @@ def test_class_module_names(dependency_testing_model) -> None:
     }
     extracted_modules: Set[str] =  md.class_module_names(dependency_testing_model)
     assert set(extracted_modules) == set(expected_modules)
+
+
+def test_package_names(dependency_testing_model) ->None:
+    """Verify that distribution package names are returned correctly for the
+    given module names when they differ from the package name.  Test fixture
+    ensures packages required for the test are installed or this test will be
+    skipped.
+    """
+    expected_packages = {
+        'scikit-learn',
+        'Pillow',
+        'PyYAML',
+    }
+    extracted_packages: Set[str] = md.package_names(
+        {
+            'sklearn',
+            'PIL',
+            'yaml'
+        }
+    )
+    assert extracted_packages == expected_packages

--- a/client/verta/tests/unit_tests/registry/test_model_dependencies.py
+++ b/client/verta/tests/unit_tests/registry/test_model_dependencies.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from typing import Callable, Set
+from typing import Callable, Dict, List, Set
 
 from verta._internal_utils import model_dependencies as md
 
@@ -137,11 +137,11 @@ def test_package_names(dependency_testing_model) -> None:
     skipped.
     """
     expected_packages = {
-        'scikit-learn',
-        'Pillow',
-        'PyYAML',
+        'sklearn': ['scikit-learn'],
+        'PIL': ['Pillow', ],
+        'yaml': ['PyYAML'],
     }
-    extracted_packages: Set[str] = md.package_names(
+    extracted_packages: Dict[str, List[str]] = md.package_names(
         {
             'sklearn',
             'PIL',

--- a/client/verta/tests/unit_tests/registry/test_model_dependencies.py
+++ b/client/verta/tests/unit_tests/registry/test_model_dependencies.py
@@ -126,11 +126,11 @@ def test_class_module_names(dependency_testing_model) -> None:
         'verta',
         'yaml',
     }
-    extracted_modules: Set[str] =  md.class_module_names(dependency_testing_model)
+    extracted_modules: Set[str] = md.class_module_names(dependency_testing_model)
     assert set(extracted_modules) == set(expected_modules)
 
 
-def test_package_names(dependency_testing_model) ->None:
+def test_package_names(dependency_testing_model) -> None:
     """Verify that distribution package names are returned correctly for the
     given module names when they differ from the package name.  Test fixture
     ensures packages required for the test are installed or this test will be

--- a/client/verta/verta/_internal_utils/model_dependencies.py
+++ b/client/verta/verta/_internal_utils/model_dependencies.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import inspect
-from importlib.metadata import packages_distributions
+from importlib_metadata import packages_distributions
 from types import ModuleType
 from typing import Callable, Dict, get_type_hints, List, Set, Type
 

--- a/client/verta/verta/_internal_utils/model_dependencies.py
+++ b/client/verta/verta/_internal_utils/model_dependencies.py
@@ -82,3 +82,4 @@ def package_names(module_names: Set[str]) -> Dict[str, List[str]]:
     """
     pkg_dist = packages_distributions()
     return {m: pkg_dist.get(m) for m in module_names if pkg_dist.get(m)}
+    # TODO: handle cases where 3rd-party module is not found in pkg_dist

--- a/client/verta/verta/_internal_utils/model_dependencies.py
+++ b/client/verta/verta/_internal_utils/model_dependencies.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 
 import inspect
-from importlib.metadata import distribution, packages_distributions
+from importlib.metadata import packages_distributions
 from types import ModuleType
-from typing import Callable, get_type_hints, List, Set, Type, Union
+from typing import Callable, Dict, get_type_hints, List, Set, Type
 
 from ..registry._verta_model_base import VertaModelBase
 
@@ -74,24 +74,11 @@ def class_module_names(model_class: Type[VertaModelBase]) -> Set[str]:
     return modules_found
 
 
-def package_names(module_names: Set[str]) -> Set[str]:
-    """Return a set of distribution package names for all 3rd-party import
-    modules in the provided set.
-
-    Package distributions don't exist for modules in the Python standard library.
-    This fact is used to capture only 3rd-party packages.  Modules associated
-    with a single package name are easily captured.  Modules associated with a
-    namespace package (e.g.`google`), may come from a variety of distribution
-    packages.  To avoid making an arbitrary choice in those cases, the main
-    namespace package name is fetched from the distribution metadata.
+def package_names(module_names: Set[str]) -> Dict[str, List[str]]:
+    """Return a dictionary where the key is the name of the import module
+    and the value is the list of possible distribution packages for each
+    3rd-party import module in the provided set that can be found in the
+    locally installed package_distributions.
     """
     pkg_dist = packages_distributions()
-    pkgs = set()
-    for mod in module_names:
-        dist_pkgs: Union[List[str], None] = pkg_dist.get(mod)
-        if dist_pkgs:
-            if len(dist_pkgs) == 1:
-                pkgs.add(dist_pkgs[0])
-            if len(dist_pkgs) > 1:
-                pkgs.add(distribution(mod).name)
-    return pkgs
+    return {m: pkg_dist.get(m) for m in module_names if pkg_dist.get(m)}

--- a/client/verta/verta/_internal_utils/model_dependencies.py
+++ b/client/verta/verta/_internal_utils/model_dependencies.py
@@ -33,9 +33,9 @@ def modules_in_function_body(func: Callable) -> Set[str]:
         if isinstance(value, ModuleType)
     ]
     _non_locals = [
-       value.__name__.split('.')[0]  # strip off submodules and classes
-       for key, value in inspect.getclosurevars(_func).nonlocals.items()
-       if isinstance(value, ModuleType)
+        value.__name__.split('.')[0]  # strip off submodules and classes
+        for key, value in inspect.getclosurevars(_func).nonlocals.items()
+        if isinstance(value, ModuleType)
     ]
     return set(_globals + _non_locals)
 
@@ -45,10 +45,10 @@ def modules_in_function_signature(func: Callable) -> Set[str]:
     function's arguments and return type hint."""
     _func = unwrap(func)
     hints = get_type_hints(_func)
-    arg_hints = { k: v for k, v in hints.items() if k != 'return' }
+    arg_hints = {k: v for k, v in hints.items() if k != 'return'}
     return_hint = hints.get('return')
 
-    modules = [ inspect.getmodule(value) for value in arg_hints.values() ]
+    modules = [inspect.getmodule(value) for value in arg_hints.values()]
 
     if return_hint:
         mod = inspect.getmodule(return_hint)
@@ -60,7 +60,7 @@ def modules_in_function_signature(func: Callable) -> Set[str]:
                     modules.append(inspect.getmodule(a))
         else:
             modules.append(inspect.getmodule(return_hint))
-    return  set([ m.__name__.split('.')[0] for m in modules ])
+    return set([m.__name__.split('.')[0] for m in modules])
 
 
 def class_module_names(model_class: Type[VertaModelBase]) -> Set[str]:

--- a/client/verta/verta/registry/_check_model_dependencies.py
+++ b/client/verta/verta/registry/_check_model_dependencies.py
@@ -68,7 +68,7 @@ def _check_model_dependencies(
     missing_packages: Dict[str, List[str]] = {
         mod: pkgs
         for mod, pkgs in detected_packages.items()
-        if not env_packages.intersection(set(pkgs))
+        if not env_packages.intersection(pkgs)
            and mod not in env_packages  # namespace package
     }
 

--- a/client/verta/verta/registry/_check_model_dependencies.py
+++ b/client/verta/verta/registry/_check_model_dependencies.py
@@ -74,7 +74,7 @@ def _check_model_dependencies(
     if missing_packages:
         error_msg = f"the following packages are required by the model but missing " \
                     f"from the environment:"
-        for m, p in missing_packages.items():
+        for m, p in sorted(missing_packages.items(), key=lambda item: item[0]):
             error_msg += f"\n{m} (installed via {p})"
         if raise_for_missing:
             raise RuntimeError(error_msg)

--- a/client/verta/verta/registry/_check_model_dependencies.py
+++ b/client/verta/verta/registry/_check_model_dependencies.py
@@ -73,14 +73,10 @@ def _check_model_dependencies(
     }
 
     if missing_packages:
-        formatted_missing_packages: List[Dict[str, List[str]]] = [
-            {'import_module': mod, 'distribution_packages': pkgs}
-            for mod, pkgs in missing_packages.items()
-        ]
-        error_msg = f"the following import modules are required by the model but missing " \
-                    f"any corresponding distribution package in the environment:"
-        for m in formatted_missing_packages:
-            error_msg += f"\n{m}"
+        error_msg = f"the following packages are required by the model but missing " \
+                    f"from the environment:"
+        for m, p in missing_packages.items():
+            error_msg += f"\n{m} (installed via {p})"
         if raise_for_missing:
             raise RuntimeError(error_msg)
         warnings.warn(

--- a/client/verta/verta/registry/_check_model_dependencies.py
+++ b/client/verta/verta/registry/_check_model_dependencies.py
@@ -23,7 +23,8 @@ def _check_model_dependencies(
     provided environment.
 
     .. note::
-        This function is not guaranteed to detect all dependencies in all cases, and should be considered a fast sanity check rather than a test.
+        This function is not guaranteed to detect all dependencies in all cases,
+        and should be considered a fast sanity check rather than a test.
 
     .. versionadded:: 0.22.2
 

--- a/client/verta/verta/registry/_check_model_dependencies.py
+++ b/client/verta/verta/registry/_check_model_dependencies.py
@@ -15,7 +15,7 @@ def _check_model_dependencies(
         model_cls: Type[VertaModelBase],
         environment: Python,
         raise_for_missing: bool = False,
-        ) -> bool:
+) -> bool:
     """Scan for missing dependencies in a model's environment.
 
     This function attempts to scan the provided model class for 3rd-party (not
@@ -63,7 +63,7 @@ def _check_model_dependencies(
     """
     detected_modules: Set[str] = md.class_module_names(model_cls)
     detected_packages: Set[str] = md.package_names(detected_modules)
-    env_packages: Set[str] = { parse_req_spec(e)[0] for e in environment.requirements }
+    env_packages: Set[str] = {parse_req_spec(e)[0] for e in environment.requirements}
 
     missing_packages = detected_packages - env_packages
     if missing_packages:

--- a/client/verta/verta/registry/_check_model_dependencies.py
+++ b/client/verta/verta/registry/_check_model_dependencies.py
@@ -69,7 +69,6 @@ def _check_model_dependencies(
         mod: pkgs
         for mod, pkgs in detected_packages.items()
         if not env_packages.intersection(pkgs)
-           and mod not in env_packages  # namespace package
     }
 
     if missing_packages:


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context
This is the missing piece of functionality for the client method `check_model_dependencies` to work properly.

The [importlib.metadata module](https://importlib-metadata.readthedocs.io/en/stable/using.html#mapping-import-to-distribution-packages) is used to capture info about the distribution packages for each of the import modules extracted from a model class.

## Risks and Area of Effect
Fairly low risk, as this is net new functionality on the first iteration and it's all hidden from the docs for now.
The Python ecosystem does not enforce package naming conventions, and the `importlib` docs warn:
> Some editable installs, [do not supply top-level names](https://github.com/pypa/packaging-problems/issues/609), and thus this function is not reliable with such installs.

This seems to be related specifically to editable installs.  However I experimented with `verta` as an `editable` installation, and the `name` attribute we need is there.  

## Testing
- [X] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

## Reverting
- [ ] Contains Migration - _Do Not Revert_