### PR TITLE
chore: [VRD-728] Apply black to client codebase

### DIFF
--- a/client/verta/verta/_internal_utils/_utils.py
+++ b/client/verta/verta/_internal_utils/_utils.py
@@ -540,7 +540,9 @@ def raise_for_http_error(response: requests.Response):
                 reason = response.text.strip()
 
         if not reason:
-            e.args = (e.args[0] + time_str,) + e.args[1:]  # attach time to error message
+            e.args = (e.args[0] + time_str,) + e.args[
+                1:
+            ]  # attach time to error message
             six.raise_from(e, None)  # use default reason
         else:
             # replicate https://github.com/psf/requests/blob/428f7a/requests/models.py#L954
@@ -550,8 +552,10 @@ def raise_for_http_error(response: requests.Response):
                 cause = "Server"
             else:  # should be impossible here, but sure okay
                 cause = "Unexpected"
-            message = f"{response.status_code} {cause} Error: {reason} " \
-                      f"for url: {response.url}{time_str}"
+            message = (
+                f"{response.status_code} {cause} Error: {reason} "
+                f"for url: {response.url}{time_str}"
+            )
             six.raise_from(requests.HTTPError(message, response=response), None)
 
 
@@ -1412,7 +1416,7 @@ def _multiple_arguments_for_each(argument, name, action, get_keys, overwrite):
                     )
                 )
 
-        for (key, path) in argument:
+        for key, path in argument:
             action(key, path)
 
 

--- a/client/verta/verta/_internal_utils/http_session.py
+++ b/client/verta/verta/_internal_utils/http_session.py
@@ -16,57 +16,60 @@ DEFAULT_STATUS_FORCELIST: Set = {404, 429, 500, 503, 504}
 
 
 def retry_config(
-        max_retries: int = DEFAULT_MAX_RETRIES,
-        status_forcelist: Set[int] = DEFAULT_STATUS_FORCELIST,
-        backoff_factor: float = DEFAULT_BACKOFF_FACTOR,
-        ) -> Retry:
-    """ Return a Retry object with the given parameters """
-    return Retry(total=None, # Let `status` param control retries on failed status codes
-                 connect=0,  # Connection errors should raise an exception immediately
-                 status=max_retries,
-                 other=0,  # Guard against infinite retry loops
-                 status_forcelist=status_forcelist,
-                 backoff_factor=backoff_factor,
-                 allowed_methods=False
-                 )
+    max_retries: int = DEFAULT_MAX_RETRIES,
+    status_forcelist: Set[int] = DEFAULT_STATUS_FORCELIST,
+    backoff_factor: float = DEFAULT_BACKOFF_FACTOR,
+) -> Retry:
+    """Return a Retry object with the given parameters"""
+    return Retry(
+        total=None,  # Let `status` param control retries on failed status codes
+        connect=0,  # Connection errors should raise an exception immediately
+        status=max_retries,
+        other=0,  # Guard against infinite retry loops
+        status_forcelist=status_forcelist,
+        backoff_factor=backoff_factor,
+        allowed_methods=False,
+    )
 
 
 def set_retry_config(
-        session: Session,
-        max_retries: int,
-        status_forcelist: Set[int],
-        backoff_factor: float
-        ) -> Session:
-    """ Creates a new Retry object with the given params and mounts it to
-        the provided session in place of the existing retry config. This
-        allows the DeployedModel.predict method to change the behavior of
-        the Session on the fly without dropping open connections. """
-    current_retry = session.get_adapter('https://').max_retries
-    if (max_retries != current_retry.status
-            or status_forcelist != current_retry.status_forcelist
-            or backoff_factor != current_retry.backoff_factor):
+    session: Session,
+    max_retries: int,
+    status_forcelist: Set[int],
+    backoff_factor: float,
+) -> Session:
+    """Creates a new Retry object with the given params and mounts it to
+    the provided session in place of the existing retry config. This
+    allows the DeployedModel.predict method to change the behavior of
+    the Session on the fly without dropping open connections."""
+    current_retry = session.get_adapter("https://").max_retries
+    if (
+        max_retries != current_retry.status
+        or status_forcelist != current_retry.status_forcelist
+        or backoff_factor != current_retry.backoff_factor
+    ):
         new_retry_config = retry_config(
-            max_retries=max_retries or  DEFAULT_MAX_RETRIES,
+            max_retries=max_retries or DEFAULT_MAX_RETRIES,
             status_forcelist=status_forcelist or DEFAULT_STATUS_FORCELIST,
-            backoff_factor=backoff_factor or DEFAULT_BACKOFF_FACTOR
-            )
+            backoff_factor=backoff_factor or DEFAULT_BACKOFF_FACTOR,
+        )
         adapter = HTTPAdapter(max_retries=new_retry_config)
