### PR TITLE
tests: Optionalize external_scan in unit test strategies

### DIFF
--- a/client/verta/tests/unit_tests/deployment/test_build_scan.py
+++ b/client/verta/tests/unit_tests/deployment/test_build_scan.py
@@ -5,7 +5,6 @@ from typing import Any, Dict
 from hypothesis import given, HealthCheck, settings
 from responses.matchers import json_params_matcher
 
-
 from tests.unit_tests.strategies import build_dict, build_scan_dict
 
 from verta._internal_utils import time_utils

--- a/client/verta/tests/unit_tests/deployment/test_build_scan.py
+++ b/client/verta/tests/unit_tests/deployment/test_build_scan.py
@@ -3,7 +3,8 @@
 from typing import Any, Dict
 
 from hypothesis import given, HealthCheck, settings
-import pytest
+from responses.matchers import json_params_matcher
+
 
 from tests.unit_tests.strategies import build_dict, build_scan_dict
 
@@ -51,6 +52,7 @@ def test_get_scan(mock_conn, mocked_responses, build_dict, build_scan_dict):
 
     assert_build_scan_fields(build_scan, build_scan_dict)
 
+
 @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
 @given(
     build_dict=build_dict(external_scan=True),
@@ -64,7 +66,12 @@ def test_start_external_scan(mock_conn, mocked_responses, build_dict, build_scan
     scan_url = f"{deployment_url}/builds/{build.id}/scan"
 
     with mocked_responses as rsps:
-        rsps.post(url=scan_url, status=200, json=build_scan_dict)
+        rsps.post(
+            url=scan_url,
+            status=200,
+            match=[json_params_matcher({"scan_external": True})],
+            json=build_scan_dict,
+        )
 
         build_scan = build.start_scan(external=True)
 

--- a/client/verta/tests/unit_tests/strategies.py
+++ b/client/verta/tests/unit_tests/strategies.py
@@ -147,13 +147,15 @@ def mock_kafka_settings_with_config_id(draw) -> KafkaSettings:
 
 
 @st.composite
-def build_dict(draw, external_scan: bool = False) -> Dict[str, Any]:
+def build_dict(draw, external_scan: Optional[bool] = None) -> Dict[str, Any]:
     """Generate a Verta model build, as returned by /api/v1/deployment/builds/{build_id}
     with option to force external scan to True for specific testing scenarios.
     """
     creator_request = {
         "requires_root": draw(st.booleans()),
-        "scan_external": True if external_scan else draw(st.booleans()),
+        "scan_external": draw(st.booleans())
+        if external_scan is None
+        else external_scan,
         "self_contained": draw(st.booleans()),
         "uses_flask": draw(st.booleans()),
     }
@@ -202,7 +204,9 @@ def build_scan_dict(draw, external_scan: Optional[bool] = None) -> Dict[str, Any
     """
     d = {
         "creator_request": {
-            "scan_external": True if external_scan else draw(st.booleans()),
+            "scan_external": draw(st.booleans())
+            if external_scan is None
+            else external_scan,
         },
         "date_updated": draw(st.datetimes()).isoformat(timespec="milliseconds") + "Z",
         "details": None,

--- a/client/verta/tests/unit_tests/strategies.py
+++ b/client/verta/tests/unit_tests/strategies.py
@@ -149,7 +149,7 @@ def mock_kafka_settings_with_config_id(draw) -> KafkaSettings:
 @st.composite
 def build_dict(draw, external_scan: Optional[bool] = None) -> Dict[str, Any]:
     """Generate a Verta model build, as returned by /api/v1/deployment/builds/{build_id}
-    with option to force external scan to True for specific testing scenarios.
+    with the option to force scan_external to True for specific testing scenarios.
     """
     creator_request = {
         "requires_root": draw(st.booleans()),


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

https://github.com/VertaAI/modeldb/pull/3778#discussion_r1178452128

## Risks and Area of Effect

We don't have tests that use `external_scan=False` (and arguably with the way we're mocking responses, we're not _really_ verifying `external_scan=True` either) so this change is somewhat moot until we add more testing.

The code is straightforward though, so I wouldn't say it's risky on its own.

## Testing
- [x] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

Tests pass in Python 3.10

```zsh
% pytest unit_tests
==================================================== test session starts ====================================================
platform darwin -- Python 3.10.6, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/miliu/Documents/modeldb/client/verta/tests, configfile: pytest.ini
plugins: forked-1.4.0, xdist-3.1.0, typeguard-2.13.3, hypothesis-6.67.1
collected 85 items                                                                                                          

unit_tests/test_runtime.py ..........................                                                                 [ 30%]
unit_tests/client/test_get_kafka_topics.py .                                                                          [ 31%]
unit_tests/custom_modules/test_custom_modules_util.py ....                                                            [ 36%]
unit_tests/deployment/test_build.py ....                                                                              [ 41%]
unit_tests/deployment/test_build_scan.py ...                                                                          [ 44%]
unit_tests/deployment/test_deployed_model.py .....................                                                    [ 69%]
unit_tests/deployment/test_endpoint.py .......                                                                        [ 77%]
unit_tests/internal_utils/test_kafka_utils.py ...                                                                     [ 81%]
unit_tests/registry/test_check_model_dependencies.py ...                                                              [ 84%]
unit_tests/registry/test_model_dependencies.py ............                                                           [ 98%]
unit_tests/registry/test_registered_model_version.py .                                                                [100%]

============================================== 85 passed, 3 warnings in 50.66s ==============================================
```

## Reverting
- [ ] Contains Migration - _Do Not Revert_

Revert this PR.