### PR TITLE
chore: Synchronize formatting of recent work with `black`

### DIFF
--- a/client/verta/tests/unit_tests/registry/conftest.py
+++ b/client/verta/tests/unit_tests/registry/conftest.py
@@ -10,6 +10,7 @@ import click
 import cloudpickle as cp
 import pytest
 import requests
+from requests import post
 import urllib3
 import yaml
 from google.protobuf.message import Message
@@ -78,6 +79,9 @@ def dependency_testing_model() -> Type[VertaModelBase]:
         @staticmethod
         def make_timeout():  # No modules in function signature
             return requests.Timeout()  # 3rd party module in function body
+
+        def post_request(self) -> None:
+            post("https://www.verta.ai")
 
         # 3rd-party modules nested inside type constructs should still be extracted
         def nested_multiple_returns_hint(

--- a/client/verta/tests/unit_tests/registry/conftest.py
+++ b/client/verta/tests/unit_tests/registry/conftest.py
@@ -12,7 +12,7 @@ import pytest
 import requests
 import urllib3
 import yaml
-from google.protobuf import message as msg
+from google.protobuf.message import Message
 
 from verta import runtime
 from verta.registry import verify_io, VertaModelBase
@@ -43,7 +43,7 @@ def dependency_testing_model() -> Type[VertaModelBase]:
                 w: calendar.Calendar,            # standard library in function arg
                 x: dt.datetime,                  # standard library in function arg via alias
                 y: numpy.ndarray,                # 3rd-party module in function arg
-                z: msg.Message,                  # 3rd-party module in function arg via alias
+                z: Message,                      # 3rd-party module in function arg via class
         ) -> pd.DataFrame:                       # 3rd-party module in return type hint
             hour = x.hour                        # standard library usage in function body
             runtime.log('error', 'Error')        # 3rd-party module in function body (VERTA)
@@ -68,6 +68,10 @@ def dependency_testing_model() -> Type[VertaModelBase]:
 
         def make_dataframe(self, input):         # No modules in function signature
             return pd.DataFrame(input)           # 3rd party module in function body
+
+        def make_message(self, input: str):
+            msg = Message(input)
+            return msg
 
         @staticmethod
         def make_timeout():                      # No modules in function signature

--- a/client/verta/tests/unit_tests/registry/conftest.py
+++ b/client/verta/tests/unit_tests/registry/conftest.py
@@ -22,7 +22,7 @@ from verta.registry import verify_io, VertaModelBase
 def dependency_testing_model() -> Type[VertaModelBase]:
     """Returns a model class that imports and calls external dependencies."""
     numpy = pytest.importorskip("numpy")
-    pd =pytest.importorskip("pandas")
+    pd = pytest.importorskip("pandas")
     sklearn = pytest.importorskip("sklearn")
     torch = pytest.importorskip("torch")
     PIL = pytest.importorskip("PIL")
