### PR TITLE
feature: [VRD-768] Add client utility functions for Kafka

### DIFF
--- a/client/verta/tests/unit_tests/conftest.py
+++ b/client/verta/tests/unit_tests/conftest.py
@@ -6,6 +6,7 @@ import os
 from unittest.mock import patch
 
 import pytest
+import responses
 
 from verta._internal_utils._utils import Connection, Configuration
 from verta.credentials import EmailCredentials
@@ -27,3 +28,9 @@ def mock_conn() -> Connection:
 def mock_config() -> Configuration:
     """ Return a mocked object of the _internal_utils._utils.Configuration class for use in tests """
     return Configuration(use_git=False, debug=False)
+
+
+@pytest.fixture
+def mocked_responses():
+    with responses.RequestsMock() as rsps:
+        yield rsps

--- a/client/verta/tests/unit_tests/internal_utils/test_kafka_utils.py
+++ b/client/verta/tests/unit_tests/internal_utils/test_kafka_utils.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+
+"""Unit tests for Kafka utilities."""
+
+from typing import Any, Dict, List
+
+import pytest
+
+from verta._internal_utils import kafka
+
+
+@pytest.fixture
+def mock_kafka_configs_response() -> Dict[str, Any]:
+    """
+    Provide mocked API result from `api/v1/uac-proxy/system_admin/listKafkaConfiguration`
+    with a single Kafka configuration.
+    """
+    return {
+        "configurations": [
+            {
+                "id": "1232abcdefg4-567h-891i-0jkl-1m1n1o2131pq",
+                "kerberos": {
+                    "enabled": True,
+                    "conf": (
+                        "[libdefaults]\ndefault_realm ="
+                        " EXAMPLE.COM\n\n[realms]\nEXAMPLE.COM"
+                        " = {\n    kdc_ports = 12,345\n    kadmind_port = 123\n    kdc ="
+                        " testing--kafka-server-X.integrations--kafka-server-headless.ci.svc.cluster.local\n"
+                        "    admin_server ="
+                        " testing--kafka-server-X.integrations--kafka-server-headless.ci.svc.cluster.local\n}"
+                    ),
+                    "keytab": "SLG45KJlksajdfglakjWlskadfj098lkjakdfjl1k3kjflakdj-lakf+alkqfvmLPWZNVTdfS84UHads3dlkfj97alfkj!lakdfjlkaj8fg=",
+                    "client_name": "test-kafka-client_name",
+                    "service_name": "test-kafka-utils",
+                },
+                "brokerAddresses": "integrations--kafka-X.integrations--kafka-headless.ci.svc.cluster.local:00001",
+                "enabled": True,
+                "name": "Test Kafka Name",
+            }
+        ]
+    }
+
+
+@pytest.fixture
+def mock_kafka_topics() -> List[str]:
+    """Provide a mock API response from `api/v1/deployment/list/kafka-topics`."""
+    return ["test-topic-1", "test-topic-2", "test-topic-3"]
+
+
+def test_list_kafka_configurations(
+    mocked_responses, mock_conn, mock_kafka_configs_response
+):
+    """Verify that list_kafka_configurations function makes the expected calls
+    and handles results correctly.
+    """
+    url = "https://test_socket/api/v1/uac-proxy/system_admin/listKafkaConfiguration"
+    mocked_responses.get(url=url, status=200, json=mock_kafka_configs_response)
+    config = kafka.list_kafka_configurations(mock_conn)
+    mocked_responses.assert_call_count(url, 1)
+    assert config == mock_kafka_configs_response["configurations"]
+
+
+def test_format_kafka_config_for_topic_search(mock_kafka_configs_response) -> None:
+    """Verify that format_kafka_config_for_topic_search function formats the
+    mocked kafka config into the expected results.
+    """
+    mock_config = mock_kafka_configs_response["configurations"][0]
+    config = kafka.format_kafka_config_for_topic_search(mock_config)
+    assert config == {
+        "broker_addresses": [
+            "integrations--kafka-X.integrations--kafka-headless.ci.svc.cluster.local:00001"
+        ],
+        "kerberos": {
+            "enabled": True,
+            "conf": (
+                "[libdefaults]\ndefault_realm = EXAMPLE.COM\n\n[realms]\nEXAMPLE.COM"
+                " = {\n    kdc_ports = 12,345\n    kadmind_port = 123\n    kdc ="
+                " testing--kafka-server-X.integrations--kafka-server-headless.ci.svc.cluster.local\n"
+                "    admin_server ="
+                " testing--kafka-server-X.integrations--kafka-server-headless.ci.svc.cluster.local\n}"
+            ),
+            "keytab": "SLG45KJlksajdfglakjWlskadfj098lkjakdfjl1k3kjflakdj-lakf+alkqfvmLPWZNVTdfS84UHads3dlkfj97alfkj!lakdfjlkaj8fg=",
+            "client_name": "test-kafka-client_name",
+            "service_name": "test-kafka-utils",
+        },
+    }
+
+
+def test_list_kafka_topics(
+    mocked_responses, mock_conn, mock_kafka_configs_response, mock_kafka_topics
+) -> None:
+    """Verify that list_kafka_topics function makes the expected calls
+    and handles results correctly.
+    """
+    url = "https://test_socket/api/v1/deployment/list/kafka-topics"
+    mocked_responses.post(url=url, status=200, json=mock_kafka_topics)
+    topics = kafka.list_kafka_topics(
+        conn=mock_conn, kafka_config=mock_kafka_configs_response["configurations"][0]
+    )
+    mocked_responses.assert_call_count(url, 1)
+    assert topics == ["test-topic-1", "test-topic-2", "test-topic-3"]

