### PR TITLE
refactor: consolidate the declaration of the common grpc context auth keys

### DIFF
--- a/backend/common/src/main/java/ai/verta/modeldb/common/authservice/AuthInterceptor.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/authservice/AuthInterceptor.java
@@ -1,5 +1,6 @@
 package ai.verta.modeldb.common.authservice;
 
+import ai.verta.modeldb.common.connections.Connection;
 import io.grpc.Context;
 import io.grpc.Contexts;
 import io.grpc.ForwardingServerCallListener;
@@ -34,14 +35,14 @@ public class AuthInterceptor implements ServerInterceptor {
         || methodName.equals("grpc.health.v1.Health/Check")
         || methodName.equals("grpc.health.v1.Health/Watch"))) {
       // validate empty headers from user request
-      var emailKey = Metadata.Key.of("email", Metadata.ASCII_STRING_MARSHALLER);
-      var devKeyUnderscore = Metadata.Key.of("developer_key", Metadata.ASCII_STRING_MARSHALLER);
-      var devKey = Metadata.Key.of("developer-key", Metadata.ASCII_STRING_MARSHALLER);
+      var emailKey = Connection.EMAIL_GRPC_METADATA_KEY;
+      var devKeyUnderscore = Connection.DEV_KEY_GRPC_METADATA_KEY;
+      var devKey = Connection.DEV_KEY_WITH_HYPHEN_GRPC_METADATA_KEY;
       var bearerAccessToken =
           Metadata.Key.of("bearer_access_token", Metadata.ASCII_STRING_MARSHALLER);
       var sessionId = Metadata.Key.of("sessionId", Metadata.ASCII_STRING_MARSHALLER);
       var sessionIdSig = Metadata.Key.of("sessionIdSig", Metadata.ASCII_STRING_MARSHALLER);
-      var sourceKey = Metadata.Key.of("source", Metadata.ASCII_STRING_MARSHALLER);
+      var sourceKey = Connection.SOURCE_GRPC_METADATA_KEY;
 
       var parameterMissing = false;
       if (!requestHeaders.containsKey(sourceKey)) {

--- a/backend/common/src/main/java/ai/verta/modeldb/common/authservice/AuthServiceChannel.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/authservice/AuthServiceChannel.java
@@ -52,15 +52,10 @@ public class AuthServiceChannel extends Connection implements AutoCloseable {
 
   private Metadata getServiceUserMetadataHeaders() {
     var requestHeaders = new Metadata();
-    var emailKey = Metadata.Key.of("email", Metadata.ASCII_STRING_MARSHALLER);
-    var devKey = Metadata.Key.of("developer_key", Metadata.ASCII_STRING_MARSHALLER);
-    var devKeyHyphen = Metadata.Key.of("developer-key", Metadata.ASCII_STRING_MARSHALLER);
-    var sourceKey = Metadata.Key.of("source", Metadata.ASCII_STRING_MARSHALLER);
-
-    requestHeaders.put(emailKey, this.serviceUserEmail);
-    requestHeaders.put(devKey, this.serviceUserDevKey);
-    requestHeaders.put(devKeyHyphen, this.serviceUserDevKey);
-    requestHeaders.put(sourceKey, "PythonClient");
+    requestHeaders.put(Connection.EMAIL_GRPC_METADATA_KEY, this.serviceUserEmail);
+    requestHeaders.put(Connection.DEV_KEY_GRPC_METADATA_KEY, this.serviceUserDevKey);
+    requestHeaders.put(Connection.DEV_KEY_WITH_HYPHEN_GRPC_METADATA_KEY, this.serviceUserDevKey);
+    requestHeaders.put(Connection.SOURCE_GRPC_METADATA_KEY, "PythonClient");
     return requestHeaders;
   }
 

--- a/backend/common/src/main/java/ai/verta/modeldb/common/connections/Connection.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/connections/Connection.java
@@ -10,6 +10,15 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 public abstract class Connection {
+  public static final Metadata.Key<String> EMAIL_GRPC_METADATA_KEY =
+      Metadata.Key.of("email", Metadata.ASCII_STRING_MARSHALLER);
+  public static final Metadata.Key<String> DEV_KEY_GRPC_METADATA_KEY =
+      Metadata.Key.of("developer_key", Metadata.ASCII_STRING_MARSHALLER);
+  public static final Metadata.Key<String> DEV_KEY_WITH_HYPHEN_GRPC_METADATA_KEY =
+      Metadata.Key.of("developer-key", Metadata.ASCII_STRING_MARSHALLER);
+  public static final Metadata.Key<String> SOURCE_GRPC_METADATA_KEY =
+      Metadata.Key.of("source", Metadata.ASCII_STRING_MARSHALLER);
+
   private final Optional<ClientInterceptor> tracingClientInterceptor;
 
   protected Connection(Optional<ClientInterceptor> tracingClientInterceptor) {
@@ -64,15 +73,11 @@ public abstract class Connection {
 
   protected static Metadata getServiceUserMetadata(ServiceUserConfig config) {
     var requestHeaders = new Metadata();
-    var emailKey = Metadata.Key.of("email", Metadata.ASCII_STRING_MARSHALLER);
-    var devKey = Metadata.Key.of("developer_key", Metadata.ASCII_STRING_MARSHALLER);
-    var devKeyHyphen = Metadata.Key.of("developer-key", Metadata.ASCII_STRING_MARSHALLER);
-    var sourceKey = Metadata.Key.of("source", Metadata.ASCII_STRING_MARSHALLER);
 
-    requestHeaders.put(emailKey, config.getEmail());
-    requestHeaders.put(devKey, config.getDevKey());
-    requestHeaders.put(devKeyHyphen, config.getDevKey());
-    requestHeaders.put(sourceKey, "PythonClient");
+    requestHeaders.put(EMAIL_GRPC_METADATA_KEY, config.getEmail());
+    requestHeaders.put(DEV_KEY_GRPC_METADATA_KEY, config.getDevKey());
+    requestHeaders.put(DEV_KEY_WITH_HYPHEN_GRPC_METADATA_KEY, config.getDevKey());
+    requestHeaders.put(SOURCE_GRPC_METADATA_KEY, "PythonClient");
     return requestHeaders;
   }
 }

--- a/backend/server/src/test/java/ai/verta/modeldb/AuthClientInterceptor.java
+++ b/backend/server/src/test/java/ai/verta/modeldb/AuthClientInterceptor.java
@@ -1,6 +1,7 @@
 package ai.verta.modeldb;
 
 import ai.verta.modeldb.common.config.ServiceUserConfig;
+import ai.verta.modeldb.common.connections.Connection;
 import ai.verta.modeldb.config.TestConfig;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.grpc.*;
@@ -83,12 +84,9 @@ public class AuthClientInterceptor {
         @Override
         public void start(Listener<RespT> responseListener, Metadata headers) {
           // TODO: Here set request metadata
-          Metadata.Key<String> email_key =
-              Metadata.Key.of("email", Metadata.ASCII_STRING_MARSHALLER);
-          Metadata.Key<String> dev_key =
-              Metadata.Key.of("developer_key", Metadata.ASCII_STRING_MARSHALLER);
-          Metadata.Key<String> source_key =
-              Metadata.Key.of("source", Metadata.ASCII_STRING_MARSHALLER);
+          Metadata.Key<String> email_key = Connection.EMAIL_GRPC_METADATA_KEY;
+          Metadata.Key<String> dev_key = Connection.DEV_KEY_GRPC_METADATA_KEY;
+          Metadata.Key<String> source_key = Connection.SOURCE_GRPC_METADATA_KEY;
 
           headers.put(email_key, clientEmail);
           headers.put(dev_key, clientDevKey);


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context
These are scattered around and declared multiple times. (including also in the registry). Seems good to only put them in one place. 

I'm open to suggestions on a better class for them to live in, but this seemed at least logical.

## Risks and Area of Effect

## Testing
- [x] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

## Reverting
- [ ] Contains Migration - _Do Not Revert_