### PR TITLE
docs: Link to product docs in model_test()

### DIFF
--- a/client/verta/verta/registry/_verta_model_base.py
+++ b/client/verta/verta/registry/_verta_model_base.py
@@ -96,12 +96,12 @@ class VertaModelBase(object):
     def model_test(self):
         """Test a model's behavior for correctness.
 
-        :meth:`model_test` does nothing by default. Implement this method—with
-        any assertions you wish—to validate your model.
+        Implement this method on your model—with any desired calls and
+        assertions—to validate behavior and state.
 
-        This method is automatically called
-
-        - when an endpoint is initializing in the Verta platform
+        See `our product documentation on model verification
+        <https://docs.verta.ai/verta/registry/guides/model-verification-and-testing#vertamodelbase.model_test>`__
+        for more information about how this method is used.
 
         .. note::
 


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

I'd like this to just link to our product docs, to help avoid having to duplicate information.

## Risks and Area of Effect

—

## Testing
- [ ] Unit test
- [ ] Deployed to dev env
- [x] Other (explain) 

Built and rendered locally:

![Screen Shot 2023-03-13 at 11 49 27 AM](https://user-images.githubusercontent.com/96442646/224800640-788e1f68-3e91-4100-b776-7da78defb568.png)

## Reverting
- [ ] Contains Migration - _Do Not Revert_

Revert this PR.