### PR TITLE
feat: [VRD-960] Implement LocalOrchestrator

### DIFF
--- a/client/verta/verta/_pipeline_orchestrator/__init__.py
+++ b/client/verta/verta/_pipeline_orchestrator/__init__.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+"""Classes and utilities for inference pipelines."""
+
 from verta._internal_utils import documentation
 
 from ._orchestrator import DeployedOrchestrator, LocalOrchestrator

--- a/client/verta/verta/_pipeline_orchestrator/__init__.py
+++ b/client/verta/verta/_pipeline_orchestrator/__init__.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+
+from verta._internal_utils import documentation
+
+from ._step_handler import ModelContainerStepHandler, ModelObjectStepHandler
+
+
+documentation.reassign_module(
+    [
+        ModelContainerStepHandler,
+        ModelObjectStepHandler,
+    ],
+    module_name=__name__,
+)

--- a/client/verta/verta/_pipeline_orchestrator/__init__.py
+++ b/client/verta/verta/_pipeline_orchestrator/__init__.py
@@ -4,12 +4,11 @@
 
 from verta._internal_utils import documentation
 
-from ._orchestrator import DeployedOrchestrator, LocalOrchestrator
+from ._orchestrator import LocalOrchestrator
 
 
 documentation.reassign_module(
     [
-        DeployedOrchestrator,
         LocalOrchestrator,
     ],
     module_name=__name__,

--- a/client/verta/verta/_pipeline_orchestrator/__init__.py
+++ b/client/verta/verta/_pipeline_orchestrator/__init__.py
@@ -2,13 +2,13 @@
 
 from verta._internal_utils import documentation
 
-from ._step_handler import ModelContainerStepHandler, ModelObjectStepHandler
+from ._orchestrator import DeployedOrchestrator, LocalOrchestrator
 
 
 documentation.reassign_module(
     [
-        ModelContainerStepHandler,
-        ModelObjectStepHandler,
+        DeployedOrchestrator,
+        LocalOrchestrator,
     ],
     module_name=__name__,
 )

--- a/client/verta/verta/_pipeline_orchestrator/_orchestrator.py
+++ b/client/verta/verta/_pipeline_orchestrator/_orchestrator.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import abc
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Set
 
 from verta._internal_utils import _utils
 from verta.external.cpython.graphlib import TopologicalSorter
@@ -77,7 +77,7 @@ class _OrchestratorBase(abc.ABC):
 
         step_handler = self._step_handlers[name]
         if input is None:
-            predecessors = step_handler.predecessors
+            predecessors: Set[str] = step_handler.predecessors
             if not predecessors:
                 raise ValueError(
                     f"unexpected error: step {name} has no predecessors, but no input was provided",

--- a/client/verta/verta/_pipeline_orchestrator/_orchestrator.py
+++ b/client/verta/verta/_pipeline_orchestrator/_orchestrator.py
@@ -148,6 +148,15 @@ class LocalOrchestrator(_OrchestratorBase):
     pipeline_spec : dict
         Pipeline specification.
 
+    Examples
+    --------
+    .. code-block:: python
+
+        from verta._pipeline_orchestrator import LocalOrchestrator
+
+        orchestrator = LocalOrchestrator(client._conn, pipeline_spec)
+        pipeline_output = orchestrator.run(pipeline_input)
+
     """
 
     def __init__(

--- a/client/verta/verta/_pipeline_orchestrator/_orchestrator.py
+++ b/client/verta/verta/_pipeline_orchestrator/_orchestrator.py
@@ -69,12 +69,12 @@ class _OrchestratorBase(abc.ABC):
 
         Returns
         -------
-        graphlib.TopologicalSorter
+        :class:`~graphlib.TopologicalSorter`
             Pipeline graph. Each node is a model version ID.
 
         Raises
         ------
-        graphlib.CycleError
+        :exc:`~graphlib.CycleError`
             If the pipeline graph has cycles.
 
         """

--- a/client/verta/verta/_pipeline_orchestrator/_orchestrator.py
+++ b/client/verta/verta/_pipeline_orchestrator/_orchestrator.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+
+import abc
+from typing import Any, Dict
+
+from verta._internal_utils import _utils
+from verta.external.cpython.graphlib import TopologicalSorter
+
+from ._step_handler import (
+    _StepHandlerBase,
+    ModelObjectStepHandler,
+)
+
+
+class _OrchestratorBase(abc.ABC):
+    def __init__(
+        self,
+        pipeline_spec: Dict[str, Any],
+        step_handlers: Dict[int, _StepHandlerBase],
+    ):
+        self._pipeline_spec = pipeline_spec
+        self._step_handlers = step_handlers
+
+    def get_dag(self) -> TopologicalSorter:
+        dag = TopologicalSorter(self._pipeline_spec["graph"]["inputs"])
+        dag.prepare()
+        # TODO: assert one input node
+        return dag
+
+    def run(
+        self,
+        input: Any,
+    ):
+        raise NotImplementedError
+        dag = self.get_dag()
+        while dag.is_active():
+            for model_version_id in dag.get_ready():
+                step_handler = self._step_handlers[model_version_id]
+                output = step_handler.run(input)  # TODO: async?
+                # TODO: track outputs
+                dag.done(model_version_id)  # TODO: callback?
+
+
+class DeployedOrchestrator(_OrchestratorBase):
+    def __init__(
+        self,
+        pipeline_spec: Dict[str, Any],
+    ):
+        raise NotImplementedError
+        super().__init__(
+            pipeline_spec=pipeline_spec,
+        )
+
+
+class LocalOrchestrator(_OrchestratorBase):
+    def __init__(
+        self,
+        conn: _utils.Connection,
+        pipeline_spec: Dict[str, Any],
+    ):
+        super().__init__(
+            pipeline_spec=pipeline_spec,
+            step_handlers=self._init_step_handlers(conn, pipeline_spec),
+        )
+
+    @staticmethod
+    def _init_step_handlers(
+        conn: _utils.Connection,
+        pipeline_spec: Dict[str, Any],
+    ) -> Dict[int, ModelObjectStepHandler]:
+        step_handlers = dict()
+        for step in pipeline_spec["steps"]:
+            model_version_id = step["rmvId"]
+            step_handlers[model_version_id] = ModelObjectStepHandler(
+                name=step["attributes"]["name"],
+                model_version_id=model_version_id,
+                predecessors=pipeline_spec["graph"]["inputs"].get(model_version_id, []),
+                model=ModelObjectStepHandler._init_model(conn, model_version_id),
+            )
+        return step_handlers

--- a/client/verta/verta/_pipeline_orchestrator/_orchestrator.py
+++ b/client/verta/verta/_pipeline_orchestrator/_orchestrator.py
@@ -31,14 +31,30 @@ class _OrchestratorBase(abc.ABC):
         self,
         input: Any,
     ):
-        raise NotImplementedError
         dag = self.get_dag()
+
+        # run input node
+        # NOTE: assumes only one input node
+        model_version_id = dag.get_ready()[0]
+        step_handler = self._step_handlers[model_version_id]
+        outputs = {model_version_id: step_handler.run(input)}
+        dag.done(model_version_id)
+
         while dag.is_active():
             for model_version_id in dag.get_ready():
                 step_handler = self._step_handlers[model_version_id]
-                output = step_handler.run(input)  # TODO: async?
-                # TODO: track outputs
+                outputs[model_version_id] = step_handler.run(  # TODO: async?
+                    outputs[step_handler.predecessors[0]]  # TEST
+                    # {
+                    #     predecessor_id: outputs[predecessor_id]
+                    #     for predecessor_id in step_handler.predecessors
+                    # }
+                )
                 dag.done(model_version_id)  # TODO: callback?
+
+        # return output from final node
+        # NOTE: assumes only one leaf node
+        return outputs[step_handler.model_version_id]
 
 
 class DeployedOrchestrator(_OrchestratorBase):

--- a/client/verta/verta/_pipeline_orchestrator/_step_handler.py
+++ b/client/verta/verta/_pipeline_orchestrator/_step_handler.py
@@ -18,9 +18,6 @@ class _StepHandlerBase(abc.ABC):
         predecessors: Set[str],
     ):
         self._name = name
