### PR TITLE
chore: switch docker image to commit status

### DIFF
--- a/.github/workflows/java-build-push-test.yaml
+++ b/.github/workflows/java-build-push-test.yaml
@@ -53,6 +53,7 @@ jobs:
           pr_sha="${{ github.event.pull_request.head.sha }}"
           sha=${pr_sha:-$GITHUB_SHA}
           sha_details=$(TZ=UTC git show -s --format=%cd--%h --date='format-local:%Y-%m-%dT%H-%M-%S' --abbrev=7 $sha)
+          echo "sha=${sha}" >> $GITHUB_OUTPUT
           echo "tag=${branch}-${sha_details}" >> $GITHUB_OUTPUT
 
       - name: Docker image status update
@@ -112,7 +113,7 @@ jobs:
         uses: ouzi-dev/commit-status-updater@v2
         with:
           name: "Tag: ${{ steps.image_info.outputs.tag }}"
-          url: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}
+          url: "${{ github.server_url }}/${{ github.repository }}/commit/${{ steps.image_info.outputs.sha }}#comments"
           status: success
 
       - name: Test

--- a/.github/workflows/java-build-push-test.yaml
+++ b/.github/workflows/java-build-push-test.yaml
@@ -10,7 +10,7 @@ on:
 
 permissions:
   id-token: write # This is required for requesting the JWT
-  contents: read  # This is required for actions/checkout
+  contents: write  # Read is is required for actions/checkout, write is required to comment on commits
   pull-requests: write # This is needed for the coverage plugin to write comments to the PR
   packages: write
   statuses: write
@@ -58,7 +58,7 @@ jobs:
       - name: Docker image status update
         uses: ouzi-dev/commit-status-updater@v2
         with:
-          name: "Docker Tag: ${{ steps.image_info.outputs.tag }}"
+          name: "Tag: ${{ steps.image_info.outputs.tag }}"
           description: "Building..."
 
       - name: Set up JDK 11
@@ -81,7 +81,7 @@ jobs:
       - name: Docker image status update
         uses: ouzi-dev/commit-status-updater@v2
         with:
-          name: "Docker Tag: ${{ steps.image_info.outputs.tag }}"
+          name: "Tag: ${{ steps.image_info.outputs.tag }}"
           description: "Publishing..."
 
       - name: Inspect image to see if it already exists
@@ -103,16 +103,17 @@ jobs:
         env:
           ECR_REGISTRY: 493416687123.dkr.ecr.us-east-1.amazonaws.com/services/oss/modeldb/backend
 
-      - name: Docker image status update
-        uses: ouzi-dev/commit-status-updater@v2
-        with:
-          name: "Docker Tag: ${{ steps.image_info.outputs.tag }}"
-          status: success
-
       - name: Create commit comment
         uses: peter-evans/commit-comment@v2
         with:
           body: "Docker Tag: ${{ steps.image_info.outputs.tag }}"
+
+      - name: Docker image status update
+        uses: ouzi-dev/commit-status-updater@v2
+        with:
+          name: "Tag: ${{ steps.image_info.outputs.tag }}"
+          url: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}
+          status: success
 
       - name: Test
         env:

--- a/.github/workflows/java-build-push-test.yaml
+++ b/.github/workflows/java-build-push-test.yaml
@@ -59,6 +59,7 @@ jobs:
         uses: ouzi-dev/commit-status-updater@v2
         with:
           name: "Docker Tag: ${{ steps.image_info.outputs.tag }}"
+          url: ${{ steps.image_info.outputs.tag }}
           description: "Building..."
 
       - name: Set up JDK 11
@@ -82,6 +83,7 @@ jobs:
         uses: ouzi-dev/commit-status-updater@v2
         with:
           name: "Docker Tag: ${{ steps.image_info.outputs.tag }}"
+          url: ${{ steps.image_info.outputs.tag }}
           description: "Publishing..."
 
       - name: Inspect image to see if it already exists
@@ -107,6 +109,7 @@ jobs:
         uses: ouzi-dev/commit-status-updater@v2
         with:
           name: "Docker Tag: ${{ steps.image_info.outputs.tag }}"
