### PR TITLE
test: Add batch_predict to expected funcs

### DIFF
--- a/client/verta/tests/unit_tests/registry/test_model_dependencies.py
+++ b/client/verta/tests/unit_tests/registry/test_model_dependencies.py
@@ -11,6 +11,7 @@ def test_class_functions(dependency_testing_model) -> None:
     """
     expected_func_names = [
         "__init__",
+        "batch_predict",
         "make_dataframe",
         "make_message",
         "make_timeout",


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

Since we added `VertaModelBase.batch_predict()` in https://github.com/VertaAI/modeldb/pull/3673, this test needs to be updated to expect it.

## Risks and Area of Effect

—

## Testing
- [x] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

In Python 3.10:

#### Before

```
========================================================= FAILURES ==========================================================
___________________________________________________ test_class_functions ____________________________________________________
                                                                                                                             
dependency_testing_model = <class 'tests.unit_tests.registry.conftest.dependency_testing_model.<locals>.DependencyTestingMode
l'>                                                                                                                          
                                                                                                                             
    def test_class_functions(dependency_testing_model) -> None:                                                              
        """Verify that all the functions in the test class are recognized and                                                
        returned.
        """
        expected_func_names = [ 
            "__init__",
            "batch_predict",
            "make_dataframe",
            "make_message",
            "make_timeout",
            "post_request",
            "model_test",
            "nested_multiple_returns_hint",
            "nested_type_hint",
            "predict",
            "unwrapped_predict",
        ]
        extracted_func_names = [
            f.__name__ for f in md.class_functions(dependency_testing_model)
>       ]
E       AssertionError: assert {'__init__', ...el_test', ...} == {'__init__', ...ns_hint', ...}
E         Extra items in the left set:
E         'batch_predict'
E         Use -v to get more diff

unit_tests/registry/test_model_dependencies.py:27: AssertionError
```

#### After

```zsh
% pytest unit_tests/registry
==================================================== test session starts ====================================================
platform darwin -- Python 3.10.6, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/miliu/Documents/modeldb/client/verta/tests, configfile: pytest.ini
plugins: forked-1.4.0, xdist-3.1.0, typeguard-2.13.3, hypothesis-6.67.1
collected 16 items                                                                                                          

unit_tests/registry/test_check_model_dependencies.py ...                                                              [ 18%]
unit_tests/registry/test_model_dependencies.py ............                                                           [ 93%]
unit_tests/registry/test_registered_model_version.py .                                                                [100%]

==================================================== 16 passed in 8.13s =====================================================
```

## Reverting
- [ ] Contains Migration - _Do Not Revert_

Revert this PR.