@@ -32,6 +32,7 @@ def dependency_testing_model() -> Type[VertaModelBase]:
         Model class that imports and calls external dependencies in a variety of ways
         for the purpose of testing our model environment validation logic.
         """
+
         def __init__(self, artifacts):
             pass
 
@@ -39,46 +40,49 @@ def dependency_testing_model() -> Type[VertaModelBase]:
         # extracted, thus we explicitly test the same scenarios with and without.
         @verify_io
         def predict(
-                self,
-                w: calendar.Calendar,            # standard library in function arg
-                x: dt.datetime,                  # standard library in function arg via alias
-                y: numpy.ndarray,                # 3rd-party module in function arg
-                z: Message,                      # 3rd-party module in function arg via class
-        ) -> pd.DataFrame:                       # 3rd-party module in return type hint
-            hour = x.hour                        # standard library usage in function body
-            runtime.log('error', 'Error')        # 3rd-party module in function body (VERTA)
-            yaml_con = yaml.constructor          # 3rd party module in function body
-            z = self.make_dataframe(y)           # 3rd party module called indirectly
+            self,
+            w: calendar.Calendar,  # standard library in function arg
+            x: dt.datetime,  # standard library in function arg via alias
+            y: numpy.ndarray,  # 3rd-party module in function arg
+            z: Message,  # 3rd-party module in function arg via class
+        ) -> pd.DataFrame:  # 3rd-party module in return type hint
+            hour = x.hour  # standard library usage in function body
+            runtime.log("error", "Error")  # 3rd-party module in function body (VERTA)
+            yaml_con = yaml.constructor  # 3rd party module in function body
+            z = self.make_dataframe(y)  # 3rd party module called indirectly
             return z
-
 
         def unwrapped_predict(
-                self,
-                a: json.JSONEncoder,             # standard library in function arg
-                b: collecs.OrderedDict,          # standard library in function arg via alias
-                c: sklearn.base.BaseEstimator,   # 3rd-party module in function arg
-                d: cp.CloudPickler,              # 3rd-party module in function arg via alias
-        ) -> requests.Timeout:                   # 3rd-party module in return type hint
-            _json = a.encode({'x':'y'})          # standard library usage in function body
-            with runtime.context():              # 3rd-party module in function body (VERTA)
-                runtime.log('error', 'Error')    # 3rd-party module in function body (VERTA)
-            click_exc = click.ClickException     # 3rd party module in function body
-            z = self.make_timeout()              # 3rd party module called indirectly
+            self,
+            a: json.JSONEncoder,  # standard library in function arg
+            b: collecs.OrderedDict,  # standard library in function arg via alias
+            c: sklearn.base.BaseEstimator,  # 3rd-party module in function arg
+            d: cp.CloudPickler,  # 3rd-party module in function arg via alias
+        ) -> requests.Timeout:  # 3rd-party module in return type hint
+            _json = a.encode({"x": "y"})  # standard library usage in function body
+            with runtime.context():  # 3rd-party module in function body (VERTA)
+                runtime.log(
+                    "error", "Error"
+                )  # 3rd-party module in function body (VERTA)
+            click_exc = click.ClickException  # 3rd party module in function body
+            z = self.make_timeout()  # 3rd party module called indirectly
             return z
 
-        def make_dataframe(self, input):         # No modules in function signature
-            return pd.DataFrame(input)           # 3rd party module in function body
+        def make_dataframe(self, input):  # No modules in function signature
+            return pd.DataFrame(input)  # 3rd party module in function body
 
         def make_message(self, input: str):
             msg = Message(input)
             return msg
 
         @staticmethod
-        def make_timeout():                      # No modules in function signature
-            return requests.Timeout()            # 3rd party module in function body
+        def make_timeout():  # No modules in function signature
+            return requests.Timeout()  # 3rd party module in function body
 
         # 3rd-party modules nested inside type constructs should still be extracted
-        def nested_multiple_returns_hint(self) -> Union[urllib3.Retry, PIL.UnidentifiedImageError]:
+        def nested_multiple_returns_hint(
+            self,
+        ) -> Union[urllib3.Retry, PIL.UnidentifiedImageError]:
             return urllib3.Retry or PIL.UnidentifiedImageError
 
         # 3rd-party modules nested inside type constructs should still be extracted

--- a/client/verta/tests/unit_tests/registry/test_check_model_dependencies.py
+++ b/client/verta/tests/unit_tests/registry/test_check_model_dependencies.py
@@ -9,27 +9,31 @@ from verta.environment import Python
 from verta.registry import _check_model_dependencies
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def complete_env() -> Python:
-    """ Environment with all 3rd-party packages expected to be extracted
+    """Environment with all 3rd-party packages expected to be extracted
     from the dependency_testing_model fixture.
     """