--- a/client/verta/tests/unit_tests/internal_utils/test_kafka_utils.py
+++ b/client/verta/tests/unit_tests/internal_utils/test_kafka_utils.py
@@ -48,7 +48,7 @@ def test_list_kafka_configurations(
     """Verify that list_kafka_configurations function makes the expected calls
     and handles results correctly.
     """
-    url = "https://test_socket/api/v1/uac-proxy/system_admin/listKafkaConfiguration"
+    url = f"{mock_conn.scheme}://{mock_conn.socket}/api/v1/uac-proxy/system_admin/listKafkaConfiguration"
     mocked_responses.get(url=url, status=200, json=mock_kafka_configs_response)
     config = kafka.list_kafka_configurations(mock_conn)
     mocked_responses.assert_call_count(url, 1)

--- a/client/verta/tests/unit_tests/internal_utils/test_kafka_utils.py
+++ b/client/verta/tests/unit_tests/internal_utils/test_kafka_utils.py
@@ -67,22 +67,8 @@ def test_format_kafka_config_for_topic_search(mock_kafka_configs_response) -> No
     mock_config = mock_kafka_configs_response["configurations"][0]
     config = kafka.format_kafka_config_for_topic_search(mock_config)
     assert config == {
-        "broker_addresses": [
-            "integrations--kafka-X.integrations--kafka-headless.ci.svc.cluster.local:00001"
-        ],
-        "kerberos": {
-            "enabled": True,
-            "conf": (
-                "[libdefaults]\ndefault_realm = EXAMPLE.COM\n\n[realms]\nEXAMPLE.COM"
-                " = {\n    kdc_ports = 12,345\n    kadmind_port = 123\n    kdc ="
-                " testing--kafka-server-X.integrations--kafka-server-headless.ci.svc.cluster.local\n"
-                "    admin_server ="
-                " testing--kafka-server-X.integrations--kafka-server-headless.ci.svc.cluster.local\n}"
-            ),
-            "keytab": "SLG45KJlksajdfglakjWlskadfj098lkjakdfjl1k3kjflakdj-lakf+alkqfvmLPWZNVTdfS84UHads3dlkfj97alfkj!lakdfjlkaj8fg=",
-            "client_name": "test-kafka-client_name",
-            "service_name": "test-kafka-utils",
-        },
+        "broker_addresses": [mock_config["brokerAddresses"]],
+        "kerberos": mock_config["kerberos"],
     }
 
 

--- a/client/verta/tests/unit_tests/internal_utils/test_kafka_utils.py
+++ b/client/verta/tests/unit_tests/internal_utils/test_kafka_utils.py
@@ -98,4 +98,4 @@ def test_list_kafka_topics(
         conn=mock_conn, kafka_config=mock_kafka_configs_response["configurations"][0]
     )
     mocked_responses.assert_call_count(url, 1)
-    assert topics == ["test-topic-1", "test-topic-2", "test-topic-3"]
+    assert topics == mock_kafka_topics

--- a/client/verta/tests/unit_tests/internal_utils/test_kafka_utils.py
+++ b/client/verta/tests/unit_tests/internal_utils/test_kafka_utils.py
@@ -22,18 +22,13 @@ def mock_kafka_configs_response() -> Dict[str, Any]:
                 "kerberos": {
                     "enabled": True,
                     "conf": (
-                        "[libdefaults]\ndefault_realm ="
-                        " EXAMPLE.COM\n\n[realms]\nEXAMPLE.COM"
-                        " = {\n    kdc_ports = 12,345\n    kadmind_port = 123\n    kdc ="
-                        " testing--kafka-server-X.integrations--kafka-server-headless.ci.svc.cluster.local\n"
-                        "    admin_server ="
-                        " testing--kafka-server-X.integrations--kafka-server-headless.ci.svc.cluster.local\n}"
+                        "kerberos.example.com"
                     ),
-                    "keytab": "SLG45KJlksajdfglakjWlskadfj098lkjakdfjl1k3kjflakdj-lakf+alkqfvmLPWZNVTdfS84UHads3dlkfj97alfkj!lakdfjlkaj8fg=",
+                    "keytab": "test-key-tab=",
                     "client_name": "test-kafka-client_name",
                     "service_name": "test-kafka-utils",
                 },
-                "brokerAddresses": "integrations--kafka-X.integrations--kafka-headless.ci.svc.cluster.local:00001",
+                "brokerAddresses": "kerberos.example.com",
                 "enabled": True,
                 "name": "Test Kafka Name",
             }

