### PR TITLE
docs: Use ReST auto-numbered footnotes

### DIFF
--- a/client/verta/tests/custom_modules/contexts.py
+++ b/client/verta/tests/custom_modules/contexts.py
@@ -40,11 +40,11 @@ def installable_package(name, dir=None):
     divergent character restrictions.
 
     The package is declared using a ``setup.py`` to reflect today's
-    ecosystem; it could be migrated to ``setup.cfg`` in the future [1]_.
+    ecosystem; it could be migrated to ``setup.cfg`` in the future [#]_.
 
     References
     ----------
-    .. [1] https://setuptools.pypa.io/en/latest/userguide/quickstart.html?highlight=setup.py#transitioning-from-setup-py-to-setup-cfg
+    .. [#] https://setuptools.pypa.io/en/latest/userguide/quickstart.html?highlight=setup.py#transitioning-from-setup-py-to-setup-cfg
 
     """
     if not dir:

--- a/client/verta/verta/_internal_utils/_artifact_utils.py
+++ b/client/verta/verta/_internal_utils/_artifact_utils.py
@@ -563,7 +563,7 @@ def global_read_zipinfo(filename):
     """
     Returns a :class:`zipfile.ZipInfo` with ``644`` permissions.
 
-    :meth:`zipfile.ZipFile.writestr` creates files with ``600`` [1]_ [2]_,
+    :meth:`zipfile.ZipFile.writestr` creates files with ``600`` [#]_ [#]_,
     which means non-owners are unable to read the file, which can be
     problematic for custom modules in deployment.
 
@@ -579,9 +579,9 @@ def global_read_zipinfo(filename):
 
     References
     ----------
-    .. [1] https://github.com/python/cpython/blob/3.9/Lib/zipfile.py#L1791
+    .. [#] https://github.com/python/cpython/blob/3.9/Lib/zipfile.py#L1791
 
-    .. [2] https://bugs.python.org/msg69937
+    .. [#] https://bugs.python.org/msg69937
 
     """
     zip_info = zipfile.ZipInfo(filename)

--- a/client/verta/verta/_internal_utils/_pip_requirements_utils.py
+++ b/client/verta/verta/_internal_utils/_pip_requirements_utils.py
@@ -462,7 +462,7 @@ def remove_local_version_identifier(requirements):
 
     PyTorch in particular adds local build information to its pip environment
     version number during installation. This suffix results in a version
-    specifier that won't be installable from PyPI [1]_ and therefore needs to
+    specifier that won't be installable from PyPI [#]_ and therefore needs to
     be removed for model deployment.
 
     Parameters
@@ -482,7 +482,7 @@ def remove_local_version_identifier(requirements):
 
     References
     ----------
-    .. [1] https://www.python.org/dev/peps/pep-0440/#local-version-identifiers
+    .. [#] https://www.python.org/dev/peps/pep-0440/#local-version-identifiers
 
     """
     for i, req in enumerate(requirements):

--- a/client/verta/verta/dataset/_path.py
+++ b/client/verta/verta/dataset/_path.py
@@ -146,7 +146,7 @@ class Path(_dataset._Dataset):
 
         References
         ----------
-        .. [1] https://en.wikipedia.org/wiki/File_URI_scheme
+        .. [#] https://en.wikipedia.org/wiki/File_URI_scheme
 
         """
         path = _file_utils.remove_prefix(path, "file://")

--- a/client/verta/verta/registry/_verify_io.py
+++ b/client/verta/verta/registry/_verify_io.py
@@ -27,7 +27,7 @@ _DECORATED_FLAG = "_verta_verify_io"
 def verify_io(f):
     """Decorator to typecheck I/O to ensure platform compatibility when deployed.
 
-    Allowed input [1]_ and output [2]_ types are validated by Python's
+    Allowed input [#]_ and output [#]_ types are validated by Python's
     standard ``json`` library.
 
     Examples
@@ -55,8 +55,8 @@ def verify_io(f):
 
     References
     ----------
-    .. [1] https://docs.python.org/3/library/json.html#json-to-py-table
-    .. [2] https://docs.python.org/3/library/json.html#py-to-json-table
+    .. [#] https://docs.python.org/3/library/json.html#json-to-py-table
+    .. [#] https://docs.python.org/3/library/json.html#py-to-json-table
 
     Notes
     -----

--- a/client/verta/verta/registry/_verta_model_base.py
+++ b/client/verta/verta/registry/_verta_model_base.py
@@ -67,8 +67,8 @@ class VertaModelBase(object):
             will be fully compatible with the Verta platform as you iterate
             locally.
 
-            :meth:`predict` must be written to both receive [1]_ and return
-            [2]_ JSON-serializable objects (i.e. mostly basic Python types).
+            :meth:`predict` must be written to both receive [#]_ and return
+            [#]_ JSON-serializable objects (i.e. mostly basic Python types).
 
             For example to work with NumPy arrays, the `input` argument should
             be a Python :class:`list` that would then be passed to
@@ -87,8 +87,8 @@ class VertaModelBase(object):
 
         References
         ----------
-        .. [1] https://docs.python.org/3/library/json.html#json-to-py-table
-        .. [2] https://docs.python.org/3/library/json.html#py-to-json-table
+        .. [#] https://docs.python.org/3/library/json.html#json-to-py-table
+        .. [#] https://docs.python.org/3/library/json.html#py-to-json-table
 
         """
         raise NotImplementedError
@@ -101,7 +101,7 @@ class VertaModelBase(object):
         .. note::
 
             :meth:`batch_predict` must be written to both receive and return
-            ``pandas.DataFrame``\ s [1]_.
+            ``pandas.DataFrame``\ s [#]_.
 
             At this time, your subclass must still implement :meth:`predict`, regardless
             of whether it contains anything meaningful.
@@ -116,7 +116,7 @@ class VertaModelBase(object):
 
         References
         ----------
-        .. [1] https://pandas.pydata.org/docs/reference/frame.html
+        .. [#] https://pandas.pydata.org/docs/reference/frame.html
 
         """
         raise NotImplementedError


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

```
WARNING: Duplicate explicit target name: "1".
ERROR: Duplicate target name, cannot be used as a unique reference: "1".
```

Apparently explicitly numbered footnotes have to be unique in the page 🤷 

Going with

> [use auto-numbered footnotes without names ([#]_)](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#footnotes)

## Risks and Area of Effect

—

## Testing
- [ ] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

Built locally, appears to work

![Screen Shot 2023-03-17 at 3 54 21 PM](https://user-images.githubusercontent.com/96442646/226066151-b4dbd8c2-3338-491d-9a1a-3da8d7902f7c.png)

## Reverting
- [ ] Contains Migration - _Do Not Revert_

Revert this PR.