### PR TITLE
chore: clean up the CommonConstants interface and mark for removal

### DIFF
--- a/backend/common/src/main/java/ai/verta/modeldb/common/CommonConstants.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/CommonConstants.java
@@ -1,27 +1,22 @@
 package ai.verta.modeldb.common;
 
+@Deprecated(forRemoval = true)
 public interface CommonConstants {
 
-  // String Constants
-  String STRING_COLON = ":";
-  String UNSIGNED_USER = "unsigned_user";
-  String INTERNAL_ERROR = "Internal server error";
-  // Set to true to export the liquibase schema as sql statements
-  String USER_DIR = "user.dir";
-  String DELETED = "deleted";
-  String EMPTY_STRING = "";
+  /** @deprecated use {@link ai.verta.modeldb.common.config.ArtifactStoreConfig#S3_TYPE_STORE} */
+  @Deprecated(forRemoval = true)
   String S3 = "S3";
-  Integer TAG_LENGTH = 40;
-  String ENABLE_LIQUIBASE_MIGRATION_ENV_VAR = "LIQUIBASE_MIGRATION";
-  String RUN_LIQUIBASE_SEPARATE = "RUN_LIQUIBASE_SEPARATE";
-  String BACKEND_PID_FILENAME = "verta-backend.pid";
-  // AWS Releated Constants
-  String AWS_ROLE_ARN = "AWS_ROLE_ARN";
-  String AWS_WEB_IDENTITY_TOKEN_FILE = "AWS_WEB_IDENTITY_TOKEN_FILE";
 
-  enum UserIdentifier {
-    VERTA_ID,
-    EMAIL_ID,
-    USER_NAME
-  }
+  /**
+   * @deprecated use {@link
+   *     ai.verta.modeldb.common.db.migration.Migration#ENABLE_MIGRATIONS_ENV_VAR}
+   */
+  @Deprecated(forRemoval = true)
+  String ENABLE_LIQUIBASE_MIGRATION_ENV_VAR = "LIQUIBASE_MIGRATION";
+  /**
+   * @deprecated use {@link
+   *     ai.verta.modeldb.common.db.migration.Migration#RUN_MIGRATIONS_SEPARATELY}
+   */
+  @Deprecated(forRemoval = true)
+  String RUN_LIQUIBASE_SEPARATE = "RUN_LIQUIBASE_SEPARATE";
 }

--- a/backend/common/src/main/java/ai/verta/modeldb/common/CommonUtils.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/CommonUtils.java
@@ -200,7 +200,7 @@ public class CommonUtils {
         status =
             Status.newBuilder()
                 .setCode(Code.INTERNAL_VALUE)
-                .setMessage(CommonConstants.INTERNAL_ERROR)
+                .setMessage("Internal server error")
                 .build();
       }
       var n = 0;
@@ -418,12 +418,11 @@ public class CommonUtils {
   }
 
   public static void cleanUpPIDFile() {
-    var path =
-        System.getProperty(CommonConstants.USER_DIR) + "/" + CommonConstants.BACKEND_PID_FILENAME;
+    var path = System.getProperty("user.dir") + "/" + "verta-backend.pid";
     File pidFile = new File(path);
     if (pidFile.exists()) {
       pidFile.deleteOnExit();
-      LOGGER.trace(CommonConstants.BACKEND_PID_FILENAME + " file is deleted: {}", pidFile.exists());
+      LOGGER.trace("verta-backend.pid" + " file is deleted: {}", pidFile.exists());
     }
   }
 }

--- a/backend/common/src/main/java/ai/verta/modeldb/common/artifactStore/ArtifactStoreDAORdbImpl.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/artifactStore/ArtifactStoreDAORdbImpl.java
@@ -2,7 +2,6 @@ package ai.verta.modeldb.common.artifactStore;
 
 import ai.verta.modeldb.GetUrlForArtifact;
 import ai.verta.modeldb.GetUrlForArtifact.Response;
-import ai.verta.modeldb.common.CommonConstants;
 import ai.verta.modeldb.common.HttpCodeToGRPCCode;
 import ai.verta.modeldb.common.artifactStore.storageservice.ArtifactStoreService;
 import ai.verta.modeldb.common.config.ArtifactStoreConfig;