-    return Python([
-        'click==0.0.1',
-        'googleapis-common-protos==0.0.1',
-        'numpy==0.0.1',
-        'pandas==0.0.1',
-        'Pillow==0.0.1',
-        'requests==0.0.1',
-        'scikit-learn==0.0.1',
-        'torch==0.0.1',
-        'urllib3==0.0.1',
-        'PyYAML==0.0.1',
-    ])  # `verta` and `cloudpickle` included by default
+    return Python(
+        [
+            "click==0.0.1",
+            "googleapis-common-protos==0.0.1",
+            "numpy==0.0.1",
+            "pandas==0.0.1",
+            "Pillow==0.0.1",
+            "requests==0.0.1",
+            "scikit-learn==0.0.1",
+            "torch==0.0.1",
+            "urllib3==0.0.1",
+            "PyYAML==0.0.1",
+        ]
+    )  # `verta` and `cloudpickle` included by default
 
 
-def test_check_model_dependencies_complete(dependency_testing_model, complete_env) -> None:
-    """ Verify that check_model_dependencies extracts all the expected packages from
+def test_check_model_dependencies_complete(
+    dependency_testing_model, complete_env
+) -> None:
+    """Verify that check_model_dependencies extracts all the expected packages from
     the test model class (dependency_testing_model fixture) and correctly reconciles
     them against the provided environment (complete_env fixture).
     """
@@ -40,12 +44,14 @@ def test_check_model_dependencies_complete(dependency_testing_model, complete_en
     )
 
 
-def test_check_model_dependencies_missing_raise(dependency_testing_model, complete_env) -> None:
-    """ Verify that check_model_dependencies raises an exception, with the
+def test_check_model_dependencies_missing_raise(
+    dependency_testing_model, complete_env
+) -> None:
+    """Verify that check_model_dependencies raises an exception, with the
     correct message, for missing packages when `raise_for_missing` is True.
     """
     incomplete_env = Python(
-        [r for r in complete_env.requirements if r != 'click==0.0.1']
+        [r for r in complete_env.requirements if r != "click==0.0.1"]
     )  # drop a single dependency to be caught
     with pytest.raises(RuntimeError) as err:
         _check_model_dependencies(
@@ -53,16 +59,25 @@ def test_check_model_dependencies_missing_raise(dependency_testing_model, comple
             environment=incomplete_env,
             raise_for_missing=True,
         )
-    assert err.value.args[0] == "the following packages are required by the model but missing " \
-                                "from the environment:\nclick (installed via ['click'])"
+    assert (
+        err.value.args[0]
+        == "the following packages are required by the model but missing "
+        "from the environment:\nclick (installed via ['click'])"
+    )
 
 
-def test_check_model_dependencies_missing_warning(dependency_testing_model, complete_env) -> None:
-    """ Verify that check_model_dependencies defaults to raising a warning, with
+def test_check_model_dependencies_missing_warning(
+    dependency_testing_model, complete_env
+) -> None:
+    """Verify that check_model_dependencies defaults to raising a warning, with
     the correct message, for missing packages when `raise_for_missing` is False.
     """
     incomplete_env = Python(
-        [r for r in complete_env.requirements if r not in ['PyYAML==0.0.1', 'pandas==0.0.1']]
+        [
+            r
+            for r in complete_env.requirements
+            if r not in ["PyYAML==0.0.1", "pandas==0.0.1"]
+        ]
     )  # drop a single dependency to be caught
     with warnings.catch_warnings(record=True) as caught_warnings:
         assert not _check_model_dependencies(
@@ -71,6 +86,9 @@ def test_check_model_dependencies_missing_warning(dependency_testing_model, comp
             raise_for_missing=False,
         )
     warn_msg = caught_warnings[0].message.args[0]
-    assert warn_msg == "the following packages are required by the model but missing " \
-                       "from the environment:\npandas (installed via ['pandas'])" \
-                       "\nyaml (installed via ['PyYAML'])"
+    assert (
+        warn_msg
+        == "the following packages are required by the model but missing "
+        "from the environment:\npandas (installed via ['pandas'])"
+        "\nyaml (installed via ['PyYAML'])"
+    )

--- a/client/verta/tests/unit_tests/registry/test_model_dependencies.py
+++ b/client/verta/tests/unit_tests/registry/test_model_dependencies.py
@@ -12,6 +12,7 @@ def test_class_functions(dependency_testing_model) -> None:
     expected_func_names = [
         '__init__',
         'make_dataframe',
+        'make_message',
         'make_timeout',
         'model_test',
         'nested_multiple_returns_hint',
@@ -48,6 +49,16 @@ def test_modules_in_function_body_return_line(dependency_testing_model) -> None:
     as expected, including when aliased (which causes them to be stored differently)"""
     func: Callable = dependency_testing_model.make_dataframe
     expected_modules = {'pandas'}
+    extracted_modules: Set[str] = md.modules_in_function_body(func)
+    assert extracted_modules == expected_modules
+
+
+def test_modules_in_function_body_as_class_instance(dependency_testing_model) -> None:
+    """ Verify that modules introduced only via class instance are extracted
+    as expected.
+    """
+    func: Callable = dependency_testing_model.make_message
+    expected_modules = {'google'}
     extracted_modules: Set[str] = md.modules_in_function_body(func)
     assert extracted_modules == expected_modules
 
@@ -108,6 +119,7 @@ def test_class_module_names(dependency_testing_model) -> None:
     """ Verify that all expected module names are extracted as expected.
     """
     expected_modules = {
+        'builtins',
         'calendar',
         'click',
         'cloudpickle',

--- a/client/verta/tests/unit_tests/registry/test_model_dependencies.py
+++ b/client/verta/tests/unit_tests/registry/test_model_dependencies.py
@@ -14,6 +14,7 @@ def test_class_functions(dependency_testing_model) -> None:
         "make_dataframe",
         "make_message",
         "make_timeout",
+        "post_request",
         "model_test",
         "nested_multiple_returns_hint",
         "nested_type_hint",
@@ -59,6 +60,16 @@ def test_modules_in_function_body_as_class_instance(dependency_testing_model) ->
     """
     func: Callable = dependency_testing_model.make_message
     expected_modules = {"google"}
+    extracted_modules: Set[str] = md.modules_in_function_body(func)
+    assert extracted_modules == expected_modules
+
+
+def tests_modules_in_function_body_as_function(dependency_testing_model) -> None:
+    """Verify that modules introduced only via function directly imported from
+    a 3rd-party module are extracted as expected.
+    """
+    func: Callable = dependency_testing_model.post_request
+    expected_modules = {"requests"}
     extracted_modules: Set[str] = md.modules_in_function_body(func)
     assert extracted_modules == expected_modules
 

--- a/client/verta/tests/unit_tests/registry/test_model_dependencies.py
+++ b/client/verta/tests/unit_tests/registry/test_model_dependencies.py
@@ -6,19 +6,19 @@ from verta._internal_utils import model_dependencies as md
 
 
 def test_class_functions(dependency_testing_model) -> None:
-    """ Verify that all the functions in the test class are recognized and
+    """Verify that all the functions in the test class are recognized and
     returned.
     """
     expected_func_names = [
-        '__init__',
-        'make_dataframe',
-        'make_message',
-        'make_timeout',
-        'model_test',
-        'nested_multiple_returns_hint',
-        'nested_type_hint',
-        'predict',
-        'unwrapped_predict',
+        "__init__",
+        "make_dataframe",
+        "make_message",
+        "make_timeout",
+        "model_test",
+        "nested_multiple_returns_hint",
+        "nested_type_hint",
+        "predict",
+        "unwrapped_predict",
     ]
     extracted_func_names = [
         f.__name__ for f in md.class_functions(dependency_testing_model)
@@ -27,116 +27,103 @@ def test_class_functions(dependency_testing_model) -> None:
 
 
 def test_modules_in_function_body_wrapped(dependency_testing_model) -> None:
-    """ Verify that modules used within a function body are extracted
-    as expected, for a function that is wrapped in verify_io """
+    """Verify that modules used within a function body are extracted
+    as expected, for a function that is wrapped in verify_io"""
     func: Callable = dependency_testing_model.predict
-    expected_modules = {'verta', 'yaml'}
+    expected_modules = {"verta", "yaml"}
     extracted_modules: Set[str] = md.modules_in_function_body(func)
     assert extracted_modules == expected_modules
 
 
 def test_modules_in_function_body_unwrapped(dependency_testing_model) -> None:
-    """ Verify that modules used within a function body are extracted
-    as expected, for a function that is not wrapped in verify_io """
+    """Verify that modules used within a function body are extracted
+    as expected, for a function that is not wrapped in verify_io"""
     func: Callable = dependency_testing_model.unwrapped_predict
-    expected_modules = {'verta', 'click'}
+    expected_modules = {"verta", "click"}
     extracted_modules: Set[str] = md.modules_in_function_body(func)
     assert extracted_modules == expected_modules
 
 
 def test_modules_in_function_body_return_line(dependency_testing_model) -> None:
-    """ Verify that modules used only within a functions return line are extracted
+    """Verify that modules used only within a functions return line are extracted
     as expected, including when aliased (which causes them to be stored differently)"""
     func: Callable = dependency_testing_model.make_dataframe
-    expected_modules = {'pandas'}
+    expected_modules = {"pandas"}
     extracted_modules: Set[str] = md.modules_in_function_body(func)
     assert extracted_modules == expected_modules
 
 
 def test_modules_in_function_body_as_class_instance(dependency_testing_model) -> None:
-    """ Verify that modules introduced only via class instance are extracted
+    """Verify that modules introduced only via class instance are extracted
     as expected.
     """
     func: Callable = dependency_testing_model.make_message
-    expected_modules = {'google'}
+    expected_modules = {"google"}
     extracted_modules: Set[str] = md.modules_in_function_body(func)
     assert extracted_modules == expected_modules
 
 
 def test_modules_in_function_signature_wrapped(dependency_testing_model) -> None:
-    """ Verify that modules used in function arguments are extracted as
+    """Verify that modules used in function arguments are extracted as
     expected when the function is wrapped in verify_io.
     """
     func: Callable = dependency_testing_model.predict
-    expected_modules = {
-        'calendar',
-        'datetime',
-        'numpy',
-        'google',
-        'pandas',
-    }
+    expected_modules = {"calendar", "datetime", "numpy", "google", "pandas"}
     extracted_modules: Set[str] = md.modules_in_function_signature(func)
     assert extracted_modules == expected_modules
 
 
 def test_modules_in_function_signature_unwrapped(dependency_testing_model) -> None:
-    """ Verify that modules used in function arguments are extracted as
+    """Verify that modules used in function arguments are extracted as
     expected with no function wrappers.
     """
     func: Callable = dependency_testing_model.unwrapped_predict
-    expected_modules = {
-        'json',
-        'collections',
-        'sklearn',
-        'cloudpickle',
-        'requests',
-    }
+    expected_modules = {"json", "collections", "sklearn", "cloudpickle", "requests"}
     extracted_modules: Set[str] = md.modules_in_function_signature(func)
     assert extracted_modules == expected_modules
 
 
 def test_modules_in_function_return_type_hint_nested(dependency_testing_model) -> None:
-    """ Verify that modules used in function return type hints are extracted
+    """Verify that modules used in function return type hints are extracted
     as expected when nested inside another type construct.
     """
     func: Callable = dependency_testing_model.nested_type_hint
-    expected_modules = {'torch'}
+    expected_modules = {"torch"}
     extracted_modules: Set[str] = md.modules_in_function_signature(func)
     assert extracted_modules == expected_modules
 
 
 def test_modules_in_function_return_type_hint_multiple(dependency_testing_model) -> None:
-    """ Verify that modules used in function return type hints are extracted
+    """Verify that modules used in function return type hints are extracted
     as expected when multiple return types are specified.
     """
     func: Callable = dependency_testing_model.nested_multiple_returns_hint
-    expected_modules = {'urllib3', 'PIL'}
+    expected_modules = {"urllib3", "PIL"}
     extracted_modules: Set[str] = md.modules_in_function_signature(func)
     assert extracted_modules == expected_modules
 
 
 def test_class_module_names(dependency_testing_model) -> None:
-    """ Verify that all expected module names are extracted as expected.
-    """
+    """Verify that all expected module names are extracted as expected."""
     expected_modules = {
-        'builtins',
-        'calendar',
-        'click',
-        'cloudpickle',
-        'collections',
-        'datetime',
-        'google',
-        'json',
-        'numpy',
-        'pandas',
-        'PIL',
-        'requests',
-        'requests',
-        'sklearn',
-        'torch',
-        'urllib3',
-        'verta',
-        'yaml',
+        "builtins",
+        "calendar",
+        "click",
+        "cloudpickle",
+        "collections",
+        "datetime",
+        "google",
+        "json",
+        "numpy",
+        "pandas",
+        "PIL",
+        "requests",
+        "requests",
+        "sklearn",
+        "torch",
+        "urllib3",
+        "verta",
+        "yaml",
     }
     extracted_modules: Set[str] = md.class_module_names(dependency_testing_model)
     assert set(extracted_modules) == set(expected_modules)
@@ -149,15 +136,11 @@ def test_package_names(dependency_testing_model) -> None:
     skipped.
     """
     expected_packages = {
-        'sklearn': ['scikit-learn'],
-        'PIL': ['Pillow'],
-        'yaml': ['PyYAML'],
+        "sklearn": ["scikit-learn"],
+        "PIL": ["Pillow"],
+        "yaml": ["PyYAML"],
     }
     extracted_packages: Dict[str, List[str]] = md.package_names(
-        {
-            'sklearn',
-            'PIL',
-            'yaml'
-        }
+        {"sklearn", "PIL", "yaml"}
     )
     assert extracted_packages == expected_packages

--- a/client/verta/verta/_internal_utils/model_dependencies.py
+++ b/client/verta/verta/_internal_utils/model_dependencies.py
@@ -27,17 +27,22 @@ def unwrap(func: Callable) -> Callable:
 def modules_in_function_body(func: Callable) -> Set[str]:
     """Return a set of all base modules called within the body of the provided function."""
     _func = unwrap(func)
-    _globals = [
+    _global_modules = {
         value.__name__.split('.')[0]  # strip off submodules and classes
         for key, value in inspect.getclosurevars(_func).globals.items()
         if isinstance(value, ModuleType)
-    ]
-    _non_locals = [
-        value.__name__.split('.')[0]  # strip off submodules and classes
-        for key, value in inspect.getclosurevars(_func).nonlocals.items()
-        if isinstance(value, ModuleType)
-    ]
-    return set(_globals + _non_locals)
+    }
+    _global_classes = {
+        inspect.getmodule(value).__name__.split('.')[0]  # strip off submodules
+        for key, value in inspect.getclosurevars(_func).globals.items()
+        if inspect.isclass(value)
+    }
+    _non_locals = {
+       value.__name__.split('.')[0]  # strip off submodules and classes
+       for key, value in inspect.getclosurevars(_func).nonlocals.items()
+       if isinstance(value, ModuleType)
+    }
+    return _global_modules | _global_classes | _non_locals
 
 
 def modules_in_function_signature(func: Callable) -> Set[str]:

--- a/client/verta/verta/_internal_utils/model_dependencies.py
+++ b/client/verta/verta/_internal_utils/model_dependencies.py
@@ -10,9 +10,9 @@ from ..registry._verta_model_base import VertaModelBase
 
 def class_functions(model_class: Type[VertaModelBase]) -> Set[Callable]:
     """Return a set of all the functions present in the provided class object."""
-    return set([
-        f[1] for f in inspect.getmembers(model_class, predicate=inspect.isfunction)
-    ])
+    return set(
+        [f[1] for f in inspect.getmembers(model_class, predicate=inspect.isfunction)]
+    )
 
 
 def unwrap(func: Callable) -> Callable:
@@ -28,19 +28,19 @@ def modules_in_function_body(func: Callable) -> Set[str]:
     """Return a set of all base modules called within the body of the provided function."""
     _func = unwrap(func)
     _global_modules = {
-        value.__name__.split('.')[0]  # strip off submodules and classes
+        value.__name__.split(".")[0]  # strip off submodules and classes
         for key, value in inspect.getclosurevars(_func).globals.items()
         if isinstance(value, ModuleType)
     }
     _global_classes = {
-        inspect.getmodule(value).__name__.split('.')[0]  # strip off submodules
+        inspect.getmodule(value).__name__.split(".")[0]  # strip off submodules
         for key, value in inspect.getclosurevars(_func).globals.items()
         if inspect.isclass(value)
     }
     _non_locals = {
-       value.__name__.split('.')[0]  # strip off submodules and classes
-       for key, value in inspect.getclosurevars(_func).nonlocals.items()
-       if isinstance(value, ModuleType)
+        value.__name__.split(".")[0]  # strip off submodules and classes
+        for key, value in inspect.getclosurevars(_func).nonlocals.items()
+        if isinstance(value, ModuleType)
     }
     return _global_modules | _global_classes | _non_locals
 
@@ -50,14 +50,14 @@ def modules_in_function_signature(func: Callable) -> Set[str]:
     function's arguments and return type hint."""
     _func = unwrap(func)
     hints = get_type_hints(_func)
-    arg_hints = {k: v for k, v in hints.items() if k != 'return'}
-    return_hint = hints.get('return')
+    arg_hints = {k: v for k, v in hints.items() if k != "return"}
+    return_hint = hints.get("return")
 
     modules = [inspect.getmodule(value) for value in arg_hints.values()]
 
     if return_hint:
         mod = inspect.getmodule(return_hint)
-        if mod.__name__ == 'typing':
+        if mod.__name__ == "typing":
             ret_ann = inspect.signature(_func).return_annotation
             nested_args = ret_ann.__args__
             for a in nested_args:
@@ -65,7 +65,7 @@ def modules_in_function_signature(func: Callable) -> Set[str]:
                     modules.append(inspect.getmodule(a))
         else:
             modules.append(inspect.getmodule(return_hint))
-    return set([m.__name__.split('.')[0] for m in modules])
+    return set([m.__name__.split(".")[0] for m in modules])
 
 
 def class_module_names(model_class: Type[VertaModelBase]) -> Set[str]:

--- a/client/verta/verta/registry/_check_model_dependencies.py
+++ b/client/verta/verta/registry/_check_model_dependencies.py
@@ -12,9 +12,7 @@ from ._verta_model_base import VertaModelBase
 
 
 def _check_model_dependencies(
-        model_cls: Type[VertaModelBase],
-        environment: Python,
-        raise_for_missing: bool = False,
+    model_cls: Type[VertaModelBase], environment: Python, raise_for_missing: bool = False
 ) -> bool:
     """Scan for missing dependencies in a model's environment.
 
@@ -72,15 +70,14 @@ def _check_model_dependencies(
     }
 
     if missing_packages:
-        error_msg = f"the following packages are required by the model but missing " \
-                    f"from the environment:"
+        error_msg = (
+            f"the following packages are required by the model but missing "
+            f"from the environment:"
+        )
         for m, p in sorted(missing_packages.items(), key=lambda item: item[0]):
             error_msg += f"\n{m} (installed via {p})"
         if raise_for_missing:
             raise RuntimeError(error_msg)
-        warnings.warn(
-            error_msg,
-            category=RuntimeWarning,
-        )
+        warnings.warn(error_msg, category=RuntimeWarning)
         return False
     return True


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context
*meant to be merged after #3659*

This PR contains no functional changes.  These files were simply auto-formatted with `black` as is our standard practice.


## Risks and Area of Effect
Very low.  Formatting changes only.

## Testing
- [X] Unit test (Re-ran them all as a sanity check)
- [ ] Deployed to dev env
- [ ] Other (explain) 

## Reverting
- [ ] Contains Migration - _Do Not Revert_