### PR TITLE
test: [VRD-768] Convert kafka utils unit tests to property tests

### DIFF
--- a/client/verta/tests/unit_tests/internal_utils/test_kafka_utils.py
+++ b/client/verta/tests/unit_tests/internal_utils/test_kafka_utils.py
@@ -2,64 +2,57 @@
 
 """Unit tests for Kafka utilities."""
 
-from typing import Any, Dict, List
+from typing import Any, Dict
 
-import pytest
+from hypothesis import given, HealthCheck, settings, strategies as st
 
 from verta._internal_utils import kafka
 
 
-@pytest.fixture
-def mock_kafka_configs_response() -> Dict[str, Any]:
+@st.composite
+def mock_kafka_configs_response(draw) -> Dict[str, Any]:
     """
     Provide mocked API result from `api/v1/uac-proxy/system_admin/listKafkaConfiguration`
     with a single Kafka configuration.
     """
+    recursive_json = st.recursive(
+        st.none() | st.booleans() | st.integers() | st.text(),
+        lambda children: st.lists(children) | st.dictionaries(st.text(), children),
+        max_leaves=5,
+    )
     return {
         "configurations": [
             {
-                "id": "1232abcdefg4-567h-891i-0jkl-1m1n1o2131pq",
-                "kerberos": {
-                    "enabled": True,
-                    "conf": (
-                        "kerberos.example.com"
-                    ),
-                    "keytab": "test-key-tab=",
-                    "client_name": "test-kafka-client_name",
-                    "service_name": "test-kafka-utils",
-                },
-                "brokerAddresses": "kerberos.example.com",
-                "enabled": True,
-                "name": "Test Kafka Name",
+                "id": draw(st.integers()),
+                "kerberos": draw(recursive_json),
+                "brokerAddresses": draw(st.text()),
+                "enabled": draw(st.booleans()),
+                "name": draw(st.text()),
             }
         ]
     }
 
 
-@pytest.fixture
-def mock_kafka_topics() -> List[str]:
-    """Provide a mock API response from `api/v1/deployment/list/kafka-topics`."""
-    return ["test-topic-1", "test-topic-2", "test-topic-3"]
-
-
-def test_list_kafka_configurations(
-    mocked_responses, mock_conn, mock_kafka_configs_response
-):
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(kafka_configs_response=mock_kafka_configs_response())
+def test_list_kafka_configurations(kafka_configs_response, mocked_responses, mock_conn):
     """Verify that list_kafka_configurations function makes the expected calls
     and handles results correctly.
     """
     url = f"{mock_conn.scheme}://{mock_conn.socket}/api/v1/uac-proxy/system_admin/listKafkaConfiguration"
-    mocked_responses.get(url=url, status=200, json=mock_kafka_configs_response)
-    config = kafka.list_kafka_configurations(mock_conn)
-    mocked_responses.assert_call_count(url, 1)
-    assert config == mock_kafka_configs_response["configurations"]
+    with mocked_responses as _responses:
+        _responses.get(url=url, status=200, json=kafka_configs_response)
+        config = kafka.list_kafka_configurations(mock_conn)
+        _responses.assert_call_count(url, 1)
+        assert config == kafka_configs_response["configurations"]
 
 
-def test_format_kafka_config_for_topic_search(mock_kafka_configs_response) -> None:
+@given(kafka_configs_response=mock_kafka_configs_response())
+def test_format_kafka_config_for_topic_search(kafka_configs_response) -> None:
     """Verify that format_kafka_config_for_topic_search function formats the
     mocked kafka config into the expected results.
     """
-    mock_config = mock_kafka_configs_response["configurations"][0]
+    mock_config = kafka_configs_response["configurations"][0]
     config = kafka.format_kafka_config_for_topic_search(mock_config)
     assert config == {
         "broker_addresses": [mock_config["brokerAddresses"]],
@@ -67,16 +60,22 @@ def test_format_kafka_config_for_topic_search(mock_kafka_configs_response) -> No
     }
 
 
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(
+    kafka_topics=st.lists(st.text()),
+    kafka_configs_response=mock_kafka_configs_response(),
+)
 def test_list_kafka_topics(
-    mocked_responses, mock_conn, mock_kafka_configs_response, mock_kafka_topics
+    kafka_topics, mocked_responses, mock_conn, kafka_configs_response
 ) -> None:
     """Verify that list_kafka_topics function makes the expected calls
     and handles results correctly.
     """
-    url = "https://test_socket/api/v1/deployment/list/kafka-topics"
-    mocked_responses.post(url=url, status=200, json=mock_kafka_topics)
-    topics = kafka.list_kafka_topics(
-        conn=mock_conn, kafka_config=mock_kafka_configs_response["configurations"][0]
-    )
-    mocked_responses.assert_call_count(url, 1)
-    assert topics == mock_kafka_topics
+    url = f"{mock_conn.scheme}://{mock_conn.socket}/api/v1/deployment/list/kafka-topics"
+    with mocked_responses as _responses:
+        _responses.post(url=url, status=200, json=kafka_topics)
+        topics = kafka.list_kafka_topics(
+            conn=mock_conn, kafka_config=kafka_configs_response["configurations"][0]
+        )
+        _responses.assert_call_count(url, 1)
+        assert topics == kafka_topics

--- a/client/verta/tests/unit_tests/internal_utils/test_kafka_utils.py
+++ b/client/verta/tests/unit_tests/internal_utils/test_kafka_utils.py
@@ -15,16 +15,17 @@ def mock_kafka_configs_response(draw) -> Dict[str, Any]:
     Provide mocked API result from `api/v1/uac-proxy/system_admin/listKafkaConfiguration`
     with a single Kafka configuration.
     """
-    recursive_json = st.recursive(
-        st.none() | st.booleans() | st.integers() | st.text(),
-        lambda children: st.lists(children) | st.dictionaries(st.text(), children),
-        max_leaves=5,
-    )
     return {
         "configurations": [
             {
                 "id": draw(st.integers()),
-                "kerberos": draw(recursive_json),
+                "kerberos": {
+                    "enabled": draw(st.booleans()),
+                    "client_name": draw(st.text()),
+                    "conf": draw(st.text()),
+                    "keytab": draw(st.text()),
+                    "service_name": draw(st.text()),
+                },
                 "brokerAddresses": draw(st.text()),
                 "enabled": draw(st.booleans()),
                 "name": draw(st.text()),


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Contex
Converts the recently added unit tests for Kafka utilities into property tests.

## Risks and Area of Effect
Change to testing only.

## Testing
- [X] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

<img width="1065" alt="Screen Shot 2023-03-31 at 3 06 33 PM" src="https://user-images.githubusercontent.com/114943931/229230767-365126f8-a9ae-4ca2-a00e-799043ebb8d3.png">

## Reverting
- [ ] Contains Migration - _Do Not Revert_