-        if len(predecessors) > 1:
-            # TODO: figure out how to orchestrate complex pipelines
-            raise ValueError("multiple inputs is not yet supported")
         self._predecessors = predecessors
 
     @abc.abstractmethod

--- a/client/verta/verta/_pipeline_orchestrator/_step_handler.py
+++ b/client/verta/verta/_pipeline_orchestrator/_step_handler.py
@@ -2,7 +2,7 @@
 
 import abc
 import json
-from typing import Any, Dict, List, Optional, Set, Type
+from typing import Any, Dict, Iterable, List, Optional, Set, Type
 
 from verta._internal_utils import _utils, http_session
 from verta.registry.entities import RegisteredModelVersion
@@ -15,10 +15,10 @@ class _StepHandlerBase(abc.ABC):
     def __init__(
         self,
         name: str,
-        predecessors: Set[str],
+        predecessors: Iterable[str],
     ):
         self._name = name
-        self._predecessors = predecessors
+        self._predecessors = set(predecessors)
 
     @abc.abstractmethod
     def run(self, input: Any) -> Any:
@@ -55,7 +55,7 @@ class ModelContainerStepHandler(_StepHandlerBase):
     ----------
     name : str
         Name of this step.
-    predecessors : set of str
+    predecessors : iterable of str
         Names of this steps' predecessors
     prediction_url : str
         REST endpoint for model predictions.