@@ -43,7 +42,7 @@ public class ArtifactStoreDAORdbImpl implements ArtifactStoreDAO {
           artifactStoreService.generatePresignedUrl(s3Key, method, partNumber, uploadId);
       return GetUrlForArtifact.Response.newBuilder()
           .setMultipartUploadOk(
-              artifactStoreConfig.getArtifactStoreType().equals(CommonConstants.S3)
+              artifactStoreConfig.getArtifactStoreType().equals(ArtifactStoreConfig.S3_TYPE_STORE)
                   && uploadId != null)
           .setUrl(presignedUrl)
           .build();

--- a/backend/common/src/main/java/ai/verta/modeldb/common/artifactStore/storageservice/s3/RefreshS3ClientCron.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/artifactStore/storageservice/s3/RefreshS3ClientCron.java
@@ -1,6 +1,5 @@
 package ai.verta.modeldb.common.artifactStore.storageservice.s3;
 
-import ai.verta.modeldb.common.CommonConstants;
 import ai.verta.modeldb.common.CommonUtils;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicSessionCredentials;
@@ -96,14 +95,14 @@ public class RefreshS3ClientCron implements Runnable {
           WebIdentityTokenCredentialsProvider.builder()
               .webIdentityTokenFile(
                   CommonUtils.appendOptionalTelepresencePath(
-                      System.getenv(CommonConstants.AWS_WEB_IDENTITY_TOKEN_FILE)))
+                      System.getenv(S3Client.AWS_WEB_IDENTITY_TOKEN_FILE)))
               .build());
     }
     return stsClientBuilder.build();
   }
 
   private AssumeRoleWithWebIdentityRequest getCredentialFromWebIdentity() throws IOException {
-    String roleArn = System.getenv(CommonConstants.AWS_ROLE_ARN);
+    String roleArn = System.getenv(S3Client.AWS_ROLE_ARN);
     String token = getWebIdentityToken();
 
     // Obtain credentials for the IAM role. Note that you cannot assume the role of
@@ -122,6 +121,6 @@ public class RefreshS3ClientCron implements Runnable {
         Files.readAllBytes(
             Paths.get(
                 CommonUtils.appendOptionalTelepresencePath(
-                    System.getenv(CommonConstants.AWS_WEB_IDENTITY_TOKEN_FILE)))));
+                    System.getenv(S3Client.AWS_WEB_IDENTITY_TOKEN_FILE)))));
   }
 }

--- a/backend/common/src/main/java/ai/verta/modeldb/common/artifactStore/storageservice/s3/S3Client.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/artifactStore/storageservice/s3/S3Client.java
@@ -1,6 +1,5 @@
 package ai.verta.modeldb.common.artifactStore.storageservice.s3;
 
-import ai.verta.modeldb.common.CommonConstants;
 import ai.verta.modeldb.common.CommonUtils;
 import ai.verta.modeldb.common.config.S3Config;
 import ai.verta.modeldb.common.exceptions.ModelDBException;
