### PR TITLE
Replace deprecated `.get()` methods with `.blockAndGet()` everywhere

### DIFF
--- a/backend/common/src/main/java/ai/verta/modeldb/common/MssqlMigrationUtil.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/MssqlMigrationUtil.java
@@ -88,7 +88,7 @@ public class MssqlMigrationUtil {
               LOGGER.debug("all tables indexes recreated successfully");
             });
     try {
-      result.get();
+      result.blockAndGet();
     } catch (Exception e) {
       throw new ModelDBException(e);
     }

--- a/backend/common/src/main/java/ai/verta/modeldb/common/event/FutureEventDAO.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/event/FutureEventDAO.java
@@ -32,7 +32,7 @@ public class FutureEventDAO {
   public void addLocalEventWithBlocking(
       String resourceType, String eventType, long workspaceId, JsonObject eventMetadata) {
     try {
-      addLocalEvent(resourceType, eventType, workspaceId, eventMetadata).get();
+      addLocalEvent(resourceType, eventType, workspaceId, eventMetadata).blockAndGet();
     } catch (Exception e) {
       throw new ModelDBException(e);
     }
@@ -74,7 +74,7 @@ public class FutureEventDAO {
 
   public Void deleteLocalEventWithBlocking(List<String> eventUUIDs) {
     try {
-      return deleteLocalEvent(eventUUIDs).get();
+      return deleteLocalEvent(eventUUIDs).blockAndGet();
     } catch (Exception e) {
       throw new ModelDBException(e);
     }

--- a/backend/common/src/main/java/ai/verta/modeldb/common/reconcilers/SendEventsWithCleanUp.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/reconcilers/SendEventsWithCleanUp.java
@@ -84,6 +84,6 @@ public class SendEventsWithCleanUp extends Reconciler<CreateEventRequest> {
               return new ReconcileResult();
             },
             executor)
-        .get();
+        .blockAndGet();
   }
 }

--- a/backend/common/src/test/java/ai/verta/modeldb/common/futures/FutureJdbiTest.java
+++ b/backend/common/src/test/java/ai/verta/modeldb/common/futures/FutureJdbiTest.java
@@ -31,7 +31,7 @@ class FutureJdbiTest {
                           return "foo";
                         }))
             .call()
-            .get();
+            .blockAndGet();
     assertThat(result).isEqualTo("foo");
     assertThat(captured).hasValue("cheddar");
   }
@@ -54,7 +54,7 @@ class FutureJdbiTest {
                       captured.set(testKey.get());
                     }))
         .call()
-        .get();
+        .blockAndGet();
     assertThat(captured).hasValue("cheddar");
   }
 

--- a/backend/server/src/main/java/ai/verta/modeldb/experimentRun/subtypes/VersionInputHandler.java
+++ b/backend/server/src/main/java/ai/verta/modeldb/experimentRun/subtypes/VersionInputHandler.java
@@ -264,7 +264,7 @@ public class VersionInputHandler {
           getVersionedInputs(Collections.singleton(entityId))
               .thenApply(
                   existingVersioningEntryMap -> existingVersioningEntryMap.get(entityId), executor)
-              .get();
+              .blockAndGet();
     } catch (Exception e) {
       throw new ModelDBException(e);
     }

--- a/backend/server/src/main/java/ai/verta/modeldb/project/FutureProjectDAO.java
+++ b/backend/server/src/main/java/ai/verta/modeldb/project/FutureProjectDAO.java
@@ -723,7 +723,7 @@ public class FutureProjectDAO {
       workspace = cacheWorkspaceMap.get(projectResource.getWorkspaceId());
     } else {
       try {
-        workspace = uacApisUtil.getWorkspaceById(projectResource.getWorkspaceId()).get();
+        workspace = uacApisUtil.getWorkspaceById(projectResource.getWorkspaceId()).blockAndGet();
       } catch (Exception e) {
         throw new ModelDBException(e);
       }


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context
- SonarQube suggests removing deprecated usages of `.get()`

## Risks and Area of Effect

## Testing
- [x] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

## Reverting
- [ ] Contains Migration - _Do Not Revert_