### PR TITLE
chore: depend on protos-all jar

### DIFF
--- a/.github/workflows/java-build-push-test.yaml
+++ b/.github/workflows/java-build-push-test.yaml
@@ -75,13 +75,16 @@ jobs:
           server-id: github-verta # Value of the distributionManagement/repository/id field of the pom.xml
 
       - name: Check formatting
-        run: mvn spotless:check
+        run: mvn -B spotless:check
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Build and Publish to GitHub Packages Apache Maven
         run: ./build_and_publish_backend.sh
         env:
           GITHUB_TOKEN: ${{ github.token }}
           BRANCH_NAME: ${{ steps.branch_names.outputs.current_branch }}
+          SHA: ${{ steps.image_info.outputs.sha }}
 
       - name: Update commit status with Docker image status
         uses: ouzi-dev/commit-status-updater@v2

--- a/backend/common/pom.xml
+++ b/backend/common/pom.xml
@@ -23,6 +23,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>ai.verta</groupId>
+            <artifactId>protos</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
         </dependency>
@@ -241,13 +246,6 @@
             .proto implementation of service to java code. -->
         <plugins>
             <plugin>
-                <groupId>org.xolstice.maven.plugins</groupId>
-                <artifactId>protobuf-maven-plugin</artifactId>
-                <configuration>
-                    <protoSourceRoot>../../protos/protos/public</protoSourceRoot>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>
             </plugin>