+          url: ${{ steps.image_info.outputs.tag }}
           status: success
 
       - name: Test
@@ -159,4 +162,17 @@ jobs:
 
             Changed Files coverage (common): coverage ${{ steps.jacoco-common.outputs.coverage-changed-files }}
             Changed Files coverage (server): ${{ steps.jacoco-server.outputs.coverage-changed-files }}
+
+
+      - name: Total Code Coverage
+        uses: ouzi-dev/commit-status-updater@v2
+        with:
+          name: "Total Coverage - Common: ${{ steps.jacoco-common.outputs.coverage-overall }} / Server: ${{ steps.jacoco-server.outputs.coverage-overall }}"
+          status: success
+
+      - name: Total Code Coverage
+        uses: ouzi-dev/commit-status-updater@v2
+        with:
+          name: "Changed File Coverage - Common: ${{ steps.jacoco-common.outputs.coverage-overall }} / Server: ${{ steps.jacoco-server.outputs.coverage-overall }}"
+          status: success
 

--- a/.github/workflows/java-build-push-test.yaml
+++ b/.github/workflows/java-build-push-test.yaml
@@ -13,6 +13,7 @@ permissions:
   contents: read  # This is required for actions/checkout
   pull-requests: write # This is needed for the coverage plugin to write comments to the PR
   packages: write
+  statuses: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -54,6 +55,13 @@ jobs:
           sha_details=$(TZ=UTC git show -s --format=%cd--%h --date='format-local:%Y-%m-%dT%H-%M-%S' --abbrev=7 $sha)
           echo "tag=${branch}-${sha_details}" >> $GITHUB_OUTPUT
 
+      - name: Docker image
+        uses: ouzi-dev/commit-status-updater@v2
+        with:
+          description: |
+            Docker tag: ${{ steps.image_info.outputs.tag }}
+            Status: Building
+
       - name: Comment Docker tag
         if: "(github.event_name == 'pull_request' && github.event.pull_request)"
         uses: thollander/actions-comment-pull-request@v2
@@ -79,6 +87,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           BRANCH_NAME: ${{ steps.branch_names.outputs.current_branch }}
+
+      - name: Docker image
+        uses: ouzi-dev/commit-status-updater@v2
+        with:
+          description: |
+            Docker tag: ${{ steps.image_info.outputs.tag }}
+            Status: Publishing
 
       - name: Comment Docker tag
         if: "(github.event_name == 'pull_request' && github.event.pull_request)"
@@ -107,6 +122,14 @@ jobs:
             493416687123.dkr.ecr.us-east-1.amazonaws.com/services/oss/modeldb/backend:${{ steps.image_info.outputs.tag }}
         env:
           ECR_REGISTRY: 493416687123.dkr.ecr.us-east-1.amazonaws.com/services/oss/modeldb/backend
+
+      - name: Docker image
+        uses: ouzi-dev/commit-status-updater@v2
+        with:
+          status: success
+          description: |
+            Docker tag: ${{ steps.image_info.outputs.tag }}
+            Status: Published
 
       - name: Comment Docker tag
         if: "(github.event_name == 'pull_request' && github.event.pull_request)"

--- a/.github/workflows/java-build-push-test.yaml
+++ b/.github/workflows/java-build-push-test.yaml
@@ -59,7 +59,6 @@ jobs:
         uses: ouzi-dev/commit-status-updater@v2
         with:
           name: "Docker Tag: ${{ steps.image_info.outputs.tag }}"
-          url: ${{ steps.image_info.outputs.tag }}
           description: "Building..."
 
       - name: Set up JDK 11
@@ -83,7 +82,6 @@ jobs:
         uses: ouzi-dev/commit-status-updater@v2
         with:
           name: "Docker Tag: ${{ steps.image_info.outputs.tag }}"
-          url: ${{ steps.image_info.outputs.tag }}
           description: "Publishing..."
 
       - name: Inspect image to see if it already exists
@@ -109,8 +107,12 @@ jobs:
         uses: ouzi-dev/commit-status-updater@v2
         with:
           name: "Docker Tag: ${{ steps.image_info.outputs.tag }}"