--- a/client/verta/tests/unit_tests/test_deployed_model.py
+++ b/client/verta/tests/unit_tests/test_deployed_model.py
@@ -35,12 +35,6 @@ MOCK_SESSION: Session = http_session.init_session(retry=MOCK_RETRY)
 VERTA_CLASS = 'verta.deployment._deployedmodel'
 
 
-@pytest.fixture
-def mocked_responses():
-    with responses.RequestsMock() as rsps:
-        yield rsps
-
-
 @patch.dict(
     os.environ,
     {'VERTA_EMAIL': 'test_email@verta.ai',

--- a/client/verta/verta/_internal_utils/kafka.py
+++ b/client/verta/verta/_internal_utils/kafka.py
@@ -19,7 +19,7 @@ def list_kafka_configurations(conn: _utils.Connection) -> List[Dict[str, Any]]:
         conn,
     )
     _utils.raise_for_http_error(response)
-    return response.json().get("configurations", [{}])
+    return response.json().get("configurations", [])
 
 
 def format_kafka_config_for_topic_search(config: Dict[str, Any]) -> Dict[str, Any]:

--- a/client/verta/verta/_internal_utils/kafka.py
+++ b/client/verta/verta/_internal_utils/kafka.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+
+"""Utilities for working with Kafka."""
+
+from typing import Any, Dict, List
+
+from verta._internal_utils import _utils
+
+
+def list_kafka_configurations(conn: _utils.Connection) -> List[Dict[str, Any]]:
+    """Make an HTTP call to fetch a list of Kafka configurations. If no
+    configurations exist, an empty dict is returned by the API.  In that
+    case this function wraps one in a list and returns it to maintain
+    type consistency.
+    """
+    response = _utils.make_request(
+        "GET",
+        f"{conn.scheme}://{conn.socket}/api/v1/uac-proxy/system_admin/listKafkaConfiguration",
+        conn,
+    )
+    _utils.raise_for_http_error(response)
+    return response.json().get("configurations", [{}])
+
+
+def format_kafka_config_for_topic_search(config: Dict[str, Any]) -> Dict[str, Any]:
+    """Extract and format relevant data from a Kafka configuration for use
+    with the `deployment/list//kafka-topics` API.
+
+    The `kerberos` object is passed through unaltered, but `brokerAddresses`
+    is altered for compatibility with the `/kafka-topics` API:
+        - Key name is changed to snake case instead of camel case.
+        - Type is converted `List[str]` instead of `str`
+    """
+    brokers: str = config.get("brokerAddresses", "")
+    kerberos: Dict[str, Any] = config.get("kerberos", {})
+    return {"broker_addresses": [brokers], "kerberos": kerberos}
+
+
+def list_kafka_topics(
+    conn: _utils.Connection, kafka_config: Dict[str, Any]
+) -> List[str]:
+    """Make an HTTP call to fetch a list of Kafka topics related to the given config."""
+    response = _utils.make_request(
+        "POST",
+        f"{conn.scheme}://{conn.socket}/api/v1/deployment/list/kafka-topics",
+        conn,
+        json=format_kafka_config_for_topic_search(kafka_config),
+    )
+    _utils.raise_for_http_error(response)
+    return response.json()

--- a/client/verta/verta/_internal_utils/kafka.py
+++ b/client/verta/verta/_internal_utils/kafka.py
@@ -8,7 +8,7 @@ from verta._internal_utils import _utils
 
 
 def list_kafka_configurations(conn: _utils.Connection) -> List[Dict[str, Any]]:
-    """Make an HTTP call to fetch a list of Kafka configurations. If no
+    """Make an HTTP call to fetch a dict of Kafka configurations. If no
     configurations exist, an empty dict is returned by the API.  In that
     case this function wraps one in a list and returns it to maintain
     type consistency.

--- a/client/verta/verta/_internal_utils/kafka.py
+++ b/client/verta/verta/_internal_utils/kafka.py
@@ -24,7 +24,7 @@ def list_kafka_configurations(conn: _utils.Connection) -> List[Dict[str, Any]]:
 
 def format_kafka_config_for_topic_search(config: Dict[str, Any]) -> Dict[str, Any]:
     """Extract and format relevant data from a Kafka configuration for use
-    with the `deployment/list//kafka-topics` API.
+    with the `deployment/list/kafka-topics` API.
 
     The `kerberos` object is passed through unaltered, but `brokerAddresses`
     is altered for compatibility with the `/kafka-topics` API:


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context
Adds new utility functions to allow the fetching of Kafka configurations and valid Kafka topics to assist users in configuration of the Kafka integration and endpoints.  This PR is the 

## Risks and Area of Effect
Based on testing in my dev env, it seems that the following error is returned BOTH when no Kafka config exists and when a config exists but the user performing the search is not a system admin.  We'll need to sort out the permissions issue there.
```
requests.exceptions.HTTPError: 400 Client Error: Kafka validation failed (check broker addresses?): : unable to dial: dial tcp :9092: connect: connection refused for url: https://ewagner.dev.verta.ai/api/v1/deployment/list/kafka-topics at <TIME>
```

## Testing
- [X] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

<img width="636" alt="Screen Shot 2023-03-30 at 7 44 24 PM" src="https://user-images.githubusercontent.com/114943931/229001713-5de30b80-11f6-4491-9c50-675636bf9851.png">



## Reverting
- [ ] Contains Migration - _Do Not Revert_