### PR TITLE
feat: Add futures onSuccess and onFailure

### DIFF
--- a/backend/common/src/main/java/ai/verta/modeldb/common/futures/Future.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/futures/Future.java
@@ -142,6 +142,30 @@ public class Future<T> {
     return from(promise);
   }
 
+  public Future<T> onSuccess(Consumer<T> fn) {
+    final var executor = getExecutor();
+    return from(
+            stage.whenCompleteAsync(
+                    (t, throwable) -> {
+                      if (throwable == null) {
+                        fn.accept(t);
+                      }
+                    },
+                    executor));
+  }
+
+  public Future<T> onFailure(Consumer<Throwable> fn) {
+    final var executor = getExecutor();
+    return from(
+            stage.whenCompleteAsync(
+                    (t, throwable) -> {
+                      if (throwable != null) {
+                        fn.accept(throwable);
+                      }
+                    },
+                    executor));
+  }
+
   public <U> Future<U> thenCompose(Function<? super T, Future<U>> fn) {
     Preconditions.checkNotNull(
         futureExecutor, "A FutureExecutor is required to be present for this method.");

--- a/backend/common/src/main/java/ai/verta/modeldb/common/futures/Future.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/futures/Future.java
@@ -145,25 +145,25 @@ public class Future<T> {
   public Future<T> onSuccess(Consumer<T> fn) {
     final var executor = getExecutor();
     return from(
-            stage.whenCompleteAsync(
-                    (t, throwable) -> {
-                      if (throwable == null) {
-                        fn.accept(t);
-                      }
-                    },
-                    executor));
+        stage.whenCompleteAsync(
+            (t, throwable) -> {
+              if (throwable == null) {
+                fn.accept(t);
+              }
+            },
+            executor));
   }
 
   public Future<T> onFailure(Consumer<Throwable> fn) {
     final var executor = getExecutor();
     return from(
-            stage.whenCompleteAsync(
-                    (t, throwable) -> {
-                      if (throwable != null) {
-                        fn.accept(throwable);
-                      }
-                    },
-                    executor));
+        stage.whenCompleteAsync(
+            (t, throwable) -> {
+              if (throwable != null) {
+                fn.accept(throwable);
+              }
+            },
+            executor));
   }
 
   public <U> Future<U> thenCompose(Function<? super T, Future<U>> fn) {

--- a/backend/common/src/main/java/ai/verta/modeldb/common/futures/InternalFuture.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/futures/InternalFuture.java
@@ -110,17 +110,17 @@ public class InternalFuture<T> {
             executor));
   }
 
-    public InternalFuture<T> onFailure(Consumer<Throwable> fn, FutureExecutor ex) {
-        final var executor = ex.captureContext();
-        return from(
-            stage.whenCompleteAsync(
-                (t, throwable) -> {
-                if (throwable != null) {
-                    fn.accept(throwable);
-                }
-                },
-                executor));
-    }
+  public InternalFuture<T> onFailure(Consumer<Throwable> fn, FutureExecutor ex) {
+    final var executor = ex.captureContext();
+    return from(
+        stage.whenCompleteAsync(
+            (t, throwable) -> {
+              if (throwable != null) {
+                fn.accept(throwable);
+              }
+            },
+            executor));
+  }
 
   public <U> InternalFuture<U> thenCompose(
       Function<? super T, InternalFuture<U>> fn, FutureExecutor ex) {

--- a/backend/common/src/main/java/ai/verta/modeldb/common/futures/InternalFuture.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/futures/InternalFuture.java
@@ -98,6 +98,30 @@ public class InternalFuture<T> {
     return ret;
   }
 
+  public InternalFuture<T> onSuccess(Consumer<T> fn, FutureExecutor ex) {
+    final var executor = ex.captureContext();
+    return from(
+        stage.whenCompleteAsync(
+            (t, throwable) -> {
+              if (throwable == null) {
+                fn.accept(t);
+              }
+            },
+            executor));
+  }
+
+    public InternalFuture<T> onFailure(Consumer<Throwable> fn, FutureExecutor ex) {
+        final var executor = ex.captureContext();
+        return from(
+            stage.whenCompleteAsync(
+                (t, throwable) -> {
+                if (throwable != null) {
+                    fn.accept(throwable);
+                }
+                },
+                executor));
+    }
+
   public <U> InternalFuture<U> thenCompose(
       Function<? super T, InternalFuture<U>> fn, FutureExecutor ex) {
     final var executor = ex.captureContext();


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context
They just forward the future value/failure, but allow us to run some computation (e.g. logs).

## Risks and Area of Effect

## Testing
- [ ] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

## Reverting
- [ ] Contains Migration - _Do Not Revert_