### PR TITLE
test: Fix batch predict unit test flakiness

### DIFF
--- a/client/verta/tests/unit_tests/test_deployed_model.py
+++ b/client/verta/tests/unit_tests/test_deployed_model.py
@@ -490,10 +490,10 @@ def test_batch_predict_with_batches_and_indexes(mocked_responses) -> None:
 
 
 @st.composite
-def generate_data(draw):
+def generate_data(draw, max_rows=50, max_cols=6):
     """ Return a dict that represents a dataframe. Generates ints, floats, and strings."""
-    num_rows = draw(st.integers(min_value=1, max_value=200))
-    num_cols = draw(st.integers(min_value=1, max_value=10))
+    num_rows = draw(st.integers(min_value=1, max_value=max_rows))
+    num_cols = draw(st.integers(min_value=1, max_value=max_cols))
     col_names = draw(st.lists(st.text(), max_size=num_cols, min_size=num_cols, unique=True))
     data = {}
     for name in col_names:
@@ -517,7 +517,7 @@ def generate_data(draw):
 
 
 @hypothesis.settings(deadline=None)  # client utilities make DataFrame handling inconsistent
-@given(json_df=generate_data(), batch_size=st.integers(min_value=1, max_value=50))
+@given(json_df=generate_data(), batch_size=st.integers(min_value=1, max_value=10))
 def test_batch(json_df, batch_size) -> None:
     """ Test that the batch_predict method works with a variety of inputs. """
     with responses.RequestsMock() as rsps:

--- a/client/verta/tests/unit_tests/test_deployed_model.py
+++ b/client/verta/tests/unit_tests/test_deployed_model.py
@@ -516,7 +516,7 @@ def generate_data(draw, max_rows=50, max_cols=6):
     return out_dict
 
 
-@hypothesis.settings(deadline=None)  # client utilities make DataFrame handling inconsistent
+@hypothesis.settings(deadline=None)  # client utils make DataFrame handling slow at first
 @given(json_df=generate_data(), batch_size=st.integers(min_value=1, max_value=10))
 def test_batch(json_df, batch_size) -> None:
     """ Test that the batch_predict method works with a variety of inputs. """

--- a/client/verta/tests/unit_tests/test_deployed_model.py
+++ b/client/verta/tests/unit_tests/test_deployed_model.py
@@ -5,6 +5,7 @@ import os
 import random
 from typing import Any, Dict
 
+import hypothesis
 import pytest
 
 from tests import utils
@@ -515,6 +516,7 @@ def generate_data(draw):
     return out_dict
 
 
+@hypothesis.settings(deadline=None)  # client utilities make DataFrame handling inconsistent
 @given(json_df=generate_data(), batch_size=st.integers(min_value=1, max_value=50))
 def test_batch(json_df, batch_size) -> None:
     """ Test that the batch_predict method works with a variety of inputs. """


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

`unit_tests/test_deployed_model.py::test_batch` always hangs for me when I run it locally.

After experimenting for a while, I managed to get the test to fail within 5sec with a timing flakiness error from Hypothesis:

```
E  hypothesis.errors.Flaky: Hypothesis test_batch(json_df={'data': {'': ['']}}, batch_size=1) produces unreliable results: Falsified on the first call but did not on a subsequent one
E  Falsifying example: test_batch(
E      json_df={'data': {'': ['']}},
E      batch_size=1,
E  )
E  Unreliable test timings! On an initial run, this test took 3499.77ms, which exceeded the deadline of 200.00ms, but on a subsequent run it took 3.84 ms, which did not. If you expect this sort of variability in your test timings, consider turning deadlines off for this test by setting deadline=None.
```

by simply adding a `print()` to the test:

```diff
diff --git a/client/verta/tests/unit_tests/test_deployed_model.py b/client/verta/tests/unit_tests/test_deployed_model.py
index 30cd337cb..afccd7ee2 100644
--- a/client/verta/tests/unit_tests/test_deployed_model.py
+++ b/client/verta/tests/unit_tests/test_deployed_model.py
@@ -518,6 +518,7 @@ def generate_data(draw):
 @given(json_df=generate_data(), batch_size=st.integers(min_value=1, max_value=50))
 def test_batch(json_df, batch_size) -> None:
     """ Test that the batch_predict method works with a variety of inputs. """
+    print("test begins")
     with responses.RequestsMock() as rsps:
         if "index" in json_df:
             input_df = pd.DataFrame(json_df["data"], index=json_df["index"])

```

Turning off the deadline then results in a `data_too_large` error from Hypothesis:

```
E  hypothesis.errors.FailedHealthCheck: Examples routinely exceeded the max allowable size. (20 examples overran while generating 8 valid ones). Generating examples this large will usually lead to bad results. You could try setting max_size parameters on your collections and turning max_leaves down on recursive() calls.
E  See https://hypothesis.readthedocs.io/en/latest/healthchecks.html for more information about this. If you want to disable just this health check, add HealthCheck.data_too_large to the suppress_health_check settings for this test.
```

so I cut down on the generated DataFrame size as well.

## Risks and Area of Effect

—

## Testing
- [x] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

### Before

`unit_tests/test_deployed_model.py::test_batch` hangs for at least 3min.

### After

`unit_tests/test_deployed_model.py::test_batch` passes in 20sec.

```zsh
% pytest unit_tests/test_deployed_model.py::test_batch
==================================================== test session starts ====================================================
platform darwin -- Python 3.10.6, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/miliu/Documents/modeldb/client/verta/tests, configfile: pytest.ini
plugins: forked-1.4.0, xdist-3.1.0, typeguard-2.13.3, hypothesis-6.67.1
collected 1 item                                                                                                            

unit_tests/test_deployed_model.py .                                                                                   [100%]

=============================================== 1 passed, 1 warning in 20.61s ===============================================
```

## Reverting
- [ ] Contains Migration - _Do Not Revert_

Revert this PR.