### PR TITLE
fix: Avoid shadowing check_model_dependencies() fn

### DIFF
--- a/client/verta/verta/registry/entities/_model.py
+++ b/client/verta/verta/registry/entities/_model.py
@@ -3,7 +3,6 @@
 from __future__ import print_function
 
 from verta._internal_utils._utils import check_unnecessary_params_warning
-from verta.registry import check_model_dependencies
 from verta.tracking import _Context
 from verta.tracking.entities import _entity
 from verta._internal_utils import _artifact_utils, _utils, arg_handler, model_validator
@@ -16,6 +15,7 @@ from ._modelversion import RegisteredModelVersion
 from ._modelversions import RegisteredModelVersions
 from .. import task_type as task_type_module
 from .. import data_type as data_type_module
+from .. import check_model_dependencies as check_model_dependencies_fn
 
 
 class RegisteredModel(_entity._ModelDBEntity):
@@ -441,7 +441,7 @@ class RegisteredModel(_entity._ModelDBEntity):
         model_validator.must_verta(model_cls)
 
         if check_model_dependencies:
-            check_model_dependencies(
+            check_model_dependencies_fn(
                 model_cls=model_cls, environment=environment, raise_for_missing=True
             )
 


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

Unhiding `check_model_dependencies` (https://github.com/VertaAI/modeldb/pull/3676) resulted in an identifier collision in `create_standard_model()`

I'm surprised pylint didn't catch this 🤔 or maybe it was just a warning rather than an error.

## Risks and Area of Effect

—

## Testing
- [x] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

Ran locally in Python 3.10:

### Before

```
============================= test session starts ==============================
platform darwin -- Python 3.10.6, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/miliu/Documents/modeldb/client/verta/tests, configfile: pytest.ini
plugins: forked-1.4.0, xdist-3.1.0, typeguard-2.13.3, hypothesis-6.67.1
collected 1 item

registry/test_standard_model.py F                                        [100%]

=================================== FAILURES ===================================
____ TestStandardModels.test_dependency_checking[VertaModelWithDependency] _____

self = <tests.registry.test_standard_model.TestStandardModels object at 0x131f8b1f0>
registered_model = name: Model 98522167993245617744
url: https://dev.verta.ai/Default/registry/18000
time created: 2023-03-27 08:54:16.861000
time updated: 2023-03-27 08:54:16.861000
description: 
labels: []
id: 18000
model = <class 'tests.models.standard_models.dependency_models.<locals>.VertaModelWithDependency'>

    @pytest.mark.parametrize("model", dependency_verta_models)
    def test_dependency_checking(self, registered_model, model):
        with pytest.raises(RuntimeError) as err:
>           registered_model.create_standard_model(
                model, Python([]), check_model_dependencies=True
            )

registry/test_standard_model.py:311: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
    
        if check_model_dependencies:
>           check_model_dependencies(
                model_cls=model_cls, environment=environment, raise_for_missing=True
            )
E           TypeError: 'bool' object is not callable

../verta/registry/entities/_model.py:444: TypeError
=========================== short test summary info ============================
FAILED registry/test_standard_model.py::TestStandardModels::test_dependency_checking[VertaModelWithDependency]
======================== 1 failed, 3 warnings in 9.09s =========================
```

### After

```
============================= test session starts ==============================
platform darwin -- Python 3.10.6, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/miliu/Documents/modeldb/client/verta/tests, configfile: pytest.ini
plugins: forked-1.4.0, xdist-3.1.0, typeguard-2.13.3, hypothesis-6.67.1
collected 1 item

registry/test_standard_model.py .                                        [100%]

======================== 1 passed, 3 warnings in 9.63s =========================
```

[`unit_tests/registry/test_check_model_dependencies.py`](https://github.com/VertaAI/modeldb/pull/3676/files#diff-880776baa0e0091193c3af945c42ce04c2d76076e57604601efa82ebb0d860ba) also passes.

## Reverting
- [ ] Contains Migration - _Do Not Revert_

Revert this PR.