-        session.mount(prefix='https://', adapter=adapter)
-        session.mount(prefix='http://', adapter=adapter)
+        session.mount(prefix="https://", adapter=adapter)
+        session.mount(prefix="http://", adapter=adapter)
     return session
 
 
 def init_session(retry: Retry) -> Session:
-    """ Instantiate a Session object with a custom Retry configuration mounted
-        via http adapter """
+    """Instantiate a Session object with a custom Retry configuration mounted
+    via http adapter"""
     adapter = HTTPAdapter(max_retries=retry)
     http_session = requests.Session()
     http_session.mount(
-        prefix='https://',
+        prefix="https://",
         adapter=adapter,
-        )
+    )
     http_session.mount(
-        prefix='http://',
+        prefix="http://",
         adapter=adapter,
-        )
+    )
     return http_session

--- a/client/verta/verta/_internal_utils/model_dependencies.py
+++ b/client/verta/verta/_internal_utils/model_dependencies.py
@@ -10,9 +10,9 @@ from ..registry._verta_model_base import VertaModelBase
 
 def class_functions(model_class: Type[VertaModelBase]) -> Set[Callable]:
     """Return a set of all the functions present in the provided class object."""
-    return set([
-        f[1] for f in inspect.getmembers(model_class, predicate=inspect.isfunction)
-    ])
+    return set(
+        [f[1] for f in inspect.getmembers(model_class, predicate=inspect.isfunction)]
+    )
 
 
 def unwrap(func: Callable) -> Callable:
@@ -50,14 +50,14 @@ def modules_in_function_signature(func: Callable) -> Set[str]:
     function's arguments and return type hint."""
     _func = unwrap(func)
     hints = get_type_hints(_func)
-    arg_hints = {k: v for k, v in hints.items() if k != 'return'}
-    return_hint = hints.get('return')
+    arg_hints = {k: v for k, v in hints.items() if k != "return"}
+    return_hint = hints.get("return")
 
     modules = [inspect.getmodule(value) for value in arg_hints.values()]
 
     if return_hint:
         mod = inspect.getmodule(return_hint)
-        if mod.__name__ == 'typing':
+        if mod.__name__ == "typing":
             ret_ann = inspect.signature(_func).return_annotation
             nested_args = ret_ann.__args__
             for a in nested_args:
@@ -65,7 +65,7 @@ def modules_in_function_signature(func: Callable) -> Set[str]:
                     modules.append(inspect.getmodule(a))
         else:
             modules.append(inspect.getmodule(return_hint))
-    return set([m.__name__.split('.')[0] for m in modules])
+    return set([m.__name__.split(".")[0] for m in modules])
 
 
 def class_module_names(model_class: Type[VertaModelBase]) -> Set[str]:

--- a/client/verta/verta/_internal_utils/model_validator.py
+++ b/client/verta/verta/_internal_utils/model_validator.py
@@ -84,9 +84,7 @@ def must_verta(model):
     expected_init_params = list(
         inspect.signature(VertaModelBase.__init__).parameters.keys()
     )