@@ -70,7 +70,7 @@ class ModelContainerStepHandler(_StepHandlerBase):
     def __init__(
         self,
         name: str,
-        predecessors: Set[str],
+        predecessors: Iterable[str],
         prediction_url: str,
     ):
         super().__init__(
@@ -100,7 +100,7 @@ class ModelObjectStepHandler(_StepHandlerBase):
     ----------
     name : str
         Name of this step.
-    predecessors : set of str
+    predecessors : iterable of str
         Names of this steps' predecessors
     model : object
         Instantiated model ready for predictions.
@@ -115,7 +115,7 @@ class ModelObjectStepHandler(_StepHandlerBase):
     def __init__(
         self,
         name: str,
-        predecessors: Set[str],
+        predecessors: Iterable[str],
         model: Any,
     ):
         super().__init__(

--- a/client/verta/verta/_pipeline_orchestrator/_step_handler.py
+++ b/client/verta/verta/_pipeline_orchestrator/_step_handler.py
@@ -15,11 +15,9 @@ class _StepHandlerBase(abc.ABC):
     def __init__(
         self,
         name: str,
-        model_version_id: int,
-        predecessors: Set[int],
+        predecessors: Set[str],
     ):
         self._name = name
-        self._model_version_id = model_version_id
         if len(predecessors) > 1:
             # TODO: figure out how to orchestrate complex pipelines
             raise ValueError("multiple inputs is not yet supported")
@@ -43,18 +41,13 @@ class _StepHandlerBase(abc.ABC):
         raise NotImplementedError
 
     @property
-    def model_version_id(self) -> int:
-        """Return the ID of the model version associated with this step."""
-        return self._model_version_id
-
-    @property
     def name(self) -> str:
         """Return the name of this step."""
         return self._name
 
     @property
-    def predecessors(self) -> Set[int]:
-        """Return the model version IDs of this step's predecessors."""
+    def predecessors(self) -> Set[str]:
+        """Return the names of this step's predecessors."""
         return self._predecessors
 
 
@@ -65,16 +58,13 @@ class ModelContainerStepHandler(_StepHandlerBase):
     ----------
     name : str
         Name of this step.
-    model_version_id : int
-        ID of the model version associated with this step.
-    predecessors : set of int
-        Model version IDs of this steps' predecessors
+    predecessors : set of str
+        Names of this steps' predecessors
     prediction_url : str
         REST endpoint for model predictions.
 
     Attributes
     ----------
-    model_version_id
     name
     predecessors
 
@@ -83,13 +73,11 @@ class ModelContainerStepHandler(_StepHandlerBase):
     def __init__(
         self,
         name: str,
-        model_version_id: int,
-        predecessors: Set[int],
+        predecessors: Set[str],
         prediction_url: str,
     ):
         super().__init__(
             name=name,
-            model_version_id=model_version_id,
             predecessors=predecessors,
         )
         self._session = http_session.init_session(retry=http_session.retry_config())
@@ -115,16 +103,13 @@ class ModelObjectStepHandler(_StepHandlerBase):
     ----------
     name : str
         Name of this step.
-    model_version_id : int
-        ID of the model version associated with this step.
-    predecessors : set of int
-        Model version IDs of this steps' predecessors
+    predecessors : set of str
+        Names of this steps' predecessors
     model : object
         Instantiated model ready for predictions.
 
     Attributes
     ----------
-    model_version_id
     name
     predecessors
 
@@ -133,13 +118,11 @@ class ModelObjectStepHandler(_StepHandlerBase):
     def __init__(
         self,
         name: str,
-        model_version_id: int,
-        predecessors: Set[int],
+        predecessors: Set[str],
         model: Any,
     ):
         super().__init__(
             name=name,
-            model_version_id=model_version_id,
             predecessors=predecessors,
         )
         self._model = model

--- a/client/verta/verta/_pipeline_orchestrator/_step_handler.py
+++ b/client/verta/verta/_pipeline_orchestrator/_step_handler.py
@@ -149,7 +149,7 @@ class ModelObjectStepHandler(_StepHandlerBase):
         conn: _utils.Connection,
         model_version_id: int,
     ) -> Any:
-        """Return an instantiated model from `model_version_id`.
+        """Instantiate and return the model from `model_version_id`.
 
         Parameters
         ----------

--- a/client/verta/verta/_pipeline_orchestrator/_step_handler.py
+++ b/client/verta/verta/_pipeline_orchestrator/_step_handler.py
@@ -12,7 +12,7 @@ class _StepHandlerBase(abc.ABC):
         self._name = name
 
     @abc.abstractmethod
-    def __call__(self, input: Dict[str, Any]) -> Dict[str, Any]:
+    def run(self, input: Dict[str, Any]) -> Dict[str, Any]:
         raise NotImplementedError
 
     @property
@@ -30,7 +30,7 @@ class ModelContainerStepHandler(_StepHandlerBase):
         self._session = http_session.init_session(retry=http_session.retry_config())
         self._prediction_url = prediction_url
 
-    def __call__(self, input: Dict[str, Any]) -> Dict[str, Any]:
+    def run(self, input: Dict[str, Any]) -> Dict[str, Any]:
         body = json.dumps(
             _utils.to_builtin(input),
             allow_nan=True,
@@ -53,5 +53,5 @@ class ModelObjectStepHandler(_StepHandlerBase):
         super().__init__(name)
         self._model = model_cls(model_artifacts)
 
-    def __call__(self, input: Dict[str, Any]) -> Dict[str, Any]:
+    def run(self, input: Dict[str, Any]) -> Dict[str, Any]:
         return self._model.predict(input)

--- a/client/verta/verta/_pipeline_orchestrator/_step_handler.py
+++ b/client/verta/verta/_pipeline_orchestrator/_step_handler.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+
+import abc
+import json
+from typing import Any, Dict, Type
+
+from verta._internal_utils import _utils, http_session
+
+
+class _StepHandlerBase(abc.ABC):
+    def __init__(self, name: str):
+        self._name = name
+
+    @abc.abstractmethod
+    def __call__(self, input: Dict[str, Any]) -> Dict[str, Any]:
+        raise NotImplementedError
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+
+class ModelContainerStepHandler(_StepHandlerBase):
+    def __init__(
+        self,
+        name: str,
+        prediction_url: str,
+    ):
+        super().__init__(name)
+        self._session = http_session.init_session(retry=http_session.retry_config())
+        self._prediction_url = prediction_url
+
+    def __call__(self, input: Dict[str, Any]) -> Dict[str, Any]:
+        body = json.dumps(
+            _utils.to_builtin(input),
+            allow_nan=True,
+        )
+        response = self._session.post(
+            self._prediction_url,
+            data=body,
+        )
+        _utils.raise_for_http_error(response)
+        return response.json()
+
+
+class ModelObjectStepHandler(_StepHandlerBase):
+    def __init__(
+        self,
+        name: str,
+        model_cls: Type[Any],
+        model_artifacts: Dict[str, Any],
+    ):
+        super().__init__(name)
+        self._model = model_cls(model_artifacts)
+
+    def __call__(self, input: Dict[str, Any]) -> Dict[str, Any]:
+        return self._model.predict(input)

--- a/client/verta/verta/_pipeline_orchestrator/_step_handler.py
+++ b/client/verta/verta/_pipeline_orchestrator/_step_handler.py
@@ -10,6 +10,8 @@ from verta.tracking.entities._entity import _MODEL_ARTIFACTS_ATTR_KEY
 
 
 class _StepHandlerBase(abc.ABC):
+    """Abstract base class for inference pipeline step handlers."""
+
     def __init__(
         self,
         name: str,
@@ -18,26 +20,66 @@ class _StepHandlerBase(abc.ABC):
     ):
         self._name = name
         self._model_version_id = model_version_id
+        if len(predecessors) > 1:
+            # TODO: figure out how to orchestrate complex pipelines
+            raise ValueError("multiple inputs is not yet supported")
         self._predecessors = predecessors
 
     @abc.abstractmethod
-    def run(self, input: Dict[str, Any]) -> Dict[str, Any]:
+    def run(self, input: Any) -> Any:
+        """Run this step.
+
+        Parameters
+        ----------
+        input : object
+            Step input.
+
+        Returns
+        -------
+        object
+            Step output.
+
+        """
         raise NotImplementedError
 
     @property
     def model_version_id(self) -> int:
+        """Return the ID of the model version associated with this step."""
         return self._model_version_id
 
     @property
     def name(self) -> str:
+        """Return the name of this step."""
         return self._name
 
     @property
     def predecessors(self) -> Set[int]:
+        """Return the model version IDs of this step's predecessors."""
         return self._predecessors
 
 
 class ModelContainerStepHandler(_StepHandlerBase):
+    """Inference pipeline step handler for an HTTP server model.
+
+    Parameters
+    ----------
+    name : str
+        Name of this step.
+    model_version_id : int
+        ID of the model version associated with this step.
+    predecessors : set of int
+        Model version IDs of this steps' predecessors
+    prediction_url : str
+        REST endpoint for model predictions.
+
+    Attributes
+    ----------
+    model_version_id
+    name
+    predecessors
+
+    """
+
     def __init__(
         self,
         name: str,
@@ -53,7 +95,7 @@ class ModelContainerStepHandler(_StepHandlerBase):
         self._session = http_session.init_session(retry=http_session.retry_config())
         self._prediction_url = prediction_url
 
-    def run(self, input: Dict[str, Any]) -> Dict[str, Any]:
+    def run(self, input: Any) -> Any:
         body = json.dumps(
             _utils.to_builtin(input),
             allow_nan=True,
@@ -67,6 +109,27 @@ class ModelContainerStepHandler(_StepHandlerBase):
 
 
 class ModelObjectStepHandler(_StepHandlerBase):
+    """Inference pipeline step handler for a locally-instantiated model.
+
+    Parameters
+    ----------
+    name : str
+        Name of this step.
+    model_version_id : int
+        ID of the model version associated with this step.
+    predecessors : set of int
+        Model version IDs of this steps' predecessors
+    model : object
+        Instantiated model ready for predictions.
+
+    Attributes
+    ----------
+    model_version_id
+    name
+    predecessors
+
+    """
+
     def __init__(
         self,
         name: str,
@@ -86,6 +149,21 @@ class ModelObjectStepHandler(_StepHandlerBase):
         conn: _utils.Connection,
         model_version_id: int,
     ) -> Any:
+        """Return an instantiated model from `model_version_id`.
+
+        Parameters
+        ----------
+        conn : :class:`~verta._internal_utils._utils.Connection`
+            Verta client connection.
+        model_version_id : int
+            Model version ID.
+
+        Returns
+        -------
+        object
+            Instantiated model ready for predictions.
+
+        """
         model_ver = RegisteredModelVersion._get_by_id(
             conn,
             _utils.Configuration(),
@@ -103,5 +181,5 @@ class ModelObjectStepHandler(_StepHandlerBase):
 
         return model_cls(artifacts=model_artifacts)
 
-    def run(self, input: Dict[str, Any]) -> Dict[str, Any]:
+    def run(self, input: Any) -> Any:
         return self._model.predict(input)

--- a/client/verta/verta/external/cpython/LICENSE
+++ b/client/verta/verta/external/cpython/LICENSE
@@ -1,0 +1,279 @@
+A. HISTORY OF THE SOFTWARE
+==========================
+
+Python was created in the early 1990s by Guido van Rossum at Stichting
+Mathematisch Centrum (CWI, see http://www.cwi.nl) in the Netherlands
+as a successor of a language called ABC.  Guido remains Python's
+principal author, although it includes many contributions from others.
+
+In 1995, Guido continued his work on Python at the Corporation for
+National Research Initiatives (CNRI, see http://www.cnri.reston.va.us)
+in Reston, Virginia where he released several versions of the
+software.
+
+In May 2000, Guido and the Python core development team moved to
+BeOpen.com to form the BeOpen PythonLabs team.  In October of the same
+year, the PythonLabs team moved to Digital Creations, which became
+Zope Corporation.  In 2001, the Python Software Foundation (PSF, see
+https://www.python.org/psf/) was formed, a non-profit organization
+created specifically to own Python-related Intellectual Property.
+Zope Corporation was a sponsoring member of the PSF.
+
+All Python releases are Open Source (see http://www.opensource.org for
+the Open Source Definition).  Historically, most, but not all, Python
+releases have also been GPL-compatible; the table below summarizes
+the various releases.
+
+    Release         Derived     Year        Owner       GPL-
+                    from                                compatible? (1)
+
+    0.9.0 thru 1.2              1991-1995   CWI         yes
+    1.3 thru 1.5.2  1.2         1995-1999   CNRI        yes
+    1.6             1.5.2       2000        CNRI        no
+    2.0             1.6         2000        BeOpen.com  no
+    1.6.1           1.6         2001        CNRI        yes (2)
+    2.1             2.0+1.6.1   2001        PSF         no
+    2.0.1           2.0+1.6.1   2001        PSF         yes
+    2.1.1           2.1+2.0.1   2001        PSF         yes
+    2.1.2           2.1.1       2002        PSF         yes
+    2.1.3           2.1.2       2002        PSF         yes
+    2.2 and above   2.1.1       2001-now    PSF         yes
+
+Footnotes:
+
+(1) GPL-compatible doesn't mean that we're distributing Python under
+    the GPL.  All Python licenses, unlike the GPL, let you distribute
+    a modified version without making your changes open source.  The
+    GPL-compatible licenses make it possible to combine Python with
+    other software that is released under the GPL; the others don't.
+
+(2) According to Richard Stallman, 1.6.1 is not GPL-compatible,
+    because its license has a choice of law clause.  According to
+    CNRI, however, Stallman's lawyer has told CNRI's lawyer that 1.6.1
+    is "not incompatible" with the GPL.
+
+Thanks to the many outside volunteers who have worked under Guido's
+direction to make these releases possible.
+
+
+B. TERMS AND CONDITIONS FOR ACCESSING OR OTHERWISE USING PYTHON
+===============================================================
+
+Python software and documentation are licensed under the
+Python Software Foundation License Version 2.
+
+Starting with Python 3.8.6, examples, recipes, and other code in
+the documentation are dual licensed under the PSF License Version 2
+and the Zero-Clause BSD license.
+
+Some software incorporated into Python is under different licenses.
+The licenses are listed with code falling under that license.
+
+
+PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2
+--------------------------------------------
+
+1. This LICENSE AGREEMENT is between the Python Software Foundation
+("PSF"), and the Individual or Organization ("Licensee") accessing and
+otherwise using this software ("Python") in source or binary form and
+its associated documentation.
+
+2. Subject to the terms and conditions of this License Agreement, PSF hereby
+grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce,
+analyze, test, perform and/or display publicly, prepare derivative works,
+distribute, and otherwise use Python alone or in any derivative version,
+provided, however, that PSF's License Agreement and PSF's notice of copyright,
+i.e., "Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
+2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Python Software Foundation;
+All Rights Reserved" are retained in Python alone or in any derivative version
+prepared by Licensee.
+
+3. In the event Licensee prepares a derivative work that is based on
+or incorporates Python or any part thereof, and wants to make
+the derivative work available to others as provided herein, then
+Licensee hereby agrees to include in any such work a brief summary of
+the changes made to Python.
+
+4. PSF is making Python available to Licensee on an "AS IS"
+basis.  PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND
+DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
+FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF PYTHON WILL NOT
+INFRINGE ANY THIRD PARTY RIGHTS.
+
+5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON
+FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS
+A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON,
+OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+
+6. This License Agreement will automatically terminate upon a material
+breach of its terms and conditions.
+
+7. Nothing in this License Agreement shall be deemed to create any
+relationship of agency, partnership, or joint venture between PSF and
+Licensee.  This License Agreement does not grant permission to use PSF
+trademarks or trade name in a trademark sense to endorse or promote
+products or services of Licensee, or any third party.
+
+8. By copying, installing or otherwise using Python, Licensee
+agrees to be bound by the terms and conditions of this License
+Agreement.
+
+
+BEOPEN.COM LICENSE AGREEMENT FOR PYTHON 2.0
+-------------------------------------------
+
+BEOPEN PYTHON OPEN SOURCE LICENSE AGREEMENT VERSION 1
+
+1. This LICENSE AGREEMENT is between BeOpen.com ("BeOpen"), having an
+office at 160 Saratoga Avenue, Santa Clara, CA 95051, and the
+Individual or Organization ("Licensee") accessing and otherwise using
+this software in source or binary form and its associated
+documentation ("the Software").
+
+2. Subject to the terms and conditions of this BeOpen Python License
+Agreement, BeOpen hereby grants Licensee a non-exclusive,
+royalty-free, world-wide license to reproduce, analyze, test, perform
+and/or display publicly, prepare derivative works, distribute, and
+otherwise use the Software alone or in any derivative version,
+provided, however, that the BeOpen Python License is retained in the
+Software, alone or in any derivative version prepared by Licensee.
+
+3. BeOpen is making the Software available to Licensee on an "AS IS"
+basis.  BEOPEN MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, BEOPEN MAKES NO AND
+DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
+FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF THE SOFTWARE WILL NOT
+INFRINGE ANY THIRD PARTY RIGHTS.
+
+4. BEOPEN SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF THE
+SOFTWARE FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS
+AS A RESULT OF USING, MODIFYING OR DISTRIBUTING THE SOFTWARE, OR ANY
+DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+
+5. This License Agreement will automatically terminate upon a material
+breach of its terms and conditions.
+
+6. This License Agreement shall be governed by and interpreted in all
+respects by the law of the State of California, excluding conflict of
+law provisions.  Nothing in this License Agreement shall be deemed to
+create any relationship of agency, partnership, or joint venture
+between BeOpen and Licensee.  This License Agreement does not grant
+permission to use BeOpen trademarks or trade names in a trademark
+sense to endorse or promote products or services of Licensee, or any
+third party.  As an exception, the "BeOpen Python" logos available at
+http://www.pythonlabs.com/logos.html may be used according to the
+permissions granted on that web page.
+
+7. By copying, installing or otherwise using the software, Licensee
+agrees to be bound by the terms and conditions of this License
+Agreement.
+
+
+CNRI LICENSE AGREEMENT FOR PYTHON 1.6.1
+---------------------------------------
+
+1. This LICENSE AGREEMENT is between the Corporation for National
+Research Initiatives, having an office at 1895 Preston White Drive,
+Reston, VA 20191 ("CNRI"), and the Individual or Organization
+("Licensee") accessing and otherwise using Python 1.6.1 software in
+source or binary form and its associated documentation.
+
+2. Subject to the terms and conditions of this License Agreement, CNRI
+hereby grants Licensee a nonexclusive, royalty-free, world-wide
+license to reproduce, analyze, test, perform and/or display publicly,
+prepare derivative works, distribute, and otherwise use Python 1.6.1
+alone or in any derivative version, provided, however, that CNRI's
+License Agreement and CNRI's notice of copyright, i.e., "Copyright (c)
+1995-2001 Corporation for National Research Initiatives; All Rights
+Reserved" are retained in Python 1.6.1 alone or in any derivative
+version prepared by Licensee.  Alternately, in lieu of CNRI's License
+Agreement, Licensee may substitute the following text (omitting the
+quotes): "Python 1.6.1 is made available subject to the terms and
+conditions in CNRI's License Agreement.  This Agreement together with
+Python 1.6.1 may be located on the internet using the following
+unique, persistent identifier (known as a handle): 1895.22/1013.  This
+Agreement may also be obtained from a proxy server on the internet
+using the following URL: http://hdl.handle.net/1895.22/1013".
+
+3. In the event Licensee prepares a derivative work that is based on
+or incorporates Python 1.6.1 or any part thereof, and wants to make
+the derivative work available to others as provided herein, then
+Licensee hereby agrees to include in any such work a brief summary of
+the changes made to Python 1.6.1.
+
+4. CNRI is making Python 1.6.1 available to Licensee on an "AS IS"
+basis.  CNRI MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, CNRI MAKES NO AND
+DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
+FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF PYTHON 1.6.1 WILL NOT
+INFRINGE ANY THIRD PARTY RIGHTS.
+
+5. CNRI SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON
+1.6.1 FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS
+A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON 1.6.1,
+OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+
+6. This License Agreement will automatically terminate upon a material
+breach of its terms and conditions.
+
+7. This License Agreement shall be governed by the federal
+intellectual property law of the United States, including without
+limitation the federal copyright law, and, to the extent such
+U.S. federal law does not apply, by the law of the Commonwealth of
+Virginia, excluding Virginia's conflict of law provisions.
+Notwithstanding the foregoing, with regard to derivative works based
+on Python 1.6.1 that incorporate non-separable material that was
+previously distributed under the GNU General Public License (GPL), the
+law of the Commonwealth of Virginia shall govern this License
+Agreement only as to issues arising under or with respect to
+Paragraphs 4, 5, and 7 of this License Agreement.  Nothing in this
+License Agreement shall be deemed to create any relationship of
+agency, partnership, or joint venture between CNRI and Licensee.  This
+License Agreement does not grant permission to use CNRI trademarks or
+trade name in a trademark sense to endorse or promote products or
+services of Licensee, or any third party.
+
+8. By clicking on the "ACCEPT" button where indicated, or by copying,
+installing or otherwise using Python 1.6.1, Licensee agrees to be
+bound by the terms and conditions of this License Agreement.
+
+        ACCEPT
+
+
+CWI LICENSE AGREEMENT FOR PYTHON 0.9.0 THROUGH 1.2
+--------------------------------------------------
+
+Copyright (c) 1991 - 1995, Stichting Mathematisch Centrum Amsterdam,
+The Netherlands.  All rights reserved.
+
+Permission to use, copy, modify, and distribute this software and its
+documentation for any purpose and without fee is hereby granted,
+provided that the above copyright notice appear in all copies and that
+both that copyright notice and this permission notice appear in
+supporting documentation, and that the name of Stichting Mathematisch
+Centrum or CWI not be used in advertising or publicity pertaining to
+distribution of the software without specific, written prior
+permission.
+
+STICHTING MATHEMATISCH CENTRUM DISCLAIMS ALL WARRANTIES WITH REGARD TO
+THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS, IN NO EVENT SHALL STICHTING MATHEMATISCH CENTRUM BE LIABLE
+FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
+OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ZERO-CLAUSE BSD LICENSE FOR CODE IN THE PYTHON DOCUMENTATION
+----------------------------------------------------------------------
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.

--- a/client/verta/verta/external/cpython/graphlib.py
+++ b/client/verta/verta/external/cpython/graphlib.py
@@ -1,0 +1,251 @@
+# https://github.com/python/cpython/blob/v3.11.0/Lib/graphlib.py
+
+from types import GenericAlias
+
+__all__ = ["TopologicalSorter", "CycleError"]
+
+_NODE_OUT = -1
+_NODE_DONE = -2
+
+
+class _NodeInfo:
+    __slots__ = "node", "npredecessors", "successors"
+
+    def __init__(self, node):
+        # The node this class is augmenting.
+        self.node = node
+
+        # Number of predecessors, generally >= 0. When this value falls to 0,
+        # and is returned by get_ready(), this is set to _NODE_OUT and when the
+        # node is marked done by a call to done(), set to _NODE_DONE.
+        self.npredecessors = 0
+
+        # List of successor nodes. The list can contain duplicated elements as
+        # long as they're all reflected in the successor's npredecessors attribute.
+        self.successors = []
+
+
+class CycleError(ValueError):
+    """Subclass of ValueError raised by TopologicalSorter.prepare if cycles
+    exist in the working graph.
+
+    If multiple cycles exist, only one undefined choice among them will be reported
+    and included in the exception. The detected cycle can be accessed via the second
+    element in the *args* attribute of the exception instance and consists in a list
+    of nodes, such that each node is, in the graph, an immediate predecessor of the
+    next node in the list. In the reported list, the first and the last node will be
+    the same, to make it clear that it is cyclic.
+    """
+
+    pass
+
+
+class TopologicalSorter:
+    """Provides functionality to topologically sort a graph of hashable nodes"""
+
+    def __init__(self, graph=None):
+        self._node2info = {}
+        self._ready_nodes = None
+        self._npassedout = 0
+        self._nfinished = 0
+
+        if graph is not None:
+            for node, predecessors in graph.items():
+                self.add(node, *predecessors)
+
+    def _get_nodeinfo(self, node):
+        if (result := self._node2info.get(node)) is None:
+            self._node2info[node] = result = _NodeInfo(node)
+        return result
+
+    def add(self, node, *predecessors):
+        """Add a new node and its predecessors to the graph.
+
+        Both the *node* and all elements in *predecessors* must be hashable.
+
+        If called multiple times with the same node argument, the set of dependencies
+        will be the union of all dependencies passed in.
+
+        It is possible to add a node with no dependencies (*predecessors* is not provided)
+        as well as provide a dependency twice. If a node that has not been provided before
+        is included among *predecessors* it will be automatically added to the graph with
+        no predecessors of its own.
+
+        Raises ValueError if called after "prepare".
+        """
+        if self._ready_nodes is not None:
+            raise ValueError("Nodes cannot be added after a call to prepare()")
+
+        # Create the node -> predecessor edges
+        nodeinfo = self._get_nodeinfo(node)
+        nodeinfo.npredecessors += len(predecessors)
+
+        # Create the predecessor -> node edges
+        for pred in predecessors:
+            pred_info = self._get_nodeinfo(pred)
+            pred_info.successors.append(node)
+
+    def prepare(self):
+        """Mark the graph as finished and check for cycles in the graph.
+
+        If any cycle is detected, "CycleError" will be raised, but "get_ready" can
+        still be used to obtain as many nodes as possible until cycles block more
+        progress. After a call to this function, the graph cannot be modified and
+        therefore no more nodes can be added using "add".
+        """
+        if self._ready_nodes is not None:
+            raise ValueError("cannot prepare() more than once")
+
+        self._ready_nodes = [
+            i.node for i in self._node2info.values() if i.npredecessors == 0
+        ]
+        # ready_nodes is set before we look for cycles on purpose:
+        # if the user wants to catch the CycleError, that's fine,
+        # they can continue using the instance to grab as many
+        # nodes as possible before cycles block more progress
+        cycle = self._find_cycle()
+        if cycle:
+            raise CycleError(f"nodes are in a cycle", cycle)
+
+    def get_ready(self):
+        """Return a tuple of all the nodes that are ready.
+
+        Initially it returns all nodes with no predecessors; once those are marked
+        as processed by calling "done", further calls will return all new nodes that
+        have all their predecessors already processed. Once no more progress can be made,
+        empty tuples are returned.
+
+        Raises ValueError if called without calling "prepare" previously.
+        """
+        if self._ready_nodes is None:
+            raise ValueError("prepare() must be called first")
+
+        # Get the nodes that are ready and mark them
+        result = tuple(self._ready_nodes)
+        n2i = self._node2info
+        for node in result:
+            n2i[node].npredecessors = _NODE_OUT
+
+        # Clean the list of nodes that are ready and update
+        # the counter of nodes that we have returned.
+        self._ready_nodes.clear()
+        self._npassedout += len(result)
+
+        return result
+
+    def is_active(self):
+        """Return ``True`` if more progress can be made and ``False`` otherwise.
+
+        Progress can be made if cycles do not block the resolution and either there
+        are still nodes ready that haven't yet been returned by "get_ready" or the
+        number of nodes marked "done" is less than the number that have been returned
+        by "get_ready".
+
+        Raises ValueError if called without calling "prepare" previously.
+        """
+        if self._ready_nodes is None:
+            raise ValueError("prepare() must be called first")
+        return self._nfinished < self._npassedout or bool(self._ready_nodes)
+
+    def __bool__(self):
+        return self.is_active()
+
+    def done(self, *nodes):
+        """Marks a set of nodes returned by "get_ready" as processed.
+
+        This method unblocks any successor of each node in *nodes* for being returned
+        in the future by a call to "get_ready".
+
+        Raises :exec:`ValueError` if any node in *nodes* has already been marked as
+        processed by a previous call to this method, if a node was not added to the
+        graph by using "add" or if called without calling "prepare" previously or if
+        node has not yet been returned by "get_ready".
+        """
+
+        if self._ready_nodes is None:
+            raise ValueError("prepare() must be called first")
+
+        n2i = self._node2info
+
+        for node in nodes:
+            # Check if we know about this node (it was added previously using add()
+            if (nodeinfo := n2i.get(node)) is None:
+                raise ValueError(f"node {node!r} was not added using add()")
+
+            # If the node has not being returned (marked as ready) previously, inform the user.
+            stat = nodeinfo.npredecessors
+            if stat != _NODE_OUT:
+                if stat >= 0:
+                    raise ValueError(
+                        f"node {node!r} was not passed out (still not ready)"
+                    )
+                elif stat == _NODE_DONE:
+                    raise ValueError(f"node {node!r} was already marked done")
+                else:
+                    assert False, f"node {node!r}: unknown status {stat}"
+
+            # Mark the node as processed
+            nodeinfo.npredecessors = _NODE_DONE
+
+            # Go to all the successors and reduce the number of predecessors, collecting all the ones
+            # that are ready to be returned in the next get_ready() call.
+            for successor in nodeinfo.successors:
+                successor_info = n2i[successor]
+                successor_info.npredecessors -= 1
+                if successor_info.npredecessors == 0:
+                    self._ready_nodes.append(successor)
+            self._nfinished += 1
+
+    def _find_cycle(self):
+        n2i = self._node2info
+        stack = []
+        itstack = []
+        seen = set()
+        node2stacki = {}
+
+        for node in n2i:
+            if node in seen:
+                continue
+
+            while True:
+                if node in seen:
+                    # If we have seen already the node and is in the
+                    # current stack we have found a cycle.
+                    if node in node2stacki:
+                        return stack[node2stacki[node] :] + [node]
+                    # else go on to get next successor
+                else:
+                    seen.add(node)
+                    itstack.append(iter(n2i[node].successors).__next__)
+                    node2stacki[node] = len(stack)
+                    stack.append(node)
+
+                # Backtrack to the topmost stack entry with
+                # at least another successor.
+                while stack:
+                    try:
+                        node = itstack[-1]()
+                        break
+                    except StopIteration:
+                        del node2stacki[stack.pop()]
+                        itstack.pop()
+                else:
+                    break
+        return None
+
+    def static_order(self):
+        """Returns an iterable of nodes in a topological order.
+
+        The particular order that is returned may depend on the specific
+        order in which the items were inserted in the graph.
+
+        Using this method does not require to call "prepare" or "done". If any
+        cycle is detected, :exc:`CycleError` will be raised.
+        """
+        self.prepare()
+        while self.is_active():
+            node_group = self.get_ready()
+            yield from node_group
+            self.done(*node_group)
+
+    __class_getitem__ = classmethod(GenericAlias)

--- a/client/verta/verta/external/cpython/graphlib.py
+++ b/client/verta/verta/external/cpython/graphlib.py
@@ -170,7 +170,8 @@ class TopologicalSorter:
 
         for node in nodes:
             # Check if we know about this node (it was added previously using add()
-            if (nodeinfo := n2i.get(node)) is None:
+            nodeinfo = n2i.get(node)
+            if nodeinfo is None:
                 raise ValueError(f"node {node!r} was not added using add()")
 
             # If the node has not being returned (marked as ready) previously, inform the user.

--- a/client/verta/verta/external/cpython/graphlib.py
+++ b/client/verta/verta/external/cpython/graphlib.py
@@ -54,7 +54,8 @@ class TopologicalSorter:
                 self.add(node, *predecessors)
 
     def _get_nodeinfo(self, node):
-        if (result := self._node2info.get(node)) is None:
+        result = self._node2info.get(node)
+        if result is None:
             self._node2info[node] = result = _NodeInfo(node)
         return result
 


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

Implements `LocalOrchestrator` and `ModelObjectStepHandler` (and `ModelContainerStepHandler`) to prepare and run a pipeline that uses locally-instantiated model objects retrieved from registered model versions.

## Risks and Area of Effect

None—all new functionality

I don't yet have tests, but I have a separate ticket for that.

## Testing
- [ ] Unit test
- [ ] Deployed to dev env
- [x] Other (explain)

Tested manually for now because things are still a bit in flux 😭 

Using a pared-down version of the pipeline spec we have exemplified in [our design doc](https://github.com/VertaAI/docs/blob/main/design-docs/2023-05-pipelines.md):

```python
spec = {
  "steps": [
    {
      "rmvId": model1.id,
      "attributes": {"name": "multiply_by_1"}
    },
    {
      "rmvId": model2.id,
      "attributes": {"name": "multiply_by_2"}
    },
    {
      "rmvId": model3.id,
      "attributes": {"name": "multiply_by_3"}
    }
  ],
  "graph": {
    "inputs": {
      "multiply_by_2": ["multiply_by_1"],
      "multiply_by_3": ["multiply_by_2"]
    }
  }
}
```

we have a silly pipeline that multiplies an input number by 1, then by 2, then by 3:

```python
from verta._pipeline_orchestrator import LocalOrchestrator

orchestrator = LocalOrchestrator(client._conn, spec)
orchestrator.run(1)
# 6
```

and outputs are stored as state for that run of the pipeline:

```python
orchestrator._outputs
# {'multiply_by_1': 1, 'multiply_by_2': 2, 'multiply_by_3': 6}
```

## Reverting
- [ ] Contains Migration - _Do Not Revert_

Revert this PR.