@@ -24,6 +23,9 @@ import org.apache.logging.log4j.Logger;
 // We use a reference counter to keep track of when we have to shutdown a previous client that
 // should not be used anymore.
 public class S3Client {
+  // AWS Releated Constants
+  public static final String AWS_ROLE_ARN = "AWS_ROLE_ARN";
+  public static final String AWS_WEB_IDENTITY_TOKEN_FILE = "AWS_WEB_IDENTITY_TOKEN_FILE";
   private static final Logger LOGGER = LogManager.getLogger(S3Service.class);
 
   private final String bucketName;
@@ -50,8 +52,8 @@ public class S3Client {
         LOGGER.debug("minio client");
         initializeMinioClient(cloudAccessKey, cloudSecretKey, awsRegion, minioEndpoint);
       }
-    } else if (CommonUtils.isEnvSet(CommonConstants.AWS_ROLE_ARN)
-        && CommonUtils.isEnvSet(CommonConstants.AWS_WEB_IDENTITY_TOKEN_FILE)) {
+    } else if (CommonUtils.isEnvSet(AWS_ROLE_ARN)
+        && CommonUtils.isEnvSet(AWS_WEB_IDENTITY_TOKEN_FILE)) {
       LOGGER.debug("temporary token based s3 client");
       initializeWithWebIdentity(awsRegion);
     } else {

--- a/backend/common/src/main/java/ai/verta/modeldb/common/authservice/AuthServiceChannel.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/authservice/AuthServiceChannel.java
@@ -1,6 +1,5 @@
 package ai.verta.modeldb.common.authservice;
 
-import ai.verta.modeldb.common.CommonConstants;
 import ai.verta.modeldb.common.CommonMessages;
 import ai.verta.modeldb.common.config.Config;
 import ai.verta.modeldb.common.connections.Connection;
@@ -41,10 +40,7 @@ public class AuthServiceChannel extends Connection implements AutoCloseable {
     int port = config.getAuthService().getPort();
     LOGGER.trace(CommonMessages.HOST_PORT_INFO_STR, host, port);
     if (host != null && port != 0) { // AuthService not available.
-      authChannel =
-          ManagedChannelBuilder.forTarget(host + CommonConstants.STRING_COLON + port)
-              .usePlaintext()
-              .build();
+      authChannel = ManagedChannelBuilder.forTarget(host + ":" + port).usePlaintext().build();
 
       this.serviceUserEmail = config.getService_user().getEmail();
       this.serviceUserDevKey = config.getService_user().getDevKey();

--- a/backend/common/src/main/java/ai/verta/modeldb/common/authservice/UACApisUtil.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/authservice/UACApisUtil.java
@@ -4,7 +4,6 @@ import ai.verta.common.KeyValueQuery;
 import ai.verta.common.ModelDBResourceEnum;
 import ai.verta.common.ModelDBResourceEnum.ModelDBServiceResourceTypes;
 import ai.verta.common.OperatorEnum;
-import ai.verta.modeldb.common.CommonConstants.UserIdentifier;
 import ai.verta.modeldb.common.CommonMessages;
 import ai.verta.modeldb.common.connections.UAC;
 import ai.verta.modeldb.common.dto.UserInfoPaginationDTO;
@@ -433,5 +432,11 @@ public class UACApisUtil {
     } catch (Exception ex) {
       throw new ModelDBException(ex);
     }
+  }
+
+  public enum UserIdentifier {
+    VERTA_ID,
+    EMAIL_ID,
+    USER_NAME
   }
 }

--- a/backend/common/src/main/java/ai/verta/modeldb/common/collaborator/CollaboratorBase.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/collaborator/CollaboratorBase.java
@@ -1,7 +1,6 @@
 package ai.verta.modeldb.common.collaborator;
 
 import ai.verta.common.EntitiesEnum.EntitiesTypes;
-import ai.verta.modeldb.common.CommonConstants;
 import ai.verta.uac.AddCollaboratorRequest.Response.Builder;
 import ai.verta.uac.Entities;
 import com.google.protobuf.GeneratedMessageV3;
@@ -19,7 +18,7 @@ public abstract class CollaboratorBase {
   }
 
   public String getVertaId() {
-    return CommonConstants.EMPTY_STRING;
+    return "";
   }
 
   public abstract String getNameForBinding();

--- a/backend/common/src/main/java/ai/verta/modeldb/common/config/ArtifactStoreConfig.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/config/ArtifactStoreConfig.java
@@ -17,6 +17,7 @@ import lombok.Setter;
 @Getter
 @Setter(AccessLevel.NONE)
 public class ArtifactStoreConfig {
+  public static final String S3_TYPE_STORE = "S3";
   @JsonProperty private String artifactStoreType;
   @JsonProperty private boolean pickArtifactStoreHostFromConfig = false;
   @JsonProperty private boolean enabled = true;

--- a/backend/common/src/main/java/ai/verta/modeldb/common/configuration/EnabledMigration.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/configuration/EnabledMigration.java
@@ -1,6 +1,6 @@
 package ai.verta.modeldb.common.configuration;
 
-import ai.verta.modeldb.common.CommonConstants;
+import ai.verta.modeldb.common.db.migration.Migration;
 import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -16,7 +16,7 @@ public class EnabledMigration implements Condition {
   private static boolean isMigration() {
     var enableLiquibaseMigrationEnvVar =
         Boolean.parseBoolean(
-            Optional.ofNullable(System.getenv(CommonConstants.ENABLE_LIQUIBASE_MIGRATION_ENV_VAR))
+            Optional.ofNullable(System.getenv(Migration.ENABLE_MIGRATIONS_ENV_VAR))
                 .orElse("false"));
     LOGGER.info("ENABLE_LIQUIBASE_MIGRATION_ENV_VAR: {}", enableLiquibaseMigrationEnvVar);
     return enableLiquibaseMigrationEnvVar;

--- a/backend/common/src/main/java/ai/verta/modeldb/common/configuration/RunLiquibaseSeparately.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/configuration/RunLiquibaseSeparately.java
@@ -1,6 +1,6 @@
 package ai.verta.modeldb.common.configuration;
 
-import ai.verta.modeldb.common.CommonConstants;
+import ai.verta.modeldb.common.db.migration.Migration;
 import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -14,7 +14,7 @@ public class RunLiquibaseSeparately implements Condition {
   private boolean liquibaseRunSeparately() {
     var liquibaseRunSeparately =
         Boolean.parseBoolean(
-            Optional.ofNullable(System.getenv(CommonConstants.RUN_LIQUIBASE_SEPARATE))
+            Optional.ofNullable(System.getenv(Migration.RUN_MIGRATIONS_SEPARATELY))
                 .orElse("false"));
     LOGGER.info("RUN_LIQUIBASE_SEPARATE: {}", liquibaseRunSeparately);
     return liquibaseRunSeparately;

--- a/backend/common/src/main/java/ai/verta/modeldb/common/configuration/ServerEnabled.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/configuration/ServerEnabled.java
@@ -1,6 +1,6 @@
 package ai.verta.modeldb.common.configuration;
 
-import ai.verta.modeldb.common.CommonConstants;
+import ai.verta.modeldb.common.db.migration.Migration;
 import java.util.Optional;
 import org.springframework.context.annotation.Condition;
 import org.springframework.context.annotation.ConditionContext;
@@ -20,11 +20,11 @@ public class ServerEnabled implements Condition {
   public static boolean serverIsEnabled() {
     var enableLiquibase =
         Boolean.parseBoolean(
-            Optional.ofNullable(System.getenv(CommonConstants.ENABLE_LIQUIBASE_MIGRATION_ENV_VAR))
+            Optional.ofNullable(System.getenv(Migration.ENABLE_MIGRATIONS_ENV_VAR))
                 .orElse("false"));
     var runLiquibaseSeparate =
         Boolean.parseBoolean(
-            Optional.ofNullable(System.getenv(CommonConstants.RUN_LIQUIBASE_SEPARATE))
+            Optional.ofNullable(System.getenv(Migration.RUN_MIGRATIONS_SEPARATELY))
                 .orElse("false"));
 
     // We run the web/grpc servers in every case where don't both have liquibase enabled and run it

--- a/backend/common/src/main/java/ai/verta/modeldb/common/connections/UAC.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/connections/UAC.java
@@ -1,6 +1,5 @@
 package ai.verta.modeldb.common.connections;
 
-import ai.verta.modeldb.common.CommonConstants;
 import ai.verta.modeldb.common.CommonMessages;
 import ai.verta.modeldb.common.authservice.AuthServiceChannel;
 import ai.verta.modeldb.common.config.Config;
@@ -86,9 +85,7 @@ public class UAC extends Connection {
     ManagedChannel authServiceChannel;
     if (host != null) {
       authServiceChannel =
-          ManagedChannelBuilder.forTarget(host + CommonConstants.STRING_COLON + port)
-              .usePlaintext()
-              .build();
+          ManagedChannelBuilder.forTarget(host + ":" + port).usePlaintext().build();
     } else {
       throw new UnavailableException(
           "Host OR Port not found for contacting authentication service");

--- a/backend/common/src/main/java/ai/verta/modeldb/common/db/migration/Migration.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/db/migration/Migration.java
@@ -4,6 +4,9 @@ import lombok.Value;
 
 @Value
 public class Migration implements Comparable<Migration> {
+  public static final String ENABLE_MIGRATIONS_ENV_VAR = "LIQUIBASE_MIGRATION";
+  public static final String RUN_MIGRATIONS_SEPARATELY = "RUN_LIQUIBASE_SEPARATE";
+
   String filename;
 
   @Override

--- a/backend/common/src/main/java/ai/verta/modeldb/common/handlers/TagsHandlerBase.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/handlers/TagsHandlerBase.java
@@ -1,6 +1,5 @@
 package ai.verta.modeldb.common.handlers;
 
-import ai.verta.modeldb.common.CommonConstants;
 import ai.verta.modeldb.common.exceptions.ModelDBException;
 import ai.verta.modeldb.common.futures.FutureExecutor;
 import ai.verta.modeldb.common.futures.FutureJdbi;
@@ -17,11 +16,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 public abstract class TagsHandlerBase<T> {
-  private static final Logger LOGGER = LogManager.getLogger(TagsHandlerBase.class);
   protected static final String ENTITY_ID_QUERY_PARAM = "entity_id";
   private static final String ENTITY_NAME_QUERY_PARAM = "entity_name";
 
@@ -42,12 +38,9 @@ public abstract class TagsHandlerBase<T> {
       if (tag.isEmpty()) {
         var errorMessage = "Invalid tag found, Tag shouldn't be empty";
         throw new ModelDBException(errorMessage, Code.INVALID_ARGUMENT);
-      } else if (tag.length() > CommonConstants.TAG_LENGTH) {
+      } else if (tag.length() > 40) {
         String errorMessage =
-            "Tag name can not be more than "
-                + CommonConstants.TAG_LENGTH
-                + " characters. Limit exceeded tag is: "
-                + tag;
+            "Tag name can not be more than " + 40 + " characters. Limit exceeded tag is: " + tag;
         throw new ModelDBException(errorMessage, Code.INVALID_ARGUMENT);
       }
     }

--- a/backend/common/src/main/java/ai/verta/modeldb/common/subtypes/CommonArtifactHandler.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/subtypes/CommonArtifactHandler.java
@@ -1,7 +1,6 @@
 package ai.verta.modeldb.common.subtypes;
 
 import ai.verta.common.Artifact;
-import ai.verta.modeldb.common.CommonConstants;
 import ai.verta.modeldb.common.CommonMessages;
 import ai.verta.modeldb.common.config.ArtifactStoreConfig;
 import ai.verta.modeldb.common.exceptions.ModelDBException;
@@ -129,7 +128,8 @@ public abstract class CommonArtifactHandler<T> {
 
     List<Artifact> pathUpdatedArtifacts = new ArrayList<>();
     for (var artifact : artifacts) {
-      var uploadCompleted = !artifactStoreConfig.getArtifactStoreType().equals(CommonConstants.S3);
+      var uploadCompleted =
+          !artifactStoreConfig.getArtifactStoreType().equals(ArtifactStoreConfig.S3_TYPE_STORE);
       if (artifact.getUploadCompleted()) {
         uploadCompleted = true;
       }

--- a/backend/server/src/main/java/ai/verta/modeldb/entities/ArtifactEntity.java
+++ b/backend/server/src/main/java/ai/verta/modeldb/entities/ArtifactEntity.java
@@ -2,7 +2,7 @@ package ai.verta.modeldb.entities;
 
 import ai.verta.common.Artifact;
 import ai.verta.modeldb.App;
-import ai.verta.modeldb.common.CommonConstants;
+import ai.verta.modeldb.common.config.ArtifactStoreConfig;
 import java.io.Serializable;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -48,7 +48,8 @@ public class ArtifactEntity implements Serializable {
     }
 
     this.field_type = fieldType;
-    var uploadCompleted = !artifactStoreConfig.getArtifactStoreType().equals(CommonConstants.S3);
+    var uploadCompleted =
+        !artifactStoreConfig.getArtifactStoreType().equals(ArtifactStoreConfig.S3_TYPE_STORE);
     if (artifact.getUploadCompleted()) {
       uploadCompleted = true;
     }

--- a/backend/server/src/main/java/ai/verta/modeldb/experimentRun/subtypes/ArtifactHandler.java
+++ b/backend/server/src/main/java/ai/verta/modeldb/experimentRun/subtypes/ArtifactHandler.java
@@ -2,8 +2,8 @@ package ai.verta.modeldb.experimentRun.subtypes;
 
 import ai.verta.common.ArtifactTypeEnum;
 import ai.verta.modeldb.*;
-import ai.verta.modeldb.common.CommonConstants;
 import ai.verta.modeldb.common.artifactStore.ArtifactStoreDAO;
+import ai.verta.modeldb.common.config.ArtifactStoreConfig;
 import ai.verta.modeldb.common.exceptions.InvalidArgumentException;
 import ai.verta.modeldb.common.exceptions.ModelDBException;
 import ai.verta.modeldb.common.exceptions.NotFoundException;
@@ -151,7 +151,10 @@ public class ArtifactHandler extends ArtifactHandlerBase {
       S3KeyFunction initializeMultipart) {
     String uploadId;
     if (partNumberSpecified
-        && mdbConfig.getArtifactStoreConfig().getArtifactStoreType().equals(CommonConstants.S3)) {
+        && mdbConfig
+            .getArtifactStoreConfig()
+            .getArtifactStoreType()
+            .equals(ArtifactStoreConfig.S3_TYPE_STORE)) {
       uploadId = artifactEntity.getUploadId();
       String message = null;
       if (uploadId == null || artifactEntity.isUploadCompleted()) {

--- a/backend/server/src/main/java/ai/verta/modeldb/experimentRun/subtypes/VersionInputHandler.java
+++ b/backend/server/src/main/java/ai/verta/modeldb/experimentRun/subtypes/VersionInputHandler.java
@@ -6,7 +6,6 @@ import ai.verta.modeldb.App;
 import ai.verta.modeldb.Location;
 import ai.verta.modeldb.ModelDBConstants;
 import ai.verta.modeldb.VersioningEntry;
-import ai.verta.modeldb.common.CommonConstants;
 import ai.verta.modeldb.common.CommonUtils;
 import ai.verta.modeldb.common.exceptions.AlreadyExistsException;
 import ai.verta.modeldb.common.exceptions.InternalErrorException;
@@ -292,7 +291,7 @@ public class VersionInputHandler {
       keysAndParameterMap.put(COMMIT_QUERY_PARAM, versioningEntry.getCommit());
       keysAndParameterMap.put(ENTITY_ID_QUERY_PARAM, entityId);
       keysAndParameterMap.put(ENTITY_TYPE_QUERY_PARAM, entity_type);
-      keysAndParameterMap.put(VERSIONING_KEY_QUERY_PARAM, CommonConstants.EMPTY_STRING);
+      keysAndParameterMap.put(VERSIONING_KEY_QUERY_PARAM, "");
       keysAndParameterMap.put(VERSIONING_LOCATION_QUERY_PARAM, null);
       keysAndParameterMap.put("versioning_blob_type", null);
       keysAndParameterMap.put(BLOB_HASH_QUERY_PARAM, null);

--- a/backend/server/src/main/java/ai/verta/modeldb/utils/ArtifactPathMigrationUtils.java
+++ b/backend/server/src/main/java/ai/verta/modeldb/utils/ArtifactPathMigrationUtils.java
@@ -1,7 +1,7 @@
 package ai.verta.modeldb.utils;
 
 import ai.verta.modeldb.ModelDBConstants;
-import ai.verta.modeldb.common.CommonConstants;
+import ai.verta.modeldb.common.config.ArtifactStoreConfig;
 import ai.verta.modeldb.entities.ArtifactEntity;
 import java.util.List;
 import java.util.Map;
@@ -23,9 +23,9 @@ public class ArtifactPathMigrationUtils {
     String artifactStoreType =
         (String) artifactStoreConfigMap.get(ModelDBConstants.ARTIFACT_STORE_TYPE);
     String storeTypePathPrefix = null;
-    if (artifactStoreType.equals(CommonConstants.S3)) {
+    if (artifactStoreType.equals(ArtifactStoreConfig.S3_TYPE_STORE)) {
       Map<String, Object> s3ConfigMap =
-          (Map<String, Object>) artifactStoreConfigMap.get(CommonConstants.S3);
+          (Map<String, Object>) artifactStoreConfigMap.get(ArtifactStoreConfig.S3_TYPE_STORE);
       String cloudBucketName = (String) s3ConfigMap.get(ModelDBConstants.CLOUD_BUCKET_NAME);
       LOGGER.trace("S3 cloud bucket name {}", cloudBucketName);
       storeTypePathPrefix = "s3://" + cloudBucketName + ModelDBConstants.PATH_DELIMITER;

--- a/backend/server/src/main/java/ai/verta/modeldb/utils/RdbmsUtils.java
+++ b/backend/server/src/main/java/ai/verta/modeldb/utils/RdbmsUtils.java
@@ -5,7 +5,6 @@ import ai.verta.common.ModelDBResourceEnum.ModelDBServiceResourceTypes;
 import ai.verta.common.OperatorEnum.Operator;
 import ai.verta.modeldb.*;
 import ai.verta.modeldb.authservice.MDBRoleService;
-import ai.verta.modeldb.common.CommonConstants;
 import ai.verta.modeldb.common.CommonUtils;
 import ai.verta.modeldb.common.authservice.UACApisUtil;
 import ai.verta.modeldb.common.exceptions.InvalidArgumentException;
@@ -2068,7 +2067,7 @@ public class RdbmsUtils {
           new VersioningModeldbEntityMapping(
               versioningEntry.getRepositoryId(),
               versioningEntry.getCommit(),
-              CommonConstants.EMPTY_STRING,
+              "",
               null,
               null,
               null,

--- a/backend/server/src/test/java/ai/verta/modeldb/DatasetTest.java
+++ b/backend/server/src/test/java/ai/verta/modeldb/DatasetTest.java
@@ -13,7 +13,7 @@ import ai.verta.common.KeyValueQuery;
 import ai.verta.common.ModelDBResourceEnum.ModelDBServiceResourceTypes;
 import ai.verta.common.OperatorEnum;
 import ai.verta.common.ValueTypeEnum.ValueType;
-import ai.verta.modeldb.common.CommonConstants;
+import ai.verta.modeldb.common.config.ArtifactStoreConfig;
 import ai.verta.modeldb.versioning.DeleteRepositoryRequest;
 import ai.verta.modeldb.versioning.RepositoryIdentification;
 import ai.verta.uac.AddCollaboratorRequest;
@@ -1570,7 +1570,7 @@ public class DatasetTest extends ModeldbTestSetup {
                   !testConfig
                       .getArtifactStoreConfig()
                       .getArtifactStoreType()
-                      .equals(CommonConstants.S3))
+                      .equals(ArtifactStoreConfig.S3_TYPE_STORE))
               .build();
 
       LogDataset logDatasetRequest =
@@ -1615,7 +1615,7 @@ public class DatasetTest extends ModeldbTestSetup {
                   !testConfig
                       .getArtifactStoreConfig()
                       .getArtifactStoreType()
-                      .equals(CommonConstants.S3))
+                      .equals(ArtifactStoreConfig.S3_TYPE_STORE))
               .build();
 
       logDatasetRequest =
@@ -1831,7 +1831,7 @@ public class DatasetTest extends ModeldbTestSetup {
                   !testConfig
                       .getArtifactStoreConfig()
                       .getArtifactStoreType()
-                      .equals(CommonConstants.S3))
+                      .equals(ArtifactStoreConfig.S3_TYPE_STORE))
               .build();
 
       LogDataset logDatasetRequest =
@@ -1870,7 +1870,7 @@ public class DatasetTest extends ModeldbTestSetup {
                   !testConfig
                       .getArtifactStoreConfig()
                       .getArtifactStoreType()
-                      .equals(CommonConstants.S3))
+                      .equals(ArtifactStoreConfig.S3_TYPE_STORE))
               .build();
 
       logDatasetRequest =

--- a/backend/server/src/test/java/ai/verta/modeldb/ExperimentRunTest.java
+++ b/backend/server/src/test/java/ai/verta/modeldb/ExperimentRunTest.java
@@ -15,7 +15,7 @@ import ai.verta.common.OperatorEnum.Operator;
 import ai.verta.common.TernaryEnum.Ternary;
 import ai.verta.common.ValueTypeEnum.ValueType;
 import ai.verta.modeldb.GetExperimentRunById.Response;
-import ai.verta.modeldb.common.CommonConstants;
+import ai.verta.modeldb.common.config.ArtifactStoreConfig;
 import ai.verta.modeldb.common.exceptions.ModelDBException;
 import ai.verta.modeldb.metadata.GenerateRandomNameRequest;
 import ai.verta.modeldb.utils.ModelDBUtils;
@@ -463,7 +463,7 @@ public class ExperimentRunTest extends ModeldbTestSetup {
                 !testConfig
                     .getArtifactStoreConfig()
                     .getArtifactStoreType()
-                    .equals(CommonConstants.S3))
+                    .equals(ArtifactStoreConfig.S3_TYPE_STORE))
             .build());
     artifactList.add(
         Artifact.newBuilder()
@@ -475,7 +475,7 @@ public class ExperimentRunTest extends ModeldbTestSetup {
                 !testConfig
                     .getArtifactStoreConfig()
                     .getArtifactStoreType()
-                    .equals(CommonConstants.S3))
+                    .equals(ArtifactStoreConfig.S3_TYPE_STORE))
             .setFilenameExtension("png")
             .build());
 
@@ -489,7 +489,7 @@ public class ExperimentRunTest extends ModeldbTestSetup {
                 !testConfig
                     .getArtifactStoreConfig()
                     .getArtifactStoreType()
-                    .equals(CommonConstants.S3))
+                    .equals(ArtifactStoreConfig.S3_TYPE_STORE))
             .setFilenameExtension("pkl")
             .build());
     datasets.add(
@@ -501,7 +501,7 @@ public class ExperimentRunTest extends ModeldbTestSetup {
                 !testConfig
                     .getArtifactStoreConfig()
                     .getArtifactStoreType()
-                    .equals(CommonConstants.S3))
+                    .equals(ArtifactStoreConfig.S3_TYPE_STORE))
             .setFilenameExtension("json")
             .build());
 
@@ -5142,7 +5142,7 @@ public class ExperimentRunTest extends ModeldbTestSetup {
                                 !testConfig
                                     .getArtifactStoreConfig()
                                     .getArtifactStoreType()
-                                    .equals(CommonConstants.S3))
+                                    .equals(ArtifactStoreConfig.S3_TYPE_STORE))
                             .build())
                     .build())
             .build();
@@ -5197,7 +5197,7 @@ public class ExperimentRunTest extends ModeldbTestSetup {
                                 !testConfig
                                     .getArtifactStoreConfig()
                                     .getArtifactStoreType()
-                                    .equals(CommonConstants.S3))
+                                    .equals(ArtifactStoreConfig.S3_TYPE_STORE))
                             .build())
                     .build())
             .setOverwrite(true)
@@ -5259,7 +5259,7 @@ public class ExperimentRunTest extends ModeldbTestSetup {
                                 !testConfig
                                     .getArtifactStoreConfig()
                                     .getArtifactStoreType()
-                                    .equals(CommonConstants.S3))
+                                    .equals(ArtifactStoreConfig.S3_TYPE_STORE))
                             .build())
                     .build())
             .build();
@@ -8041,7 +8041,7 @@ public class ExperimentRunTest extends ModeldbTestSetup {
                   !testConfig
                       .getArtifactStoreConfig()
                       .getArtifactStoreType()
-                      .equals(CommonConstants.S3))
+                      .equals(ArtifactStoreConfig.S3_TYPE_STORE))
               .build();
       artifacts.add(artifact1);
       artifactMap.put(artifact1.getKey(), artifact1);
@@ -8055,7 +8055,7 @@ public class ExperimentRunTest extends ModeldbTestSetup {
                   !testConfig
                       .getArtifactStoreConfig()
                       .getArtifactStoreType()
-                      .equals(CommonConstants.S3))
+                      .equals(ArtifactStoreConfig.S3_TYPE_STORE))
               .build();
       artifacts.add(artifact2);
       artifactMap.put(artifact2.getKey(), artifact2);

--- a/backend/server/src/test/java/ai/verta/modeldb/ExperimentTest.java
+++ b/backend/server/src/test/java/ai/verta/modeldb/ExperimentTest.java
@@ -11,7 +11,7 @@ import ai.verta.common.CodeVersion;
 import ai.verta.common.KeyValue;
 import ai.verta.common.ModelDBResourceEnum.ModelDBServiceResourceTypes;
 import ai.verta.common.ValueTypeEnum.ValueType;
-import ai.verta.modeldb.common.CommonConstants;
+import ai.verta.modeldb.common.config.ArtifactStoreConfig;
 import ai.verta.uac.DeleteRoleBindings;
 import ai.verta.uac.GetResources;
 import ai.verta.uac.GetResourcesResponseItem;
@@ -205,7 +205,7 @@ public class ExperimentTest extends ModeldbTestSetup {
                 !testConfig
                     .getArtifactStoreConfig()
                     .getArtifactStoreType()
-                    .equals(CommonConstants.S3))
+                    .equals(ArtifactStoreConfig.S3_TYPE_STORE))
             .build());
     artifactList.add(
         Artifact.newBuilder()
@@ -217,7 +217,7 @@ public class ExperimentTest extends ModeldbTestSetup {
                 !testConfig
                     .getArtifactStoreConfig()
                     .getArtifactStoreType()
-                    .equals(CommonConstants.S3))
+                    .equals(ArtifactStoreConfig.S3_TYPE_STORE))
             .build());
 
     return CreateExperiment.newBuilder()
