### PR TITLE
fix: [VRD-954] Revert changes to artifact tests

### DIFF
--- a/client/verta/tests/deployable_entity/test_artifacts.py
+++ b/client/verta/tests/deployable_entity/test_artifacts.py
@@ -489,6 +489,9 @@ class TestModels:
         assert deployable_entity.get_model().__dict__ == custom.__dict__
         assert deployable_entity.get_model().predict(strs) == custom.predict(strs)
 
+    # pyspark model objects return a reader object for ".read()" instead of a string
+    # which breaks the verta/_internal_utils/_artifact_utils.py:ensure_bytestream() function
+    @pytest.mark.skip
     def test_pyspark(self, deployable_entity, in_tempdir):
         data_filename = "census-train.csv"
         spark_model_dir = "spark-model"


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context
Reverts one of the changes made in PR-3881.

These tests are for the artifact proto, not the `model_packaging` stuff removed in the previous PR.

Additionally, a `pyspark` related unit test is marked to be skipped as it is failing for reasons unrelated to these changes.  [Jira issue](https://vertaai.atlassian.net/browse/VRD-963) created for tracking.

## Risks and Area of Effect

## Testing
- [X] Unit test - returned to prior state, and still passing
- [ ] Deployed to dev env
- [ ] Other (explain) 

## Reverting
- [ ] Contains Migration - _Do Not Revert_