-    init_params = list(
-        inspect.signature(model.__init__).parameters.keys()
-    )
+    init_params = list(inspect.signature(model.__init__).parameters.keys())
     if init_params != expected_init_params:
         raise TypeError(
             "model __init__() parameters must be {},"
@@ -102,9 +100,7 @@ def must_verta(model):
     expected_test_params = list(
         inspect.signature(VertaModelBase.model_test).parameters.keys()
     )
-    test_params = list(
-        inspect.signature(model.model_test).parameters.keys()
-    )
+    test_params = list(inspect.signature(model.model_test).parameters.keys())
     if test_params != expected_test_params:
         raise TypeError(
             "model model_test() parameters must be {},"

--- a/client/verta/verta/_uac/_organization.py
+++ b/client/verta/verta/_uac/_organization.py
@@ -1,6 +1,8 @@
 from ._role import Role
 from verta._protos.public.uac import GroupV2_pb2
 from verta._protos.public.uac import RoleV2_pb2
+
+
 class OrganizationV2:
     def __init__(self, conn, org_id):
         self.conn = conn
@@ -10,13 +12,17 @@ class OrganizationV2:
         response_groups = self.conn.make_proto_request(
             "GET", f"/api/v2/uac-proxy/organization/{self.org_id}/groups"
         )
-        return self.conn.maybe_proto_response(response_groups, GroupV2_pb2.SearchGroups.Response).groups
+        return self.conn.maybe_proto_response(
+            response_groups, GroupV2_pb2.SearchGroups.Response
+        ).groups
 
     def get_roles(self):
         response_roles = self.conn.make_proto_request(
             "GET", f"/api/v2/uac-proxy/organization/{self.org_id}/roles"
         )
-        return self.conn.maybe_proto_response(response_roles, RoleV2_pb2.SearchRolesV2.Response).roles
+        return self.conn.maybe_proto_response(
+            response_roles, RoleV2_pb2.SearchRolesV2.Response
+        ).roles
 
     def create_role(self, name, resource_actions):
         return Role._create(self.conn, name, self.org_id, resource_actions).id

--- a/client/verta/verta/_uac/_role.py
+++ b/client/verta/verta/_uac/_role.py
@@ -16,9 +16,7 @@ class Role(object):
         self.name = msg.name
 
     @classmethod
-    def _create(
-        cls, conn, name, org_id, resource_actions
-    ):
+    def _create(cls, conn, name, org_id, resource_actions):
         Message = RoleV2_pb2.SetRoleV2
         msg = cls._create_msg(name, org_id, resource_actions)
 
@@ -35,8 +33,7 @@ class Role(object):
     @classmethod
     def _create_msg(cls, name, org_id, resource_actions):
         Message = RoleV2_pb2.RoleV2
-        msg = Message(name=name, org_id=org_id,
-                      resource_actions = resource_actions)
+        msg = Message(name=name, org_id=org_id, resource_actions=resource_actions)
         return msg
 
     def delete(self):

--- a/client/verta/verta/_uac/_workspace.py
+++ b/client/verta/verta/_uac/_workspace.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from verta._protos.public.uac import WorkspaceV2_pb2
 
+
 class Workspace(object):
     """
     Object representing a Workspace.
@@ -15,9 +16,7 @@ class Workspace(object):
         self.name = msg.name
 
     @classmethod
-    def _create(
-        cls, conn, name, org_id, permissions
-    ):
+    def _create(cls, conn, name, org_id, permissions):
         Message = WorkspaceV2_pb2.SetWorkspaceV2
         msg = cls._create_msg(name, org_id, permissions)
 
@@ -34,8 +33,7 @@ class Workspace(object):
     @classmethod
     def _create_msg(cls, name, org_id, permissions):
         Message = WorkspaceV2_pb2.WorkspaceV2
-        msg = Message(name=name, org_id=org_id,
-                      permissions = permissions)
+        msg = Message(name=name, org_id=org_id, permissions=permissions)
         return msg
 
     def delete(self):

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -1757,13 +1757,28 @@ class Client(object):
         """
         org = OrganizationV2(self._conn, org_id)
         groups = org.get_groups()
-        all_users_group_id = next(iter(set(group.id for group in groups if group.name == "All Users")))
-        admins_group_id = next(iter(set(group.id for group in groups if group.name == "Admins")))
-        super_user_role_id = next(iter(set(role.id for role in org.get_roles() if role.name == "Super User")))
-        custom_role_id: str = org.create_role(workspace_name + "role", resource_action_groups)
+        all_users_group_id = next(
+            iter(set(group.id for group in groups if group.name == "All Users"))
+        )
+        admins_group_id = next(
+            iter(set(group.id for group in groups if group.name == "Admins"))
+        )
+        super_user_role_id = next(
+            iter(set(role.id for role in org.get_roles() if role.name == "Super User"))
+        )
+        custom_role_id: str = org.create_role(
+            workspace_name + "role", resource_action_groups
+        )
         return Workspace._create(
-            self._conn, workspace_name, org_id, [WorkspaceV2_pb2.Permission(group_id = admins_group_id,
-                                                                       role_id = super_user_role_id),
-                                                 WorkspaceV2_pb2.Permission(group_id = all_users_group_id,
-                                                                       role_id = custom_role_id)])
-
+            self._conn,
+            workspace_name,
+            org_id,
+            [
+                WorkspaceV2_pb2.Permission(
+                    group_id=admins_group_id, role_id=super_user_role_id
+                ),
+                WorkspaceV2_pb2.Permission(
+                    group_id=all_users_group_id, role_id=custom_role_id
+                ),
+            ],
+        )

--- a/client/verta/verta/endpoint/_endpoint.py
+++ b/client/verta/verta/endpoint/_endpoint.py
@@ -837,10 +837,12 @@ class Endpoint(object):
                 "model is not currently deployed (status: {})".format(status)
             )
         details: dict = self._get_json_by_id(self._conn, self.workspace, self.id)