@@ -1545,7 +1545,7 @@ public class ExperimentTest extends ModeldbTestSetup {
                                 !testConfig
                                     .getArtifactStoreConfig()
                                     .getArtifactStoreType()
-                                    .equals(CommonConstants.S3))
+                                    .equals(ArtifactStoreConfig.S3_TYPE_STORE))
                             .build())
                     .build())
             .build();
@@ -1602,7 +1602,7 @@ public class ExperimentTest extends ModeldbTestSetup {
                                 !testConfig
                                     .getArtifactStoreConfig()
                                     .getArtifactStoreType()
-                                    .equals(CommonConstants.S3))
+                                    .equals(ArtifactStoreConfig.S3_TYPE_STORE))
                             .build())
                     .build())
             .build();

--- a/backend/server/src/test/java/ai/verta/modeldb/ProjectTest.java
+++ b/backend/server/src/test/java/ai/verta/modeldb/ProjectTest.java
@@ -12,8 +12,8 @@ import ai.verta.common.CollaboratorTypeEnum.CollaboratorType;
 import ai.verta.common.KeyValue;
 import ai.verta.common.ModelDBResourceEnum.ModelDBServiceResourceTypes;
 import ai.verta.common.ValueTypeEnum.ValueType;
-import ai.verta.modeldb.common.CommonConstants;
 import ai.verta.modeldb.common.CommonUtils;
