### PR TITLE
docs: Mention importlib-metadata in client changelog

### DIFF
--- a/client/verta/docs/changelog.rst
+++ b/client/verta/docs/changelog.rst
@@ -40,6 +40,10 @@ Changelog
 v0.22.1 (2023-03-13)
 --------------------
 
+Backwards Incompatibilities
+- add ``importlib_metadata>=3.7.0`` dependency
+  (`#3652 <https://github.com/VertaAI/modeldb/pull/3652>`__)
+
 New Features
 ^^^^^^^^^^^^
 - add ``model_test()`` to ``VertaModelBase`` interface

--- a/client/verta/docs/changelog.rst
+++ b/client/verta/docs/changelog.rst
@@ -42,7 +42,7 @@ v0.22.1 (2023-03-13)
 
 Backwards Incompatibilities
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-- add ``https://pypi.org/project/importlib-metadata/>=3.7.0`` dependency
+- add ``importlib-metadata>=3.7.0`` dependency
   (`#3652 <https://github.com/VertaAI/modeldb/pull/3652>`__)
 
 New Features

--- a/client/verta/docs/changelog.rst
+++ b/client/verta/docs/changelog.rst
@@ -41,7 +41,8 @@ v0.22.1 (2023-03-13)
 --------------------
 
 Backwards Incompatibilities
-- add ``importlib_metadata>=3.7.0`` dependency
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+- add ``https://pypi.org/project/importlib-metadata/>=3.7.0`` dependency
   (`#3652 <https://github.com/VertaAI/modeldb/pull/3652>`__)
 
 New Features

--- a/client/verta/requirements.txt
+++ b/client/verta/requirements.txt
@@ -1,7 +1,7 @@
 click >= 7.0, < 9.0
 cloudpickle >= 1.0, < 3.0
 googleapis-common-protos >= 1.5, < 2.0
-importlib_metadata >= 3.7.0
+importlib-metadata >= 3.7.0
 protobuf >= 3.8, < 4.0
 pytimeparse >= 1.1.8, < 2.0
 pyyaml >= 5.1, < 7.0


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

I totally missed this! It's here now.

## Risks and Area of Effect

I'm not sure whether to consider a dependency addition a "backwards incompatibility". It's what I've been doing, and it's true that the client isn't compatible with environments that _don't_ have the dependency.

Still, I think `importlib-metadata` is lightweight enough that it doesn't warrant any corrective action, nor a minor version release.

## Testing
- [ ] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

Built and rendered locally:

![Screen Shot 2023-03-14 at 2 10 58 AM](https://user-images.githubusercontent.com/96442646/224952024-cc041b52-3269-4c1c-92a3-db2cbdda571f.png)

## Reverting
- [ ] Contains Migration - _Do Not Revert_

Revert this PR.