-          url: ${{ steps.image_info.outputs.tag }}
           status: success
+
+      - name: Create commit comment
+        uses: peter-evans/commit-comment@v2
+        with:
+          body: "Docker Tag: ${{ steps.image_info.outputs.tag }}"
 
       - name: Test
         env:
@@ -151,28 +153,13 @@ jobs:
           debug-mode: false
           title: Backend Code Coverage
 
-      - name: Code Coverage
-        uses: ouzi-dev/commit-status-updater@v2
+      - name: Create Code Coverage comment
+        uses: peter-evans/commit-comment@v2
         with:
-          name: "Code Coverage (common -- server): ${{ steps.jacoco-common.outputs.coverage-overall }} -- ${{ steps.jacoco-server.outputs.coverage-overall }}"
-          status: success
-          description: |
+          body: |
             Total coverage (common): ${{ steps.jacoco-common.outputs.coverage-overall }}
             Total coverage (server): ${{ steps.jacoco-server.outputs.coverage-overall }}
 
             Changed Files coverage (common): coverage ${{ steps.jacoco-common.outputs.coverage-changed-files }}
             Changed Files coverage (server): ${{ steps.jacoco-server.outputs.coverage-changed-files }}
-
-
-      - name: Total Code Coverage
-        uses: ouzi-dev/commit-status-updater@v2
-        with:
-          name: "Total Coverage - Common: ${{ steps.jacoco-common.outputs.coverage-overall }} / Server: ${{ steps.jacoco-server.outputs.coverage-overall }}"
-          status: success
-
-      - name: Total Code Coverage
-        uses: ouzi-dev/commit-status-updater@v2
-        with:
-          name: "Changed File Coverage - Common: ${{ steps.jacoco-common.outputs.coverage-overall }} / Server: ${{ steps.jacoco-server.outputs.coverage-overall }}"
-          status: success
 

--- a/.github/workflows/java-build-push-test.yaml
+++ b/.github/workflows/java-build-push-test.yaml
@@ -55,21 +55,11 @@ jobs:
           sha_details=$(TZ=UTC git show -s --format=%cd--%h --date='format-local:%Y-%m-%dT%H-%M-%S' --abbrev=7 $sha)
           echo "tag=${branch}-${sha_details}" >> $GITHUB_OUTPUT
 
-      - name: Docker image
+      - name: Docker image status update
         uses: ouzi-dev/commit-status-updater@v2
         with:
-          description: |
-            Docker tag: ${{ steps.image_info.outputs.tag }}
-            Status: Building
-
-      - name: Comment Docker tag
-        if: "(github.event_name == 'pull_request' && github.event.pull_request)"
-        uses: thollander/actions-comment-pull-request@v2
-        with:
-          message: |
-            Docker tag: ${{ steps.image_info.outputs.tag }}
-            Status: Building
-          comment_tag: docker_tag_${{ steps.image_info.outputs.tag }}
+          name: "Docker Tag: ${{ steps.image_info.outputs.tag }}"
+          description: "Building..."
 
       - name: Set up JDK 11
         uses: actions/setup-java@v3
@@ -88,21 +78,11 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           BRANCH_NAME: ${{ steps.branch_names.outputs.current_branch }}
 
-      - name: Docker image
+      - name: Docker image status update
         uses: ouzi-dev/commit-status-updater@v2
         with:
-          description: |
-            Docker tag: ${{ steps.image_info.outputs.tag }}
-            Status: Publishing
-
-      - name: Comment Docker tag
-        if: "(github.event_name == 'pull_request' && github.event.pull_request)"
-        uses: thollander/actions-comment-pull-request@v2
-        with:
-          message: |
-            Docker tag: ${{ steps.image_info.outputs.tag }}
-            Status: Publishing
-          comment_tag: docker_tag_${{ steps.image_info.outputs.tag }}
+          name: "Docker Tag: ${{ steps.image_info.outputs.tag }}"
+          description: "Publishing..."
 
       - name: Inspect image to see if it already exists
         id: inspect_image