+import ai.verta.modeldb.common.config.ArtifactStoreConfig;
 import ai.verta.modeldb.common.exceptions.AlreadyExistsException;
 import ai.verta.modeldb.utils.ModelDBUtils;
 import ai.verta.uac.*;
@@ -227,7 +227,7 @@ public class ProjectTest extends ModeldbTestSetup {
                 !testConfig
                     .getArtifactStoreConfig()
                     .getArtifactStoreType()
-                    .equals(CommonConstants.S3))
+                    .equals(ArtifactStoreConfig.S3_TYPE_STORE))
             .build());
     datasets.add(
         Artifact.newBuilder()
@@ -239,7 +239,7 @@ public class ProjectTest extends ModeldbTestSetup {
                 !testConfig
                     .getArtifactStoreConfig()
                     .getArtifactStoreType()
-                    .equals(CommonConstants.S3))
+                    .equals(ArtifactStoreConfig.S3_TYPE_STORE))
             .build());
     CreateExperimentRun createExperimentRunRequest =
         getCreateExperimentRunRequest(project.getId(), experiment.getId(), "ExperimentRun_sprt_1");
@@ -360,7 +360,7 @@ public class ProjectTest extends ModeldbTestSetup {
                 !testConfig
                     .getArtifactStoreConfig()
                     .getArtifactStoreType()
-                    .equals(CommonConstants.S3))
+                    .equals(ArtifactStoreConfig.S3_TYPE_STORE))
             .build());
     artifactList.add(
         Artifact.newBuilder()
@@ -372,7 +372,7 @@ public class ProjectTest extends ModeldbTestSetup {
                 !testConfig
                     .getArtifactStoreConfig()
                     .getArtifactStoreType()
-                    .equals(CommonConstants.S3))
+                    .equals(ArtifactStoreConfig.S3_TYPE_STORE))
             .build());
 
     return CreateProject.newBuilder()