-        if 'full_url' in details.keys():
-            url: str = details['full_url']
+        if "full_url" in details.keys():
+            url: str = details["full_url"]
         else:
-            url: str = f"{self._conn.scheme}://{self._conn.socket}/api/v1/predict{self.path}"
+            url: str = (
+                f"{self._conn.scheme}://{self._conn.socket}/api/v1/predict{self.path}"
+            )
         access_token: str = self.get_access_token()
         return DeployedModel(url, access_token, creds=credentials)
 

--- a/client/verta/verta/endpoint/resources.py
+++ b/client/verta/verta/endpoint/resources.py
@@ -27,7 +27,7 @@ class Resources(object):
         CPU cores allowed for an endpoint's model.
     memory : str
         Memory allowed for an endpoint's model. Expects the same representation as Kubernetes:
-        
+
             You can express memory as a plain integer or as a fixed-point integer
             using one of these suffixes: **E, P, T, G, M, K**. You can also use the
             power-of-two equivalents: **Ei, Pi, Ti, Gi, Mi, Ki**. For example, the

--- a/client/verta/verta/integrations/xgboost/__init__.py
+++ b/client/verta/verta/integrations/xgboost/__init__.py
@@ -39,6 +39,7 @@ class VertaCallback(xgb.callback.TrainingCallback):
         )
 
     """
+
     def __init__(self, run):
         self.run = run
 
@@ -46,7 +47,9 @@ class VertaCallback(xgb.callback.TrainingCallback):
         for data, metric in evals_log.items():
             for metric_name, log in metric.items():
                 try:
-                    self.run.log_observation(f"{data}-{metric_name}", log[-1])  # don't halt execution
+                    self.run.log_observation(
+                        f"{data}-{metric_name}", log[-1]
+                    )  # don't halt execution
                 except:
                     pass
         # TODO: support `xgb.cv()`, which gives `(metric, val, std_dev)` across folds

--- a/client/verta/verta/registry/__init__.py
+++ b/client/verta/verta/registry/__init__.py
@@ -10,11 +10,6 @@ from ._verify_io import verify_io
 from ._verta_model_base import VertaModelBase
 
 documentation.reassign_module(
-    [
-        check_model_dependencies,
-        DockerImage,
-        verify_io,
-        VertaModelBase
-    ],
+    [check_model_dependencies, DockerImage, verify_io, VertaModelBase],
     module_name=__name__,
 )

--- a/client/verta/verta/registry/check_model_dependencies.py
+++ b/client/verta/verta/registry/check_model_dependencies.py
@@ -12,9 +12,9 @@ from ._verta_model_base import VertaModelBase
 
 
 def check_model_dependencies(
-        model_cls: Type[VertaModelBase],
-        environment: Python,
-        raise_for_missing: bool = False,
+    model_cls: Type[VertaModelBase],
+    environment: Python,
+    raise_for_missing: bool = False,
 ) -> bool:
     """Scan for missing dependencies in a model's environment.
 
