### PR TITLE
chore: Remove endpoint date_updated

### DIFF
--- a/client/verta/tests/test_cli/test_endpoint.py
+++ b/client/verta/tests/test_cli/test_endpoint.py
@@ -104,7 +104,6 @@ class TestGet:
         assert in_output("curl: <endpoint not deployed>")
         assert in_output("status")
         assert in_output("date created")
-        assert in_output("date updated")
         assert in_output("stage's date created")
         assert in_output("stage's date updated")
         assert in_output("components")

--- a/client/verta/tests/test_cli/test_endpoint.py
+++ b/client/verta/tests/test_cli/test_endpoint.py
@@ -95,16 +95,19 @@ class TestGet:
             ["deployment", "get", "endpoint", path],
         )
         assert not result.exception
-        assert "path: {}".format(endpoint.path) in result.output
-        assert "id: {}".format(endpoint.id) in result.output
-        assert "curl: <endpoint not deployed>" in result.output
 
-        assert "status" in result.output
-        assert "date created" in result.output
-        assert "date updated" in result.output
-        assert "stage's date created" in result.output
-        assert "stage's date updated" in result.output
-        assert "components" in result.output
+        def in_output(s: str) -> bool:
+            return any(line.startswith(s) for line in result.output.splitlines())
+
+        assert in_output("path: {}".format(endpoint.path))
+        assert in_output("id: {}".format(endpoint.id))
+        assert in_output("curl: <endpoint not deployed>")
+        assert in_output("status")
+        assert in_output("date created")
+        assert in_output("date updated")
+        assert in_output("stage's date created")
+        assert in_output("stage's date updated")
+        assert in_output("components")
 
         updated_status = endpoint.update(experiment_run, DirectUpdateStrategy(), True)
         result = runner.invoke(

--- a/client/verta/tests/test_cli/test_endpoint.py
+++ b/client/verta/tests/test_cli/test_endpoint.py
@@ -99,8 +99,8 @@ class TestGet:
         def in_output(s: str) -> bool:
             return any(line.startswith(s) for line in result.output.splitlines())
 
-        assert in_output("path: {}".format(endpoint.path))
-        assert in_output("id: {}".format(endpoint.id))
+        assert in_output(f"path: {endpoint.path}")
+        assert in_output(f"id: {endpoint.id}")
         assert in_output("curl: <endpoint not deployed>")
         assert in_output("status")
         assert in_output("date created")
@@ -109,14 +109,12 @@ class TestGet:
         assert in_output("stage's date updated")
         assert in_output("components")
 
-        updated_status = endpoint.update(experiment_run, DirectUpdateStrategy(), True)
+        endpoint.update(experiment_run, DirectUpdateStrategy(), True)
         result = runner.invoke(
             cli,
             ["deployment", "get", "endpoint", path],
         )
-        assert (
-            "curl: {}".format(endpoint.get_deployed_model().get_curl()) in result.output
-        )
+        assert f"curl: {endpoint.get_deployed_model().get_curl()}" in result.output
 
 
 class TestUpdate:

--- a/client/verta/tests/test_endpoint/test_endpoint.py
+++ b/client/verta/tests/test_endpoint/test_endpoint.py
@@ -136,19 +136,20 @@ class TestEndpoint:
         created_entities.append(endpoint)
         str_repr = repr(endpoint)
 
-        assert "path: {}".format(endpoint.path) in str_repr
-        assert endpoint.url in str_repr
-        assert "url" in str_repr
-        assert "id: {}".format(endpoint.id) in str_repr
-        assert "curl: <endpoint not deployed>" in str_repr
+        def in_repr(s: str) -> bool:
+            return any(line.startswith(s) for line in str_repr.splitlines())
 
-        # these fields might have changed:
-        assert "status" in str_repr
-        assert "date created" in str_repr
-        assert "date updated" in str_repr
-        assert "stage's date created" in str_repr
-        assert "stage's date updated" in str_repr
-        assert "components" in str_repr
+        assert in_repr("path: {}".format(endpoint.path))
+        assert in_repr(endpoint.url)
+        assert in_repr("url")
+        assert in_repr("id: {}".format(endpoint.id))
+        assert in_repr("curl: <endpoint not deployed>")
+        assert in_repr("status")
+        assert in_repr("date created")
+        assert in_repr("date updated")
+        assert in_repr("stage's date created")
+        assert in_repr("stage's date updated")
+        assert in_repr("components")
 
         endpoint.update(experiment_run, DirectUpdateStrategy(), True)
         str_repr = repr(endpoint)

--- a/client/verta/tests/test_endpoint/test_endpoint.py
+++ b/client/verta/tests/test_endpoint/test_endpoint.py
@@ -139,10 +139,9 @@ class TestEndpoint:
         def in_repr(s: str) -> bool:
             return any(line.startswith(s) for line in str_repr.splitlines())
 
-        assert in_repr("path: {}".format(endpoint.path))
-        assert in_repr(endpoint.url)
-        assert in_repr("url")
-        assert in_repr("id: {}".format(endpoint.id))
+        assert in_repr(f"path: {endpoint.path}")
+        assert in_repr(f"url: {endpoint.url}")
+        assert in_repr(f"id: {endpoint.id}")
         assert in_repr("curl: <endpoint not deployed>")
         assert in_repr("status")
         assert in_repr("date created")
@@ -153,7 +152,7 @@ class TestEndpoint:
 
         endpoint.update(experiment_run, DirectUpdateStrategy(), True)
         str_repr = repr(endpoint)
-        assert "curl: {}".format(endpoint.get_deployed_model().get_curl()) in str_repr
+        assert f"curl: {endpoint.get_deployed_model().get_curl()}" in str_repr
 
     def test_download_manifest(self, client, in_tempdir):
         download_to_path = "manifest.yaml"

--- a/client/verta/tests/test_endpoint/test_endpoint.py
+++ b/client/verta/tests/test_endpoint/test_endpoint.py
@@ -145,7 +145,6 @@ class TestEndpoint:
         assert in_repr("curl: <endpoint not deployed>")
         assert in_repr("status")
         assert in_repr("date created")
-        assert in_repr("date updated")
         assert in_repr("stage's date created")
         assert in_repr("stage's date updated")
         assert in_repr("components")

--- a/client/verta/verta/_cli/deployment/list.py
+++ b/client/verta/verta/_cli/deployment/list.py
@@ -28,7 +28,7 @@ def lst_endpoint(workspace):
     endpoints = client.endpoints
     if workspace:
         endpoints = endpoints.with_workspace(workspace)
-    table_data = [["PATH", "ID", "DATE UPDATED"]] + list(
+    table_data = [["PATH", "ID", "DATE CREATED"]] + list(
         sorted(
             map(lambda endpoint: endpoint._get_info_list_by_id(), endpoints),
             key=lambda data: data[0],

--- a/client/verta/verta/endpoint/_endpoint.py
+++ b/client/verta/verta/endpoint/_endpoint.py
@@ -76,7 +76,6 @@ class Endpoint(object):
                 "status: {}".format(status["status"]),
                 "Kafka settings: {}".format(self.kafka_settings),
                 "date created: {}".format(data["date_created"]),
-                "date updated: {}".format(data["date_updated"]),
                 "stage's date created: {}".format(status["date_created"]),
                 "stage's date updated: {}".format(status["date_updated"]),
                 "components: {}".format(json.dumps(status["components"], indent=4)),

--- a/client/verta/verta/endpoint/_endpoint.py
+++ b/client/verta/verta/endpoint/_endpoint.py
@@ -125,8 +125,8 @@ class Endpoint(object):
     def _path(self, data):
         return data["creator_request"]["path"]
 
-    def _date_updated(self, data):
-        return data["date_updated"]
+    def _date_created(self, data):
+        return data["date_created"]
 
     @classmethod
     def _create(
@@ -201,7 +201,7 @@ class Endpoint(object):
 
     def _get_info_list_by_id(self):
         data = Endpoint._get_json_by_id(self._conn, self.workspace, self.id)
-        return [self._path(data), str(self.id), self._date_updated(data)]
+        return [self._path(data), str(self.id), self._date_created(data)]
 
     @classmethod
     def _get_json_by_id(cls, conn, workspace, id):


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

It currently provides no user-facing value [[Slack](https://vertaai.slack.com/archives/CJ2MM54Q3/p1680195224383989?thread_ts=1680035708.529379&cid=CJ2MM54Q3)].

## Risks and Area of Effect

Low; I'm skeptical anyone was even paying it any mind through the client.

## Testing
- [x] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

Oops not a unit test, but

```zsh
% pytest test_cli/test_endpoint.py::TestGet::test_get test_endpoint/test_endpoint.py::TestEndpoint::test_repr
==================================================== test session starts ====================================================
platform darwin -- Python 3.10.6, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/miliu/Documents/modeldb/client/verta/tests, configfile: pytest.ini
plugins: forked-1.4.0, xdist-3.1.0, typeguard-2.13.3, hypothesis-6.67.1
collected 2 items                                                                                                           

test_cli/test_endpoint.py .                                                                                           [ 50%]
test_endpoint/test_endpoint.py .                                                                                      [100%]

========================================= 2 passed, 4 warnings in 373.39s (0:06:13) =========================================
```

## Reverting
- [ ] Contains Migration - _Do Not Revert_