### PR TITLE
Update Readme.md: Remove "How to Contribute" line not in use

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ This version of ModelDB is built upon its predecessor from [CSAIL, MIT](https://
 - [Documentation](#documentation)
 - [Community](#community)
 - [Architecture](#architecture)
-- [How to Contribute](#how-to-contribute)
 - [License](#license)
 - [Thanks to Our Contributors](#thanks)
 


### PR DESCRIPTION
I noticed that the mentioned line  "How to Contribute" in "What's In This Document" lacked any description or content for the "How to Contribute" section. Consequently, it appeared superfluous and could potentially confuse or mislead contributors. To address this issue, I have made the necessary changes to the Readme file to remove the line entirely. Additionally, it ensures that the Readme accurately reflects the available information and helps new contributors get started on the right track.

<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

## Risks and Area of Effect

## Testing
- [ ] Unit test
- [ ] Deployed to dev env
- [x] Other (explain) 

## Reverting
- [ ] Contains Migration - _Do Not Revert_