@@ -72,8 +72,10 @@ def check_model_dependencies(
     }
 
     if missing_packages:
-        error_msg = f"the following packages are required by the model but missing " \
-                    f"from the environment:"
+        error_msg = (
+            f"the following packages are required by the model but missing "
+            f"from the environment:"
+        )
         for m, p in sorted(missing_packages.items(), key=lambda item: item[0]):
             error_msg += f"\n{m} (installed via {p})"
         if raise_for_missing:

--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -42,9 +42,7 @@ from verta.tracking.entities import _deployable_entity
 from .. import lock, DockerImage
 from ..stage_change import _StageChange
 
-from verta.dataset.entities import (
-    _dataset_version
-)
+from verta.dataset.entities import _dataset_version
 
 logger = logging.getLogger(__name__)
 
@@ -126,7 +124,9 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
                 "experiment run id: {}".format(msg.experiment_run_id),
                 # "archived status: {}".format(msg.archived == _CommonCommonService.TernaryEnum.TRUE),
                 "artifact keys: {}".format(sorted(artifact_keys)),
-                "dataset version keys: {}".format(sorted(dataset.key for dataset in msg.datasets)),
+                "dataset version keys: {}".format(
+                    sorted(dataset.key for dataset in msg.datasets)
+                ),
                 "code version keys: {}".format(sorted(msg.code_blob_map.keys())),
             )
         )

--- a/client/verta/verta/runtime.py
+++ b/client/verta/verta/runtime.py
@@ -20,7 +20,7 @@ def _get_thread_logs() -> Dict[str, Any]:
     """
     Return the 'logs' attribute of the thread-local variable.
     """
-    if hasattr(_THREAD, 'logs'):
+    if hasattr(_THREAD, "logs"):
         return _THREAD.logs
     return {}
 
@@ -37,14 +37,14 @@ def _delete_thread_logs() -> None:
     """
     Drop the `log` attribute from the thread local variable.
     """
-    delattr(_THREAD, 'logs')
+    delattr(_THREAD, "logs")
 
 
 def _get_validate_flag() -> bool:
     """
     Return the 'validate' attribute of the thread local variable.
     """
-    if hasattr(_THREAD, 'validate'):
+    if hasattr(_THREAD, "validate"):
         return _THREAD.validate
     return False
 
@@ -61,7 +61,7 @@ def _delete_validate_flag() -> None:
     """
     Drop the `validate` attribute from the thread local variable.
     """
-    delattr(_THREAD, 'validate')
+    delattr(_THREAD, "validate")
 
 
 def _validate_json(value: Any) -> str:
@@ -75,20 +75,21 @@ def _validate_json(value: Any) -> str:
         raise
 
 
-def _validate_s3(
-        value: str,
-        pattern: re.Pattern = _S3_REGEX
-    ) -> None:
+def _validate_s3(value: str, pattern: re.Pattern = _S3_REGEX) -> None:
     """
     Check the provided value for any special characters that would
     violate Amazon S3 object key naming rules. Raise ValueError if any
     are found.
     """
     if len(value) > 100:
-        raise ValueError(" provided key value must be 100 characters or less in length.")
+        raise ValueError(
+            " provided key value must be 100 characters or less in length."
+        )
     if not pattern.match(value):
-        raise ValueError(f" provided value \"{value}\" contains non-alphanumeric "
-                         f"characters. (dashes and underscores permitted)")
+        raise ValueError(
+            f' provided value "{value}" contains non-alphanumeric '
+            f"characters. (dashes and underscores permitted)"
+        )
 
 
 def log(key: str, value: Any) -> None:
