### PR TITLE
test: Mock classes to override repr

### DIFF
--- a/client/verta/tests/unit_tests/conftest.py
+++ b/client/verta/tests/unit_tests/conftest.py
@@ -54,11 +54,21 @@ def mocked_responses():
 
 @pytest.fixture
 def mock_endpoint(mock_conn, mock_config) -> Endpoint:
-    """Return a mocked object of the Endpoint class for use in tests"""
-    return Endpoint(conn=mock_conn, conf=mock_config, workspace=456, id=123)
+    class MockEndpoint(Endpoint):
+        def __repr__(self):
+            return object.__repr__(self)
+
+    return MockEndpoint(conn=mock_conn, conf=mock_config, workspace=456, id=123)
 
 
 @pytest.fixture(scope="session")
 def mock_registered_model_version(mock_conn, mock_config):
-    Message = _RegistryService.ModelVersion
-    return RegisteredModelVersion(mock_conn, mock_config, Message(id=555))
+    class MockRegisteredModelVersion(RegisteredModelVersion):
+        def __repr__(self):
+            return object.__repr__(self)
+
+    return MockRegisteredModelVersion(
+        mock_conn,
+        mock_config,
+        _RegistryService.ModelVersion(id=555),
+    )

--- a/client/verta/tests/unit_tests/conftest.py
+++ b/client/verta/tests/unit_tests/conftest.py
@@ -54,6 +54,8 @@ def mocked_responses():
 
 @pytest.fixture
 def mock_endpoint(mock_conn, mock_config) -> Endpoint:
+    """Return a mocked object of the Endpoint class for use in tests"""
+
     class MockEndpoint(Endpoint):
         def __repr__(self):  # avoid network calls when displaying test results
             return object.__repr__(self)
@@ -63,6 +65,8 @@ def mock_endpoint(mock_conn, mock_config) -> Endpoint:
 
 @pytest.fixture(scope="session")
 def mock_registered_model_version(mock_conn, mock_config):
+    """Return a mocked object of the RegisteredModelVersion class for use in tests"""
+
     class MockRegisteredModelVersion(RegisteredModelVersion):
         def __repr__(self):  # avoid network calls when displaying test results
             return object.__repr__(self)

--- a/client/verta/tests/unit_tests/conftest.py
+++ b/client/verta/tests/unit_tests/conftest.py
@@ -55,7 +55,7 @@ def mocked_responses():
 @pytest.fixture
 def mock_endpoint(mock_conn, mock_config) -> Endpoint:
     class MockEndpoint(Endpoint):
-        def __repr__(self):
+        def __repr__(self):  # avoid network calls when displaying test results
             return object.__repr__(self)
 
     return MockEndpoint(conn=mock_conn, conf=mock_config, workspace=456, id=123)
@@ -64,7 +64,7 @@ def mock_endpoint(mock_conn, mock_config) -> Endpoint:
 @pytest.fixture(scope="session")
 def mock_registered_model_version(mock_conn, mock_config):
     class MockRegisteredModelVersion(RegisteredModelVersion):
-        def __repr__(self):
+        def __repr__(self):  # avoid network calls when displaying test results
             return object.__repr__(self)
 
     return MockRegisteredModelVersion(


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

Our test suite had a bad interaction between

- `hypothesis`
- mocked `Connection`s
- `verta` client objects that attempt networked calls in their `__repr__()`s

After 3 days of wrestling with it, what seems to be happening is

1. Test legitimately fails.
2. Hypothesis attempts to helpfully display a falsifying example, printing fixture values' `__repr__()`s.
3. _That_ fails, because `Endpoint` and `RegisteredModelVersion` make network calls in their `__repr__()`s, but they have mocked connections.
4. Hypothesis ends up outputting
   ```
   requests.exceptions.ConnectionError: HTTPSConnectionPool(host='test_socket', port=443):
   Max retries exceeded with url: /api/v1/registry/registered_models/0 (Caused by
   NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x106479570>: Failed to establish a
   new connection: [Errno 8] nodename nor servname provided, or not known'))
   ```
   trying to use [`https://test_socket/` from the mocked connection](https://github.com/VertaAI/modeldb/blob/afed6e936e0ab0956113a3cfedeeb735e3ab2db6/client/verta/tests/unit_tests/conftest.py#L40), obfuscating the actual test failure, basically just saying, "Your test failed for some reason. Good luck."

## Risks and Area of Effect

This would break any unit tests that check our objects' `__repr__()`s, but currently none do. We can deal with that when we get there 😬

## Testing
- [x] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

```
% pytest unit_tests
==================================================== test session starts ====================================================
platform darwin -- Python 3.10.6, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/miliu/Documents/modeldb/client/verta/tests, configfile: pytest.ini
plugins: forked-1.4.0, xdist-3.1.0, typeguard-2.13.3, hypothesis-6.67.1
collected 83 items                                                                                                          

unit_tests/test_runtime.py ..........................                                                                 [ 31%]
unit_tests/client/test_get_kafka_topics.py .                                                                          [ 32%]
unit_tests/custom_modules/test_custom_modules_util.py ....                                                            [ 37%]
unit_tests/deployment/test_build.py ...                                                                               [ 40%]
unit_tests/deployment/test_build_scan.py ..                                                                           [ 43%]
unit_tests/deployment/test_deployed_model.py .....................                                                    [ 68%]
unit_tests/deployment/test_endpoint.py .......                                                                        [ 77%]
unit_tests/internal_utils/test_kafka_utils.py ...                                                                     [ 80%]
unit_tests/registry/test_check_model_dependencies.py ...                                                              [ 84%]
unit_tests/registry/test_model_dependencies.py ............                                                           [ 98%]
unit_tests/registry/test_registered_model_version.py .                                                                [100%]

============================================== 83 passed, 3 warnings in 48.77s ==============================================
```

## Reverting
- [ ] Contains Migration - _Do Not Revert_

Revert this PR.