@@ -123,22 +103,11 @@ jobs:
         env:
           ECR_REGISTRY: 493416687123.dkr.ecr.us-east-1.amazonaws.com/services/oss/modeldb/backend
 
-      - name: Docker image
+      - name: Docker image status update
         uses: ouzi-dev/commit-status-updater@v2
         with:
+          name: "Docker Tag: ${{ steps.image_info.outputs.tag }}"
           status: success
-          description: |
-            Docker tag: ${{ steps.image_info.outputs.tag }}
-            Status: Published
-
-      - name: Comment Docker tag
-        if: "(github.event_name == 'pull_request' && github.event.pull_request)"
-        uses: thollander/actions-comment-pull-request@v2
-        with:
-          message: |
-            Docker tag: ${{ steps.image_info.outputs.tag }}
-            Status: Testing
-          comment_tag: docker_tag_${{ steps.image_info.outputs.tag }}
 
       - name: Test
         env:
@@ -179,20 +148,15 @@ jobs:
           debug-mode: false
           title: Backend Code Coverage
 
-      - name: Get the Coverage info
-        run: |
-          echo "Total coverage (common): ${{ steps.jacoco-common.outputs.coverage-overall }}"
-          echo "Changed Files coverage (common): coverage ${{ steps.jacoco-common.outputs.coverage-changed-files }}"
-          echo "Total coverage (server): ${{ steps.jacoco-server.outputs.coverage-overall }}"
-          echo "Changed Files coverage (server): ${{ steps.jacoco-server.outputs.coverage-changed-files }}"
-
-
-      - name: Comment Docker tag
-        if: "(github.event_name == 'pull_request' && github.event.pull_request)"
-        uses: thollander/actions-comment-pull-request@v2
+      - name: Code Coverage
+        uses: ouzi-dev/commit-status-updater@v2
         with:
-          message: |
-            Docker tag: ${{ steps.image_info.outputs.tag }}
-            Status: Complete
-          comment_tag: docker_tag_${{ steps.image_info.outputs.tag }}
+          name: "Code Coverage (common -- server): ${{ steps.jacoco-common.outputs.coverage-overall }} -- ${{ steps.jacoco-server.outputs.coverage-overall }}"
+          status: success
+          description: |
+            Total coverage (common): ${{ steps.jacoco-common.outputs.coverage-overall }}
+            Total coverage (server): ${{ steps.jacoco-server.outputs.coverage-overall }}
+
+            Changed Files coverage (common): coverage ${{ steps.jacoco-common.outputs.coverage-changed-files }}
+            Changed Files coverage (server): ${{ steps.jacoco-server.outputs.coverage-changed-files }}
 

--- a/.github/workflows/java-build-push-test.yaml
+++ b/.github/workflows/java-build-push-test.yaml
@@ -142,6 +142,7 @@ jobs:
           min-coverage-overall: 10
           min-coverage-changed-files: 70
           debug-mode: false
+          update-comment: true
           title: Common Code Coverage
 
       - name: Jacoco Report Server to PR
@@ -153,6 +154,7 @@ jobs:
           min-coverage-overall: 34
           min-coverage-changed-files: 70
           debug-mode: false
+          update-comment: true
           title: Backend Code Coverage
 
       - name: Create Code Coverage comment


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context
Docker tag is in commit status: 
<img width="838" alt="Screenshot 2023-05-26 at 12 04 26 PM" src="https://github.com/VertaAI/modeldb/assets/96086065/556f907b-265c-41f4-842b-017bed5597b2">

Also in commit comments for easy of finding later: 
<img width="890" alt="Screenshot 2023-05-26 at 12 07 03 PM" src="https://github.com/VertaAI/modeldb/assets/96086065/fb024b59-2165-4e17-a3d7-683865e68479">

<img width="1021" alt="Screenshot 2023-05-26 at 12 07 14 PM" src="https://github.com/VertaAI/modeldb/assets/96086065/24aea915-9430-42aa-abe4-d61b5601e543">

## Risks and Area of Effect

## Testing
- [ ] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

## Reverting
- [ ] Contains Migration - _Do Not Revert_