### PR TITLE
docs: Disable PDF build of client API docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,8 +1,5 @@
 version: 2
 
-formats:
-  - pdf
-
 python:
   version: 3
   install:


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

Read the Docs released a new version this morning (https://github.com/readthedocs/readthedocs.org/pull/10146) which included a new change which breaks builds if PDF generation fails (https://github.com/readthedocs/readthedocs.org/pull/10113).

I don't think anyone uses the PDF render of our docs, and we're lacking in bandwidth to address this this week, so I'm disabling the PDF build altogether.

## Risks and Area of Effect

No one will be able to view our docs as a PDF, although the build has been broken to begin with...

## Testing
- [ ] Unit test
- [ ] Deployed to dev env
- [x] Other (explain) 

Build succeeds from this branch

<img width="800" alt="Screen Shot 2023-03-14 at 1 24 04 PM" src="https://user-images.githubusercontent.com/96442646/225127778-ab883007-157d-490f-a914-5e4503c9ba5d.png">

## Reverting
- [ ] Contains Migration - _Do Not Revert_

Revert this PR.