### PR TITLE
feat: add get_dataset_versions method to RegisteredModelVersion object

### DIFF
--- a/client/verta/tests/registry/model_version/test_log_dataset.py
+++ b/client/verta/tests/registry/model_version/test_log_dataset.py
@@ -32,10 +32,10 @@ class TestLogDataset:
         dataset = model_version.get_dataset_version(key3)
         assert dataset_version3.id == dataset.id
 
-        dataset_versions =  model_version.get_dataset_versions()
-        assert dataset_versions[key1].id == dataset_version1.id
-        assert dataset_versions[key2].id == dataset_version2.id
-        assert dataset_versions[key3].id == dataset_version3.id
+        dataset_versions = model_version.get_dataset_versions()
+        assert dataset_versions[0].id == dataset_version1.id
+        assert dataset_versions[1].id == dataset_version2.id
+        assert dataset_versions[2].id == dataset_version3.id
 
         with pytest.raises(KeyError, match="no dataset found with key"):
             model_version.del_dataset_version("fake")

--- a/client/verta/tests/registry/model_version/test_log_dataset.py
+++ b/client/verta/tests/registry/model_version/test_log_dataset.py
@@ -32,6 +32,11 @@ class TestLogDataset:
         dataset = model_version.get_dataset_version(key3)
         assert dataset_version3.id == dataset.id
 
+        dataset_versions =  model_version.get_dataset_versions()
+        assert dataset_versions[key1].id == dataset_version1.id
+        assert dataset_versions[key2].id == dataset_version2.id
+        assert dataset_versions[key3].id == dataset_version3.id
+
         with pytest.raises(KeyError, match="no dataset found with key"):
             model_version.del_dataset_version("fake")
 

--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -1668,27 +1668,27 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
     
     def get_dataset_versions(self):
         """
-        Gets all the ``DatasetVersion``\ s associated with this Model Version.
+        Gets all DatasetVersions associated with this Model Version.
 
         Returns
         -------
-        dict of :class:`~verta.dataset.entities.DatasetVersion`
-            DatasetVersion associated with the given key.
-
+        list of :class:`~verta.dataset.entities.DatasetVersion`
+            DatasetVersions associated with this Model Version.
         """
         self._refresh_cache()
 
-        dataset_versions = dict()
+        dataset_versions = list()
 
         for dataset in self._msg.datasets:
-            dataset_versions[dataset.key] = _dataset_version.DatasetVersion(
+            dataset_versions.append(
+                _dataset_version.DatasetVersion(
                     self._conn,
                     self._conf,
                     _dataset_version.DatasetVersion._get_proto_by_id(
                         self._conn, dataset.linked_artifact_id
                     ),
                 )
-        
+            )
         return dataset_versions
 
     def del_dataset_version(self, key):

--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -1665,6 +1665,31 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
                 )
 
         raise KeyError("no dataset found with key {}".format(key))
+    
+    def get_dataset_versions(self):
+        """
+        Gets all the ``DatasetVersion``\ s with associated with this Model Version.
+
+        Returns
+        -------
+        dict of :class:`~verta.dataset.entities.DatasetVersion`
+            DatasetVersion associated with the given key.
+
+        """
+        self._refresh_cache()
+
+        dataset_versions = dict()
+
+        for dataset in self._msg.datasets:
+            dataset_versions[dataset.key] = _dataset_version.DatasetVersion(
+                    self._conn,
+                    self._conf,
+                    _dataset_version.DatasetVersion._get_proto_by_id(
+                        self._conn, dataset.linked_artifact_id
+                    ),
+                )
+        
+        return dataset_versions
 
     def del_dataset_version(self, key):
         """

--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -1668,7 +1668,7 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
     
     def get_dataset_versions(self):
         """
-        Gets all the ``DatasetVersion``\ s with associated with this Model Version.
+        Gets all the ``DatasetVersion``\ s associated with this Model Version.
 
         Returns
         -------


### PR DESCRIPTION
## Impact and Context

Allows fetching all dataset versions associated with a RegisteredModelVersion

## Risks and Area of Effect

## Testing
- [x] Unit test
```
(base) baasitsharief@Baasits-MBP tests % pytest registry/model_version/test_log_dataset.py 
=================================================================== test session starts ====================================================================
platform darwin -- Python 3.9.13, pytest-7.1.2, pluggy-1.0.0
rootdir: /Users/baasitsharief/code/VertaAI/modeldb/client/verta/tests, configfile: pytest.ini
plugins: anyio-3.5.0, hypothesis-6.75.2, dash-2.9.1
collected 1 item                                                                                                                                           

registry/model_version/test_log_dataset.py .                                                                                                         [100%]

==================================================================== 1 passed in 4.83s =====================================================================
```
- [ ] Deployed to dev env
- [ ] Other (explain) 

## Reverting
- [ ] Contains Migration - _Do Not Revert_