@@ -467,7 +467,7 @@ public class ProjectTest extends ModeldbTestSetup {
                 !testConfig
                     .getArtifactStoreConfig()
                     .getArtifactStoreType()
-                    .equals(CommonConstants.S3))
+                    .equals(ArtifactStoreConfig.S3_TYPE_STORE))
             .build());
     artifactList.add(
         Artifact.newBuilder()
@@ -479,7 +479,7 @@ public class ProjectTest extends ModeldbTestSetup {
                 !testConfig
                     .getArtifactStoreConfig()
                     .getArtifactStoreType()
-                    .equals(CommonConstants.S3))
+                    .equals(ArtifactStoreConfig.S3_TYPE_STORE))
             .setFilenameExtension("png")
             .build());
 
@@ -493,7 +493,7 @@ public class ProjectTest extends ModeldbTestSetup {
                 !testConfig
                     .getArtifactStoreConfig()
                     .getArtifactStoreType()
-                    .equals(CommonConstants.S3))
+                    .equals(ArtifactStoreConfig.S3_TYPE_STORE))
             .setFilenameExtension("pkl")
             .build());
     datasets.add(
@@ -505,7 +505,7 @@ public class ProjectTest extends ModeldbTestSetup {
                 !testConfig
                     .getArtifactStoreConfig()
                     .getArtifactStoreType()
-                    .equals(CommonConstants.S3))
+                    .equals(ArtifactStoreConfig.S3_TYPE_STORE))
             .setFilenameExtension("json")
             .build());
 
@@ -3127,7 +3127,7 @@ public class ProjectTest extends ModeldbTestSetup {
                                   !testConfig
                                       .getArtifactStoreConfig()
                                       .getArtifactStoreType()
-                                      .equals(CommonConstants.S3))
+                                      .equals(ArtifactStoreConfig.S3_TYPE_STORE))
                               .build())
                       .build())
               .build();
@@ -3201,7 +3201,7 @@ public class ProjectTest extends ModeldbTestSetup {
                                 !testConfig
                                     .getArtifactStoreConfig()
                                     .getArtifactStoreType()
-                                    .equals(CommonConstants.S3))
+                                    .equals(ArtifactStoreConfig.S3_TYPE_STORE))
                             .build())
                     .build())
             .build();


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context
Many of these constants were only used in one place, or were more verbose/harder to read than just using the string directly. 

3 of them are used outside of modeldb, so they are marked as deprecated for now.

Some of these constants were moved into places more appropriate and close to where they were used.

## Risks and Area of Effect

## Testing
- [x] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

## Reverting
- [ ] Contains Migration - _Do Not Revert_