### PR TITLE
chore!: [VRD-954] Remove `model_packaging` from ExperimentRun and RegisteredModelVersion

### DIFF
--- a/client/verta/tests/deployable_entity/test_artifacts.py
+++ b/client/verta/tests/deployable_entity/test_artifacts.py
@@ -22,27 +22,6 @@ from verta._internal_utils import (
 from .. import utils
 
 
-def assert_model_packaging(deployable_entity, serialization, framework):
-    """Validate model serialization fields in Artifact proto.
-
-    For TestModels and TestArbitraryModels.
-
-    """
-    model_msg = deployable_entity._get_artifact_msg(
-        deployable_entity._MODEL_KEY,
-    )
-
-    if not serialization:
-        assert not model_msg.serialization
-    else:
-        assert model_msg.serialization == serialization
-
-    if not framework:
-        assert not model_msg.artifact_subtype
-    else:
-        assert model_msg.artifact_subtype == framework
-
-
 class TestUtils:
     def test_calc_sha256(self):
         FILE_SIZE = 6 * 10**6  # 6 MB
@@ -288,11 +267,6 @@ class TestModels:
         pipeline.fit(X, y)
 
         deployable_entity.log_model(pipeline)
-        assert_model_packaging(
-            deployable_entity,
-            serialization="cloudpickle",
-            framework="sklearn",
-        )
         retrieved_pipeline = deployable_entity.get_model()
 
         assert np.allclose(pipeline.predict(X), retrieved_pipeline.predict(X))
@@ -346,11 +320,6 @@ class TestModels:
             optimizer.step()
 
         deployable_entity.log_model(net)
-        assert_model_packaging(
-            deployable_entity,
-            serialization="cloudpickle",
-            framework="torch",
-        )
         retrieved_net = deployable_entity.get_model()
 
         assert torch.allclose(net(X), retrieved_net(X))
@@ -429,11 +398,6 @@ class TestModels:
         net.fit(X, y, epochs=5)
 
         deployable_entity.log_model(net)
-        assert_model_packaging(
-            deployable_entity,
-            serialization="keras",
-            framework="tensorflow",
-        )
         retrieved_net = deployable_entity.get_model()
 
         assert np.allclose(net.predict(X), retrieved_net.predict(X))
@@ -455,11 +419,6 @@ class TestModels:
             return (args, kwargs)
 
         deployable_entity.log_model(func)
-        assert_model_packaging(
-            deployable_entity,
-            serialization="cloudpickle",
-            framework="callable",
-        )
         assert deployable_entity.get_model().__defaults__ == func.__defaults__
         assert deployable_entity.get_model()(*func_args, **func_kwargs) == func(
             *func_args, **func_kwargs
@@ -481,11 +440,6 @@ class TestModels:
         custom = Custom(*init_args, **init_kwargs)
 
         deployable_entity.log_model(custom)
-        assert_model_packaging(
-            deployable_entity,
-            serialization="cloudpickle",
-            framework="custom",
-        )
         assert deployable_entity.get_model().__dict__ == custom.__dict__
         assert deployable_entity.get_model().predict(strs) == custom.predict(strs)
 
@@ -526,11 +480,6 @@ class TestModels:
         # log model
         model = LogisticRegression().fit(df)
         deployable_entity.log_model(model, custom_modules=[])
-        assert_model_packaging(
-            deployable_entity,
-            serialization="cloudpickle",
-            framework=None,
-        )
 
         # get model
         with zipfile.ZipFile(deployable_entity.get_model()) as zipf:
@@ -572,11 +521,6 @@ class TestArbitraryModels:
             f.seek(0)
 
             deployable_entity.log_model(f)
-        assert_model_packaging(
-            deployable_entity,
-            serialization=None,
-            framework=None,
-        )
 
         assert deployable_entity.get_model().read() == random_data
 
@@ -586,11 +530,6 @@ class TestArbitraryModels:
         dirpath, filepaths = dir_and_files
 
         deployable_entity.log_model(dirpath)
-        assert_model_packaging(
-            deployable_entity,
-            serialization=_artifact_utils.ZIP_EXTENSION,
-            framework=None,
-        )
 
         with zipfile.ZipFile(deployable_entity.get_model(), "r") as zipf:
             assert set(zipf.namelist()) == filepaths
@@ -601,11 +540,6 @@ class TestArbitraryModels:
         model = {"a": 1}
 
         deployable_entity.log_model(model)
-        assert_model_packaging(
-            deployable_entity,
-            serialization="cloudpickle",
-            framework=None,
-        )
 
         assert deployable_entity.get_model() == model
 

--- a/client/verta/tests/test_cli/test_registry.py
+++ b/client/verta/tests/test_cli/test_registry.py
@@ -357,11 +357,6 @@ class TestCreate:
 
             # Log model api:
             model_api = ModelAPI(train_data.tolist(), classifier(train_data).tolist())
-            model_api["model_packaging"] = {
-                "deserialization": "cloudpickle",
-                "type": "torch",
-                "python_version": "3.9.13",
-            }
             model_version.log_artifact(
                 _artifact_utils.MODEL_API_KEY, model_api, True, "json"
             )

--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -526,13 +526,6 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
         if model_type or model_api:  # only if provided or model is deployable
             if model_api is None:
                 model_api = utils.ModelAPI()
-            if "model_packaging" not in model_api:
-                # add model serialization info to model_api
-                model_api["model_packaging"] = {
-                    "python_version": _utils.get_python_version(),
-                    "type": model_type,
-                    "deserialization": method,
-                }
             self.log_artifact(
                 _artifact_utils.MODEL_API_KEY, model_api, overwrite, "json"
             )

--- a/client/verta/verta/tracking/entities/_experimentrun.py
+++ b/client/verta/verta/tracking/entities/_experimentrun.py
@@ -1320,13 +1320,6 @@ class ExperimentRun(_DeployableEntity):
         if model_type or model_api:  # only if provided or model is deployable
             if model_api is None:
                 model_api = utils.ModelAPI()
-            if "model_packaging" not in model_api:
-                # add model serialization info to model_api
-                model_api["model_packaging"] = {
-                    "python_version": _utils.get_python_version(),
-                    "type": model_type,
-                    "deserialization": method,
-                }
             if self._conf.debug:
                 print("[DEBUG] model API is:")
                 pprint.pprint(model_api.to_dict())


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context
This removes a now redundant bit of metadata being added to the `ModelAPI` by the client that by the client that is not required by the back-end anymore.

## Risks and Area of Effect
This change affects the model information shared by the client and Python Model Service.  Prior to [PR-216](https://github.com/VertaAI/python-services/pull/216), PyMS was expecting to unpack the ModelAPI info from the client.  After that change is merged, this change should be relatively safe.



## Testing
- [X] Unit test - All altered test files still pass
- [ ] Deployed to dev env
- [X] Other (explain)
Manual testing in DEV confirmed that a model can be registered and deployed without any issues, even when the `model_packaging` dict contains none of the current values.  Those values are pulled from other sources, not from the data provided by the client.

## Reverting
- [ ] Contains Migration - _Do Not Revert_