### PR TITLE
docs: Update Read the Docs config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,6 +1,7 @@
 version: 2
 
 build:
+  os: ubuntu-22.04
   tools:
     python: "3"
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,7 +1,10 @@
 version: 2
 
+build:
+  tools:
+    python: "3"
+
 python:
-  version: 3
   install:
   - method: pip
     path: client/verta


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

`python.version` [is deprecated](https://docs.readthedocs.io/en/stable/config-file/v2.html#python-version) in favor of [`build.tools.python`](https://docs.readthedocs.io/en/stable/config-file/v2.html#build-tools-python).

## Risks and Area of Effect

Only affects our Read the Docs builds.

## Testing
- [ ] Unit test
- [ ] Deployed to dev env
- [x] Other (explain) 

Built this branch in Read the Docs:

![Screen Shot 2023-03-21 at 11 23 07 AM](https://user-images.githubusercontent.com/96442646/226705600-0e4979b3-0c5a-48d6-97c7-0737ad75359d.png)

## Reverting
- [ ] Contains Migration - _Do Not Revert_

Revert this PR.