@@ -153,7 +154,7 @@ def log(key: str, value: Any) -> None:
                 return embedding
 
     """
-    if not hasattr(_THREAD, 'logs'):
+    if not hasattr(_THREAD, "logs"):
         raise RuntimeError(
             "no active verta.runtime.context() found; please ensure calls to"
             " verta.runtime.log() are made within your model's predict()"
@@ -164,7 +165,7 @@ def log(key: str, value: Any) -> None:
     _validate_s3(key)
     local_logs: Dict[str, Any] = _get_thread_logs()
     if key in local_logs.keys():
-        raise ValueError(f" cannot overwrite existing value for \"{key}\"")
+        raise ValueError(f' cannot overwrite existing value for "{key}"')
     local_logs.update({key: value})
 
 
@@ -209,6 +210,7 @@ class context:
         print(json.dumps(ctx.logs()))
 
     """
+
     def __init__(self, validate: Optional[bool] = False):
         self._validate = validate
         self._logs_dict = dict()
@@ -217,7 +219,7 @@ class context:
         """
         Ensure empty logs to start and set validation flag.
         """
-        if hasattr(_THREAD, 'logs'):  # If logs attribute exists already.
+        if hasattr(_THREAD, "logs"):  # If logs attribute exists already.
             raise RuntimeError(
                 "nesting an instance of verta.runtime.context() inside"
                 " an existing instance is not supported."
@@ -246,4 +248,4 @@ class context:
         logs : Dict[str, Any]
             Dictionary of logs collected within this context manager.
         """
-        return  self._logs_dict or _get_thread_logs()
+        return self._logs_dict or _get_thread_logs()

--- a/client/verta/verta/tracking/entities/_entity.py
+++ b/client/verta/verta/tracking/entities/_entity.py
@@ -216,7 +216,7 @@ class _ModelDBEntity(object):
         tags=None,
         attrs=None,
         date_created=None,
-        **kwargs
+        **kwargs,
     ):  # recommended params
         raise NotImplementedError
 

--- a/client/verta/verta/tracking/entities/_experimentrun.py
+++ b/client/verta/verta/tracking/entities/_experimentrun.py
@@ -16,7 +16,10 @@ import warnings
 import requests
 
 from verta._protos.public.common import CommonService_pb2 as _CommonCommonService
-from verta._protos.public.modeldb import CommonService_pb2 as _CommonService, ProjectService_pb2
+from verta._protos.public.modeldb import (
+    CommonService_pb2 as _CommonService,
+    ProjectService_pb2,
+)
 from verta._protos.public.modeldb import (
     ExperimentRunService_pb2 as _ExperimentRunService,
 )
@@ -116,7 +119,7 @@ class ExperimentRun(_DeployableEntity):
     @property
     def workspace(self):
         self._refresh_cache()
-        
+
         msg = ProjectService_pb2.GetProjectById(id=self._msg.project_id)
         url = "/api/v1/modeldb/project/getProjectById"
         response = self._conn.make_proto_request("GET", url, params=msg)
@@ -124,7 +127,9 @@ class ExperimentRun(_DeployableEntity):
         proj_proto = response.project
 
         if proj_proto.workspace_service_id:
-            return self._conn.get_workspace_name_from_id(proj_proto.workspace_service_id)
+            return self._conn.get_workspace_name_from_id(
+                proj_proto.workspace_service_id
+            )
         else:
             return self._conn._OSS_DEFAULT_WORKSPACE
 


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

Ran

```zsh
cd ~/Documents/modeldb \
    && git checkout main \
    && git reset --hard \
    && git pull \
    && git checkout -b liu/black \
    && black client/verta/verta \
    && git commit -am "chore: [VRD-728] Apply black to client codebase" \
    && git push origin
```

## Risks and Area of Effect

None; this is the purest of reformats. And if it introduces functional changes, then `black` would have serious issues that go far beyond this PR.

We also have at least a week before the next client release to catch any issues.

And we don't have any open client PRs since February; we shouldn't have to contend with any major merge conflicts.

## Testing
- [ ] Unit test
- [ ] Deployed to dev env
- [x] Other (explain) 

If linting passes, I think we're good.

## Reverting
- [ ] Contains Migration - _Do Not Revert_

Revert this PR.

[VRD-728]: https://vertaai.atlassian.net/browse/VRD-728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