### PR TITLE
test: Nest endpoint unit tests into classes

### DIFF
--- a/client/verta/tests/unit_tests/test_endpoint.py
+++ b/client/verta/tests/unit_tests/test_endpoint.py
@@ -69,212 +69,238 @@ GET_STATUS_RESPONSE: Dict[str, Any] = {
 GET_ACCESS_TOKEN_RESPONSE: str = "123-test-456-token-789"
 
 
-# TODO: Implement a less verbose, more universal method of patching method and http calls.
-@patch(f"{VERTA_CLASS}.get_status", return_value=GET_STATUS_RESPONSE)
-@patch(f"{VERTA_CLASS}._get_json_by_id", return_value=GET_JSON_BY_ID_RESPONSE)
-@patch(f"{VERTA_CLASS}.get_access_token", return_value=GET_ACCESS_TOKEN_RESPONSE)
-def test_get_deployed_model_call_get_status(
-    mock_get_access_token, mock_get_json_by_id, mock_get_status, mock_endpoint, mock_conn
-) -> None:
-    """Verify that get_deployed_model calls the methods it should with the expected params"""
-    mock_endpoint.get_deployed_model()
-    mock_get_status.assert_called_once()
-    mock_get_json_by_id.assert_called_once_with(mock_conn, WORKSPACE_ID, DEPLOYMENT_ID)
-    mock_get_access_token.assert_called_once()
+class TestGetDeployedModel:
+    # TODO: Implement a less verbose, more universal method of patching method and http calls.
+    @patch(f"{VERTA_CLASS}.get_status", return_value=GET_STATUS_RESPONSE)
+    @patch(f"{VERTA_CLASS}._get_json_by_id", return_value=GET_JSON_BY_ID_RESPONSE)
+    @patch(f"{VERTA_CLASS}.get_access_token", return_value=GET_ACCESS_TOKEN_RESPONSE)
+    def test_get_deployed_model_call_get_status(
+        self,
+        mock_get_access_token,
+        mock_get_json_by_id,
+        mock_get_status,
+        mock_endpoint,
+        mock_conn,
+    ) -> None:
+        """Verify that get_deployed_model calls the methods it should with the expected params"""
+        mock_endpoint.get_deployed_model()
+        mock_get_status.assert_called_once()
+        mock_get_json_by_id.assert_called_once_with(
+            mock_conn, WORKSPACE_ID, DEPLOYMENT_ID
+        )
+        mock_get_access_token.assert_called_once()
 
+    @patch(f"{VERTA_CLASS}.get_status", return_value=GET_STATUS_RESPONSE)
+    @patch(f"{VERTA_CLASS}._get_json_by_id", return_value=GET_JSON_BY_ID_RESPONSE)
+    @patch(f"{VERTA_CLASS}.get_access_token", return_value=GET_ACCESS_TOKEN_RESPONSE)
+    def test_get_deployed_model_with_full_url(
+        self,
+        mock_get_access_token,  # pass in patched methods in order
+        mock_get_json_by_id,
+        mock_get_status,
+        mock_endpoint,
+    ) -> None:
+        """Verify that the get_deployed_model method returns the correct value for the full_url when it is returned
+        by the get_json_by_id method.  The 'full_url' key was added to the schema of the response 10/2022.
+        """
+        deployed_model = mock_endpoint.get_deployed_model()
+        assert (
+            deployed_model.prediction_url
+            == "https://test_socket/api/v1/predict/test_path"
+        )
 
-@patch(f"{VERTA_CLASS}.get_status", return_value=GET_STATUS_RESPONSE)
-@patch(f"{VERTA_CLASS}._get_json_by_id", return_value=GET_JSON_BY_ID_RESPONSE)
-@patch(f"{VERTA_CLASS}.get_access_token", return_value=GET_ACCESS_TOKEN_RESPONSE)
-def test_get_deployed_model_with_full_url(
-    mock_get_access_token,  # pass in patched methods in order
-    mock_get_json_by_id,
-    mock_get_status,
-    mock_endpoint,
-) -> None:
-    """Verify that the get_deployed_model method returns the correct value for the full_url when it is returned
-    by the get_json_by_id method.  The 'full_url' key was added to the schema of the response 10/2022.
-    """
-    deployed_model = mock_endpoint.get_deployed_model()
-    assert (
-        deployed_model.prediction_url == "https://test_socket/api/v1/predict/test_path"
+    GET_JSON_BY_ID_RESPONSE_MISSING_URL: Dict[str, Any] = deepcopy(
+        GET_JSON_BY_ID_RESPONSE
     )
+    GET_JSON_BY_ID_RESPONSE_MISSING_URL.pop(
+        "full_url"
+    )  # Remove the full url key and value from the dict.
 
-
-GET_JSON_BY_ID_RESPONSE_MISSING_URL: Dict[str, Any] = deepcopy(GET_JSON_BY_ID_RESPONSE)
-GET_JSON_BY_ID_RESPONSE_MISSING_URL.pop(
-    "full_url"
-)  # Remove the full url key and value from the dict.
-
-
-@patch(f"{VERTA_CLASS}.get_status", return_value=GET_STATUS_RESPONSE)
-@patch(
-    f"{VERTA_CLASS}._get_json_by_id", return_value=GET_JSON_BY_ID_RESPONSE_MISSING_URL
-)
-@patch(f"{VERTA_CLASS}.get_access_token", return_value=GET_ACCESS_TOKEN_RESPONSE)
-def test_get_deployed_model_missing_full_url(
-    mock_get_access_token,  # pass in patched methods in order
-    mock_get_json_by_id,
-    mock_get_status,
-    mock_endpoint,
-) -> None:
-    """Verify that the get_deployed_model method returns the correct value for the full_url when it is returned
-    by the get_json_by_id method.  The 'full_url' key was added to the schema of the response 10/2022.
-    """
-    deployed_model = mock_endpoint.get_deployed_model()
-    assert (
-        deployed_model.prediction_url == "https://test_socket/api/v1/predict/test_path"
+    @patch(f"{VERTA_CLASS}.get_status", return_value=GET_STATUS_RESPONSE)
+    @patch(
+        f"{VERTA_CLASS}._get_json_by_id",
+        return_value=GET_JSON_BY_ID_RESPONSE_MISSING_URL,
     )
+    @patch(f"{VERTA_CLASS}.get_access_token", return_value=GET_ACCESS_TOKEN_RESPONSE)
+    def test_get_deployed_model_missing_full_url(
+        self,
+        mock_get_access_token,  # pass in patched methods in order
+        mock_get_json_by_id,
+        mock_get_status,
+        mock_endpoint,
+    ) -> None:
+        """Verify that the get_deployed_model method returns the correct value for the full_url when it is returned
+        by the get_json_by_id method.  The 'full_url' key was added to the schema of the response 10/2022.
+        """
+        deployed_model = mock_endpoint.get_deployed_model()
+        assert (
+            deployed_model.prediction_url
+            == "https://test_socket/api/v1/predict/test_path"
+        )
 
 
-@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
-@given(
-    kafka_settings=mock_kafka_settings(),
-    kafka_configs_response=mock_kafka_configs_response(),
-)
-def test_kafka_cluster_config_id_default(
-    kafka_settings,
-    kafka_configs_response,
-    mock_endpoint,
-    mock_conn,
-    mocked_responses,
-    mock_registered_model_version,
-) -> None:
-    """Verify that, while updating an endpoint, not including a `cluster_config_id`
-    in the KafkaSettings results in the correct sequence of HTTP requests, including
-    a call to fetch the ID of the current Kafka config by default."""
-    deployment_url = f"{mock_conn.scheme}://{mock_conn.socket}/api/v1/deployment"
-    stages_url = (
-        f"{deployment_url}/workspace/{WORKSPACE_ID}/endpoints/{DEPLOYMENT_ID}/stages"
+class TestKafka:
+    @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+    @given(
+        kafka_settings=mock_kafka_settings(),
+        kafka_configs_response=mock_kafka_configs_response(),
     )
-    put_config_url = f"{deployment_url}/stages/654/kafka"
-    builds_url = f"{deployment_url}/workspace/{WORKSPACE_ID}/builds"
+    def test_kafka_cluster_config_id_default(
+        self,
+        kafka_settings,
+        kafka_configs_response,
+        mock_endpoint,
+        mock_conn,
+        mocked_responses,
+        mock_registered_model_version,
+    ) -> None:
+        """Verify that, while updating an endpoint, not including a `cluster_config_id`
+        in the KafkaSettings results in the correct sequence of HTTP requests, including
+        a call to fetch the ID of the current Kafka config by default."""
+        deployment_url = f"{mock_conn.scheme}://{mock_conn.socket}/api/v1/deployment"
+        stages_url = f"{deployment_url}/workspace/{WORKSPACE_ID}/endpoints/{DEPLOYMENT_ID}/stages"
+        put_config_url = f"{deployment_url}/stages/654/kafka"
+        builds_url = f"{deployment_url}/workspace/{WORKSPACE_ID}/builds"
 
-    get_configs_url = f"{mock_conn.scheme}://{mock_conn.socket}/api/v1/uac-proxy/system_admin/listKafkaConfiguration"
+        get_configs_url = f"{mock_conn.scheme}://{mock_conn.socket}/api/v1/uac-proxy/system_admin/listKafkaConfiguration"
 
-    with mocked_responses as _responses:
-        # Mock all HTTP requests involved
-        _responses.get(url=stages_url, status=200, json={"stages": [{"id": STAGE_ID}]})
-        _responses.get(url=stages_url + f"/{STAGE_ID}", status=200, json={"id": STAGE_ID})
-        _responses.put(url=stages_url + f"/{STAGE_ID}/update", status=200, json={"id": STAGE_ID})
-        _responses.get(url=get_configs_url, status=200, json=kafka_configs_response)
-        _responses.put(
-            url=put_config_url,
-            status=200,
-            json={"update_request": {"cluster_config_id": KAFKA_CONFIG_ID}},
-        )
-        _responses.post(
-            url=builds_url, status=200, json={"id": BUILD_ID, "status": "succeeded"}
-        )
+        with mocked_responses as _responses:
+            # Mock all HTTP requests involved
+            _responses.get(
+                url=stages_url, status=200, json={"stages": [{"id": STAGE_ID}]}
+            )
+            _responses.get(
+                url=stages_url + f"/{STAGE_ID}", status=200, json={"id": STAGE_ID}
+            )
+            _responses.put(
+                url=stages_url + f"/{STAGE_ID}/update",
+                status=200,
+                json={"id": STAGE_ID},
+            )
+            _responses.get(url=get_configs_url, status=200, json=kafka_configs_response)
+            _responses.put(
+                url=put_config_url,
+                status=200,
+                json={"update_request": {"cluster_config_id": KAFKA_CONFIG_ID}},
+            )
+            _responses.post(
+                url=builds_url, status=200, json={"id": BUILD_ID, "status": "succeeded"}
+            )
 
-        mock_endpoint.update(
-            mock_registered_model_version, kafka_settings=kafka_settings
-        )
-        _responses.assert_call_count(get_configs_url, 1)
-
-
-@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
-@given(kafka_settings=mock_kafka_settings_with_config_id())
-def test_kafka_cluster_config_id_value(
-    kafka_settings,
-    mock_endpoint,
-    mock_conn,
-    mocked_responses,
-    mock_registered_model_version,
-) -> None:
-    """Verify that, while updating an endpoint, the provided value for
-    `cluster_config_id` is used, resulting in the correct sequence of HTTP
-    requests.
-    """
-    deployment_url = f"{mock_conn.scheme}://{mock_conn.socket}/api/v1/deployment"
-    stages_url = (
-        f"{deployment_url}/workspace/{WORKSPACE_ID}/endpoints/{DEPLOYMENT_ID}/stages"
-    )
-    put_config_url = f"{deployment_url}/stages/{STAGE_ID}/kafka"
-    builds_url = f"{deployment_url}/workspace/{WORKSPACE_ID}/builds"
-
-    with mocked_responses as _responses:
-        # Mock all HTTP requests involved
-        _responses.get(url=stages_url, status=200, json={"stages": [{"id": STAGE_ID}]})
-        _responses.put(
-            url=put_config_url,
-            status=200,
-            json={"update_request": {"cluster_config_id": KAFKA_CONFIG_ID}},
-        )
-        _responses.post(
-            url=builds_url, status=200, json={"id": BUILD_ID, "status": "succeeded"}
-        )
-        _responses.put(url=stages_url + f"/{STAGE_ID}/update", status=200, json={"id": STAGE_ID})
-        _responses.get(url=stages_url + f"/{STAGE_ID}", status=200, json={"id": STAGE_ID})
-        mock_endpoint.update(
-            mock_registered_model_version, kafka_settings=kafka_settings
-        )
-
-
-@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
-@given(
-    kafka_settings=mock_kafka_settings(),
-    kafka_configs_response=mock_kafka_configs_response(),
-)
-def test_kafka_config_missing_config_id_exception(
-    kafka_settings,
-    kafka_configs_response,
-    mock_endpoint,
-    mock_conn,
-    mocked_responses,
-    mock_registered_model_version,
-) -> None:
-    """In the unlikely evert the ID of a found Kafka config is missing from the
-    backend response, the expected exception is raised.
-    """
-    kafka_configs_response["configurations"][0].pop("id")
-    deployment_url = f"{mock_conn.scheme}://{mock_conn.socket}/api/v1/deployment"
-    stages_url = (
-        f"{deployment_url}/workspace/{WORKSPACE_ID}/endpoints/{DEPLOYMENT_ID}/stages"
-    )
-    get_configs_url = f"{mock_conn.scheme}://{mock_conn.socket}/api/v1/uac-proxy/system_admin/listKafkaConfiguration"
-
-    with mocked_responses as _responses:
-        # Mock all HTTP requests before bad config is encountered
-        _responses.get(url=stages_url, status=200, json={"stages": [{"id": STAGE_ID}]})
-        _responses.get(url=get_configs_url, status=200, json=kafka_configs_response)
-        with pytest.raises(RuntimeError) as err:
             mock_endpoint.update(
                 mock_registered_model_version, kafka_settings=kafka_settings
             )
-        assert (
-            str(err.value)
-            == "active Kafka configuration is missing its ID; please notify the Verta"
-            " development team"
-        )
+            _responses.assert_call_count(get_configs_url, 1)
 
+    @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+    @given(kafka_settings=mock_kafka_settings_with_config_id())
+    def test_kafka_cluster_config_id_value(
+        self,
+        kafka_settings,
+        mock_endpoint,
+        mock_conn,
+        mocked_responses,
+        mock_registered_model_version,
+    ) -> None:
+        """Verify that, while updating an endpoint, the provided value for
+        `cluster_config_id` is used, resulting in the correct sequence of HTTP
+        requests.
+        """
+        deployment_url = f"{mock_conn.scheme}://{mock_conn.socket}/api/v1/deployment"
+        stages_url = f"{deployment_url}/workspace/{WORKSPACE_ID}/endpoints/{DEPLOYMENT_ID}/stages"
+        put_config_url = f"{deployment_url}/stages/{STAGE_ID}/kafka"
+        builds_url = f"{deployment_url}/workspace/{WORKSPACE_ID}/builds"
 
-@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
-@given(kafka_settings=mock_kafka_settings())
-def test_no_kafka_configs_found_exception(
-    kafka_settings,
-    mock_endpoint,
-    mock_conn,
-    mocked_responses,
-    mock_registered_model_version,
-) -> None:
-    """If no valid Kafka configurations are found, the expected exception is raised."""
-    deployment_url = f"{mock_conn.scheme}://{mock_conn.socket}/api/v1/deployment"
-    stages_url = (
-        f"{deployment_url}/workspace/{WORKSPACE_ID}/endpoints/{DEPLOYMENT_ID}/stages"
-    )
-    get_configs_url = f"{mock_conn.scheme}://{mock_conn.socket}/api/v1/uac-proxy/system_admin/listKafkaConfiguration"
-
-    with mocked_responses as _responses:
-        # Mock all HTTP requests before lack of Kafka configs is encountered
-        _responses.get(url=stages_url, status=200, json={"stages": [{"id": STAGE_ID}]})
-        _responses.get(url=get_configs_url, status=200, json={"configurations": []})
-        with pytest.raises(RuntimeError) as err:
+        with mocked_responses as _responses:
+            # Mock all HTTP requests involved
+            _responses.get(
+                url=stages_url, status=200, json={"stages": [{"id": STAGE_ID}]}
+            )
+            _responses.put(
+                url=put_config_url,
+                status=200,
+                json={"update_request": {"cluster_config_id": KAFKA_CONFIG_ID}},
+            )
+            _responses.post(
+                url=builds_url, status=200, json={"id": BUILD_ID, "status": "succeeded"}
+            )
+            _responses.put(
+                url=stages_url + f"/{STAGE_ID}/update",
+                status=200,
+                json={"id": STAGE_ID},
+            )
+            _responses.get(
+                url=stages_url + f"/{STAGE_ID}", status=200, json={"id": STAGE_ID}
+            )
             mock_endpoint.update(
                 mock_registered_model_version, kafka_settings=kafka_settings
             )
-        assert (
-            str(err.value)
-            == "no Kafka configuration found; please ensure that Kafka is configured in"
-            " Verta"
-        )
+
+    @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+    @given(
+        kafka_settings=mock_kafka_settings(),
+        kafka_configs_response=mock_kafka_configs_response(),
+    )
+    def test_kafka_config_missing_config_id_exception(
+        self,
+        kafka_settings,
+        kafka_configs_response,
+        mock_endpoint,
+        mock_conn,
+        mocked_responses,
+        mock_registered_model_version,
+    ) -> None:
+        """In the unlikely evert the ID of a found Kafka config is missing from the
+        backend response, the expected exception is raised.
+        """
+        kafka_configs_response["configurations"][0].pop("id")
+        deployment_url = f"{mock_conn.scheme}://{mock_conn.socket}/api/v1/deployment"
+        stages_url = f"{deployment_url}/workspace/{WORKSPACE_ID}/endpoints/{DEPLOYMENT_ID}/stages"
+        get_configs_url = f"{mock_conn.scheme}://{mock_conn.socket}/api/v1/uac-proxy/system_admin/listKafkaConfiguration"
+
+        with mocked_responses as _responses:
+            # Mock all HTTP requests before bad config is encountered
+            _responses.get(
+                url=stages_url, status=200, json={"stages": [{"id": STAGE_ID}]}
+            )
+            _responses.get(url=get_configs_url, status=200, json=kafka_configs_response)
+            with pytest.raises(RuntimeError) as err:
+                mock_endpoint.update(
+                    mock_registered_model_version, kafka_settings=kafka_settings
+                )
+            assert (
+                str(err.value)
+                == "active Kafka configuration is missing its ID; please notify the Verta"
+                " development team"
+            )
+
+    @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+    @given(kafka_settings=mock_kafka_settings())
+    def test_no_kafka_configs_found_exception(
+        self,
+        kafka_settings,
+        mock_endpoint,
+        mock_conn,
+        mocked_responses,
+        mock_registered_model_version,
+    ) -> None:
+        """If no valid Kafka configurations are found, the expected exception is raised."""
+        deployment_url = f"{mock_conn.scheme}://{mock_conn.socket}/api/v1/deployment"
+        stages_url = f"{deployment_url}/workspace/{WORKSPACE_ID}/endpoints/{DEPLOYMENT_ID}/stages"
+        get_configs_url = f"{mock_conn.scheme}://{mock_conn.socket}/api/v1/uac-proxy/system_admin/listKafkaConfiguration"
+
+        with mocked_responses as _responses:
+            # Mock all HTTP requests before lack of Kafka configs is encountered
+            _responses.get(
+                url=stages_url, status=200, json={"stages": [{"id": STAGE_ID}]}
+            )
+            _responses.get(url=get_configs_url, status=200, json={"configurations": []})
+            with pytest.raises(RuntimeError) as err:
+                mock_endpoint.update(
+                    mock_registered_model_version, kafka_settings=kafka_settings
+                )
+            assert (
+                str(err.value)
+                == "no Kafka configuration found; please ensure that Kafka is configured in"
+                " Verta"
+            )


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

We have two distinct groups of unit tests for `Endpoint` (deployed model and Kafka) so I'm giving them their own `class`es.

I also applied `black` because I don't know how to turn it off in my IDE.

## Risks and Area of Effect

—

## Testing
- [x] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

In Python 3.10:

```
 % pytest unit_tests/test_endpoint.py 
==================================================== test session starts ====================================================
platform darwin -- Python 3.10.6, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/miliu/Documents/modeldb/client/verta/tests, configfile: pytest.ini
plugins: forked-1.4.0, xdist-3.1.0, typeguard-2.13.3, hypothesis-6.67.1
collected 7 items                                                                                                           

unit_tests/test_endpoint.py .......                                                                                   [100%]

=============================================== 7 passed, 1 warning in 10.39s ===============================================
```

## Reverting
- [ ] Contains Migration - _Do Not Revert_

Revert this PR.