@@ -310,10 +308,10 @@
                             <includes>
                                 <include>ai/verta/modeldb/common/**</include>
                             </includes>
-                        </configuration>                        
+                        </configuration>
                     </execution>
                 </executions>
-            </plugin>                 
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/backend/common/pom.xml
+++ b/backend/common/pom.xml
@@ -21,10 +21,27 @@
         </dependencies>
     </dependencyManagement>
 
+    <repositories>
+        <repository>
+            <id>central</id>
+            <url>https://repo1.maven.org/maven2</url>
+        </repository>
+        <repository>
+            <id>github-verta</id>
+            <url>https://maven.pkg.github.com/VertaAI/.github</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+
     <dependencies>
+
         <dependency>
             <groupId>ai.verta</groupId>
             <artifactId>protos</artifactId>
+            <version>${verta-protos.version}</version>
         </dependency>
 
         <dependency>

--- a/backend/common/pom.xml
+++ b/backend/common/pom.xml
@@ -32,29 +32,6 @@
             <artifactId>snakeyaml</artifactId>
         </dependency>
 
-        <!-- The main transport implementation based on Netty, for both the client
-            and the server (https://grpc.io/grpc-java/javadoc/io/grpc/netty/package-summary.html) -->
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-netty-shaded</artifactId>
-        </dependency>
-        <!-- API for gRPC over Protocol Buffers, including tools for serializing
-            and de-serializing protobuf messages (https://grpc.io/grpc-java/javadoc/io/grpc/protobuf/package-summary.html) -->
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-protobuf</artifactId>
-        </dependency>
-        <!-- API for the Stub layer (https://grpc.io/grpc-java/javadoc/io/grpc/stub/package-summary.html) -->
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-stub</artifactId>
-        </dependency>
-        <!-- https://mvnrepository.com/artifact/io.grpc/grpc-services -->
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-services</artifactId>
-        </dependency>
-
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
@@ -241,9 +218,6 @@
 
     <build>
         <finalName>modeldb-${project.version}-common-module-build</finalName>
-        <!-- follow gRPC git repo URL link for plugin (kr.motd.maven, protobuf-maven-plugin)
-            https://github.com/grpc/grpc-java At the maven build time this plugin converted
-            .proto implementation of service to java code. -->
         <plugins>
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>

--- a/backend/server/pom.xml
+++ b/backend/server/pom.xml
@@ -23,6 +23,11 @@
     </dependencyManagement>
 
     <dependencies>
+        <dependency>
+            <groupId>ai.verta.common</groupId>
+            <artifactId>common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <!-- https://mvnrepository.com/artifact/junit/junit -->
         <dependency>
@@ -35,48 +40,6 @@
             <artifactId>snakeyaml</artifactId>
         </dependency>
 
-        <!-- The main transport implementation based on Netty, for both the client
-            and the server (https://grpc.io/grpc-java/javadoc/io/grpc/netty/package-summary.html) -->
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-netty-shaded</artifactId>
-        </dependency>
-        <!-- API for gRPC over Protocol Buffers, including tools for serializing
-            and de-serializing protobuf messages (https://grpc.io/grpc-java/javadoc/io/grpc/protobuf/package-summary.html) -->
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-protobuf</artifactId>
-        </dependency>
-        <!-- API for the Stub layer (https://grpc.io/grpc-java/javadoc/io/grpc/stub/package-summary.html) -->
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-stub</artifactId>
-        </dependency>
-        <dependency> <!-- necessary for Java 9+ -->
-            <groupId>org.apache.tomcat</groupId>
-            <artifactId>annotations-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <!-- https://mvnrepository.com/artifact/io.grpc/grpc-services -->
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-services</artifactId>
-        </dependency>
-        <!-- https://mvnrepository.com/artifact/com.google.api.grpc/googleapis-common-protos -->
-        <dependency>
-            <groupId>com.google.api.grpc</groupId>
-            <artifactId>googleapis-common-protos</artifactId>
-        </dependency>
-        <!-- Provide Utils for grpc like using jsonFormat this utils you can convert
-            json to protobuf object. (https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java-util) -->
-        <dependency>
-            <groupId>com.google.protobuf</groupId>
-            <artifactId>protobuf-java-util</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.google.protobuf</groupId>
-            <artifactId>protobuf-java</artifactId>
-        </dependency>
         <!-- Use for read .yaml file configuration (site : https://yaml.org/) -->
         <dependency>
             <groupId>com.pholser</groupId>
@@ -192,11 +155,6 @@
         <dependency>
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ai.verta.common</groupId>
-            <artifactId>common</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <!-- otel dependencies-->

--- a/backend/server/pom.xml
+++ b/backend/server/pom.xml
@@ -244,13 +244,6 @@
 
         <plugins>
             <plugin>
-                <groupId>org.xolstice.maven.plugins</groupId>
-                <artifactId>protobuf-maven-plugin</artifactId>
-                <configuration>
-                    <protoSourceRoot>../../protos/protos/public</protoSourceRoot>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -26,9 +26,7 @@
         <verta-protos.version>1.0-ln-protos-publish-SNAPSHOT</verta-protos.version>
         <hibernate.version>5.6.15.Final</hibernate.version>
         <log4j.version>2.20.0</log4j.version>
-        <grpc.version>1.55.1</grpc.version>
         <prometheus.version>0.16.0</prometheus.version>
-        <protobuf.version>3.23.2</protobuf.version>
         <aws.version>1.12.477</aws.version>
         <jackson.version>2.15.2</jackson.version>
         <os-maven-plugin.version>1.7.1</os-maven-plugin.version>
@@ -163,57 +161,6 @@
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
                 <version>2.0</version>
-            </dependency>
-            <!-- PRISMA-2022-0239 -->
-            <!-- The main transport implementation based on Netty, for both the client
-                and the server (https://grpc.io/grpc-java/javadoc/io/grpc/netty/package-summary.html) -->
-            <dependency>
-                <groupId>io.grpc</groupId>
-                <artifactId>grpc-netty-shaded</artifactId>
-                <version>${grpc.version}</version>
-            </dependency>
-            <!-- API for gRPC over Protocol Buffers, including tools for serializing
-                and de-serializing protobuf messages (https://grpc.io/grpc-java/javadoc/io/grpc/protobuf/package-summary.html) -->
-            <dependency>
-                <groupId>io.grpc</groupId>
-                <artifactId>grpc-protobuf</artifactId>
-                <version>${grpc.version}</version>
-            </dependency>
-            <!-- API for the Stub layer (https://grpc.io/grpc-java/javadoc/io/grpc/stub/package-summary.html) -->
-            <dependency>
-                <groupId>io.grpc</groupId>
-                <artifactId>grpc-stub</artifactId>
-                <version>${grpc.version}</version>
-            </dependency>
-            <dependency> <!-- necessary for Java 9+ -->
-                <groupId>org.apache.tomcat</groupId>
-                <artifactId>annotations-api</artifactId>
-                <version>6.0.53</version>
-                <scope>provided</scope>
-            </dependency>
-            <!-- https://mvnrepository.com/artifact/io.grpc/grpc-services -->
-            <dependency>
-                <groupId>io.grpc</groupId>
-                <artifactId>grpc-services</artifactId>
-                <version>${grpc.version}</version>
-            </dependency>
-            <!-- https://mvnrepository.com/artifact/com.google.api.grpc/googleapis-common-protos -->
-            <dependency>
-                <groupId>com.google.api.grpc</groupId>
-                <artifactId>googleapis-common-protos</artifactId>
-                <version>0.0.3</version>
-            </dependency>
-            <!-- Provide Utils for grpc like using jsonFormat this utils you can convert
-                json to protobuf object. (https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java-util) -->
-            <dependency>
-                <groupId>com.google.protobuf</groupId>
-                <artifactId>protobuf-java-util</artifactId>
-                <version>${protobuf.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.protobuf</groupId>
-                <artifactId>protobuf-java</artifactId>
-                <version>${protobuf.version}</version>
             </dependency>
             <!-- Use for read .yaml file configuration (site : https://yaml.org/) -->
             <dependency>
@@ -445,17 +392,6 @@
                 </plugin>
             </plugins>
         </pluginManagement>
-
-        <!-- follow gRPC git repo URL link for plugin (kr.motd.maven, protobuf-maven-plugin)
-            https://github.com/grpc/grpc-java At the maven build time this plugin converted
-            .proto implementation of service to java code. -->
-        <extensions>
-            <extension>
-                <groupId>kr.motd.maven</groupId>
-                <artifactId>os-maven-plugin</artifactId>
-                <version>${os-maven-plugin.version}</version>
-            </extension>
-        </extensions>
     </build>
 
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
 
     <properties>
         <revision>1.0-SNAPSHOT</revision>
+        <verta-protos.version>1.0-ln-protos-publish-SNAPSHOT</verta-protos.version>
         <hibernate.version>5.6.15.Final</hibernate.version>
         <log4j.version>2.20.0</log4j.version>
         <grpc.version>1.55.1</grpc.version>
@@ -55,6 +56,20 @@
             <url>https://maven.pkg.github.com/VertaAI/modeldb</url>
         </snapshotRepository>
     </distributionManagement>
+
+    <repositories>
+        <repository>
+            <id>central</id>
+            <url>https://repo1.maven.org/maven2</url>
+        </repository>
+        <repository>
+            <id>github-verta</id>
+            <url>https://maven.pkg.github.com/VertaAI/.github</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 
     <dependencyManagement>
         <dependencies>
@@ -102,6 +117,13 @@
                 <version>${mockito.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+
+
+            <dependency>
+                <groupId>ai.verta</groupId>
+                <artifactId>protos</artifactId>
+                <version>${verta-protos.version}</version>
             </dependency>
 
             <!-- PRISMA-2022-0239 - https://github.com/square/okhttp/issues/6738 -->
@@ -350,25 +372,6 @@
     <build>
         <pluginManagement>
             <plugins>
-                <plugin>
-                    <groupId>org.xolstice.maven.plugins</groupId>
-                    <artifactId>protobuf-maven-plugin</artifactId>
-                    <version>0.6.1</version>
-                    <configuration>
-                        <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
-                        <pluginId>grpc-java</pluginId>
-                        <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
-                        <checkStaleness>true</checkStaleness>
-                    </configuration>
-                    <executions>
-                        <execution>
-                            <goals>
-                                <goal>compile</goal>
-                                <goal>compile-custom</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
                 <plugin>
                     <groupId>com.diffplug.spotless</groupId>
                     <artifactId>spotless-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -23,13 +23,12 @@
 
     <properties>
         <revision>1.0-SNAPSHOT</revision>
-        <verta-protos.version>1.0-ln-protos-publish-SNAPSHOT</verta-protos.version>
+        <verta-protos.version>0.90.0-ln-protos-publish-SNAPSHOT</verta-protos.version>
         <hibernate.version>5.6.15.Final</hibernate.version>
         <log4j.version>2.20.0</log4j.version>
         <prometheus.version>0.16.0</prometheus.version>
         <aws.version>1.12.477</aws.version>
         <jackson.version>2.15.2</jackson.version>
-        <os-maven-plugin.version>1.7.1</os-maven-plugin.version>
         <otel.core.version>1.26.0</otel.core.version>
         <otel.instrumentation.version>1.26.0-alpha</otel.instrumentation.version>
         <otel.contrib.version>1.26.0-alpha</otel.contrib.version>

--- a/pom.xml
+++ b/pom.xml
@@ -116,13 +116,6 @@
                 <scope>import</scope>
             </dependency>
 
-
-            <dependency>
-                <groupId>ai.verta</groupId>
-                <artifactId>protos</artifactId>
-                <version>${verta-protos.version}</version>
-            </dependency>
-
             <!-- PRISMA-2022-0239 - https://github.com/square/okhttp/issues/6738 -->
             <dependency>
                 <groupId>com.squareup.okhttp3</groupId>


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context
Ah, I think a public github actions repo token can't access private GHA packages. This will need to be done slightly differently.  Maybe add a pom.xml to the `protos` in this repo and publish them alongside `common` for `modeldb`?

## Risks and Area of Effect

## Testing
- [ ] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

## Reverting
- [ ] Contains Migration - _Do Not Revert_