### PR TITLE
Revert "chore: Restore get_personal_workspace()"

### DIFF
--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -331,38 +331,8 @@ class Connection(object):
         workspace_id = user_info.verta_info.default_workspace_id
         if workspace_id:
             return self.get_workspace_name_from_id(workspace_id)
-        else:  # workaround; see get_personal_workspace()
-            warnings.warn(
-                "default_workspace_id not set for user;"
-                " falling back to username (as personal workspace)"
-            )
-            return self.get_personal_workspace()
-
-    def get_personal_workspace(self):
-        """
-        Return username, for use as one's personal workspace in permission v1.
-
-        This has been irrelevant for normal users since 2021, but is still
-        necessary for bootstrapped internal accounts in permission v1 as they
-        are not assigned a ``default_workspace_id`` on creation (VUMM-872).
-
-        """
-        email = self.auth.get("Grpc-Metadata-email")
-        if email is not None:
-            msg = UACService_pb2.GetUser(email=email)
-            response = self.make_proto_request(
-                "GET", "/api/v1/uac-proxy/uac/getUser", params=msg
-            )
-
-            if (
-                response.ok and self.is_html_response(response)
-            ) or response.status_code == requests.codes.not_found:  # fetched webapp  # UAC not found
-                pass  # fall through to OSS default workspace
-            else:
-                return self.must_proto_response(
-                    response, UACService_pb2.UserInfo
-                ).verta_info.username
-        return self._OSS_DEFAULT_WORKSPACE
+        else:
+            raise RuntimeError("default workspace is not set")
 
 
 class NoneProtoResponse(object):


### PR DESCRIPTION
Reverts VertaAI/modeldb#3602

<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

As of https://github.com/VertaAI/verta-uacservice/pull/2119, bootstrapped users in all environments now correctly have a default workspace configured.

## Risks and Area of Effect

Low; see https://github.com/VertaAI/modeldb/pull/3404.

## Testing
- [ ] Unit test
- [ ] Deployed to dev env
- [x] Other (explain) 

I launched the client test suite against permissions V1 and V2 test environments, and neither one started failing catastrophically with `default workspace is not set`, which means this works!

## Reverting
- [ ] Contains Migration - _Do Not Revert_

Revert this PR.

