### PR TITLE
fix: don't throw an exception from a failed S3 token refresh job (#3747)

### DIFF
--- a/backend/common/src/main/java/ai/verta/modeldb/common/artifactStore/storageservice/s3/RefreshS3ClientCron.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/artifactStore/storageservice/s3/RefreshS3ClientCron.java
@@ -42,7 +42,7 @@ public class RefreshS3ClientCron implements Runnable {
       createAndRefreshNewClient(awsCredentials);
     } catch (Throwable ex) {
       LOGGER.error("Failed to refresh S3 Client: " + ex.getMessage(), ex);
-      throw new RuntimeException(ex);
+      return;
     }
     LOGGER.info("Refreshing S3Client complete");
   }

--- a/backend/common/src/main/java/ai/verta/modeldb/common/artifactStore/storageservice/s3/S3Client.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/artifactStore/storageservice/s3/S3Client.java
@@ -96,13 +96,12 @@ public class S3Client {
     return new RefCountedS3Client(awsCredentials, s3Client, referenceCounter);
   }
 
-  private void initializeWithWebIdentity(Regions awsRegion) throws IOException {
-    /* While creating RoleCredentials we have set time (900 seconds (15 minutes))
-    in the AssumeRoleWithWebIdentityRequest so here expiration will be 900 seconds
-    so set cron to half of the duration of the credentials which will be ~(450 Second (7.5 minutes))
-     */
+  private void initializeWithWebIdentity(Regions awsRegion) {
+    // While creating RoleCredentials we have a set time (900 seconds (15 minutes))
+    // in the AssumeRoleWithWebIdentityRequest so here expiration will be 900 seconds
+    // so set cron to 1/3 of the duration of the credentials which will be 5 minutes.
     var durationSeconds = 900; /*900 seconds (15 minutes)*/
-    var refreshTokenFrequency = durationSeconds / 2;
+    var refreshTokenFrequency = durationSeconds / 3;
     LOGGER.trace(String.format("S3 Client refresh frequency %d seconds", refreshTokenFrequency));
 
     CommonUtils.scheduleTask(


### PR DESCRIPTION
And, make the refresh interval 5 minutes, so we can fail once without a problem.

(cherry picked from commit 1a8c0d2e04a062cd2f5dc29b5de4feb0e9674d52)

<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

## Risks and Area of Effect

## Testing
- [ ] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

## Reverting
- [ ] Contains Migration - _Do Not Revert_