### PR TITLE
feat: [VRD-820] Implement `Build.date_created`

### DIFF
--- a/client/verta/tests/test_utils/test_time_utils.py
+++ b/client/verta/tests/test_utils/test_time_utils.py
@@ -89,3 +89,14 @@ class TestParseDuration:
         with pytest.warns(UserWarning):
             duration = time_utils.parse_duration(delta)
         assert duration == timedelta(milliseconds=millis)
+
+
+class TestDatetimeFromISO:
+    """Tests for :func:`verta._internal_utils.time_utils.datetime_from_iso`."""
+
+    @given(dt=st.datetimes())
+    def test_zulu(self, dt: datetime):
+        """Verify that we can parse timestamps with ISO 8601's Z suffix."""
+        date_string = dt.isoformat() + "Z"
+        parsed_dt = time_utils.datetime_from_iso(date_string)
+        assert dt == parsed_dt.replace(tzinfo=None)

--- a/client/verta/tests/unit_tests/deployment/test_build.py
+++ b/client/verta/tests/unit_tests/deployment/test_build.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from typing import Any, Dict
+
 from hypothesis import given, HealthCheck, settings
 
 from tests.unit_tests.strategies import build_dict
@@ -8,18 +10,22 @@ from verta._internal_utils import time_utils
 from verta.endpoint.build import Build
 
 
-@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
-@given(build_dict=build_dict())
-def test_instantiation(build_dict):
-    """Verify a Build object can be instantated from a dict."""
-    build = Build(build_dict)
-
+def assert_build_fields(build: Build, build_dict: Dict[str, Any]) -> None:
     assert build.id == build_dict["id"]
     assert build.date_created == time_utils.datetime_from_iso(
         build_dict["date_created"],
     )
     assert build.status == build_dict["status"]
     assert build.message == build_dict["message"] or Build._EMPTY_MESSAGE
+
+
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(build_dict=build_dict())
+def test_instantiation(build_dict):
+    """Verify a Build object can be instantated from a dict."""
+    build = Build(build_dict)
+
+    assert_build_fields(build, build_dict)
 
 
 @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
@@ -45,9 +51,4 @@ def test_endpoint_get_current_build(
 
         build = mock_endpoint.get_current_build()
 
-    assert build.id == build_dict["id"]
-    assert build.date_created == time_utils.datetime_from_iso(
-        build_dict["date_created"],
-    )
-    assert build.status == build_dict["status"]
-    assert build.message == build_dict["message"] or Build._EMPTY_MESSAGE
+    assert_build_fields(build, build_dict)

--- a/client/verta/tests/unit_tests/deployment/test_build.py
+++ b/client/verta/tests/unit_tests/deployment/test_build.py
@@ -19,6 +19,7 @@ def assert_build_fields(build: Build, build_dict: Dict[str, Any]) -> None:
     assert build.message == build_dict["message"] or Build._EMPTY_MESSAGE
 
 
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
 @given(build_dict=build_dict())
 def test_instantiation(build_dict):
     """Verify a Build object can be instantated from a dict."""

--- a/client/verta/tests/unit_tests/deployment/test_build.py
+++ b/client/verta/tests/unit_tests/deployment/test_build.py
@@ -4,6 +4,7 @@ from hypothesis import given, HealthCheck, settings
 
 from tests.unit_tests.strategies import build_dict
 
+from verta._internal_utils import time_utils
 from verta.endpoint.build import Build
 
 
@@ -14,6 +15,9 @@ def test_instantiation(build_dict):
     build = Build(build_dict)
 
     assert build.id == build_dict["id"]
+    assert build.date_created == time_utils.datetime_from_iso(
+        build_dict["date_created"],
+    )
     assert build.status == build_dict["status"]
     assert build.message == build_dict["message"] or Build._EMPTY_MESSAGE
 
@@ -42,5 +46,8 @@ def test_endpoint_get_current_build(
         build = mock_endpoint.get_current_build()
 
     assert build.id == build_dict["id"]
+    assert build.date_created == time_utils.datetime_from_iso(
+        build_dict["date_created"],
+    )
     assert build.status == build_dict["status"]
     assert build.message == build_dict["message"] or Build._EMPTY_MESSAGE

--- a/client/verta/tests/unit_tests/deployment/test_build.py
+++ b/client/verta/tests/unit_tests/deployment/test_build.py
@@ -19,7 +19,6 @@ def assert_build_fields(build: Build, build_dict: Dict[str, Any]) -> None:
     assert build.message == build_dict["message"] or Build._EMPTY_MESSAGE
 
 
-@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
 @given(build_dict=build_dict())
 def test_instantiation(build_dict):
     """Verify a Build object can be instantated from a dict."""

--- a/client/verta/verta/_internal_utils/time_utils.py
+++ b/client/verta/verta/_internal_utils/time_utils.py
@@ -67,6 +67,30 @@ def datetime_from_millis(millis):
     return UNIX_EPOCH + timedelta(milliseconds=millis)
 
 
+def datetime_from_iso(date_string) -> datetime:
+    """Basically the std lib's :func:`datetime.datetime.fromisoformat`.
+
+    Additionally has a handler for ISO 8601's Z suffix as returned by some of
+    our backends, which isn't supported until Python 3.11 [#]_.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        dt = datetime_from_iso("2011-11-04T00:05:23Z")
+        expected_dt = datetime(2011, 11, 4, 0, 5, 23, tzinfo=timezone.utc)
+        assert dt == expected_dt
+
+    References
+    ----------
+    .. [#] https://docs.python.org/3.11/library/datetime.html#datetime.datetime.fromisoformat
+
+    """
+    if date_string[-1] == "Z":
+        date_string = date_string[:-1] + "+00:00"
+    return datetime.fromisoformat(date_string)
+
+
 def parse_duration(value):
     duration = None
     if isinstance(value, six.string_types):

--- a/client/verta/verta/endpoint/build/_build.py
+++ b/client/verta/verta/endpoint/build/_build.py
@@ -25,6 +25,8 @@ class Build:
     ----------
     id : int
         Build ID.
+    date_created : timezone-aware :class:`~datetime.datetime`
+        The date and time when this build was created.
     status : str
         Status of the build (e.g. ``"building"``, ``"finished"``).
     message : str

--- a/client/verta/verta/endpoint/build/_build.py
+++ b/client/verta/verta/endpoint/build/_build.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 
-from verta._internal_utils import _utils
+from datetime import datetime
+
+from verta._internal_utils import _utils, time_utils
 
 
 class Build:
@@ -51,6 +53,10 @@ class Build:
     @property
     def id(self) -> int:
         return self._json["id"]
+
+    @property
+    def date_created(self) -> datetime:
+        return time_utils.datetime_from_iso(self._json["date_created"])
 
     @property
     def status(self) -> str:


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

Return `datetime` object as a new `Build.date_created` attribute.

## Risks and Area of Effect

None; entirely new functionality, covered by tests.

## Testing
- [x] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

In Python 3.10:

```
% pytest unit_tests/deployment/test_build.py 
==================================================== test session starts ====================================================
platform darwin -- Python 3.10.6, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/miliu/Documents/modeldb/client/verta/tests, configfile: pytest.ini
plugins: forked-1.4.0, xdist-3.1.0, typeguard-2.13.3, hypothesis-6.67.1
collected 2 items                                                                                                           

unit_tests/deployment/test_build.py ..                                                                                [100%]

=============================================== 2 passed, 1 warning in 2.67s ================================================
```

## Reverting
- [ ] Contains Migration - _Do Not Revert_

Revert this PR.