### PR TITLE
cleanup: remove the usage of unimplemented getAllowedResources

### DIFF
--- a/backend/common/src/main/java/ai/verta/modeldb/common/CommonUtils.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/CommonUtils.java
@@ -120,10 +120,10 @@ public class CommonUtils {
     T retryCall(boolean retry);
   }
 
-  public static Object retryOrThrowException(
+  public static <T> T retryOrThrowException(
       StatusRuntimeException ex,
       boolean retry,
-      RetryCallInterface<?> retryCallInterface,
+      RetryCallInterface<T> retryCallInterface,
       Integer requestTimeout) {
     String errorMessage = ex.getMessage();
     LOGGER.debug(errorMessage);

--- a/backend/common/src/main/java/ai/verta/modeldb/common/authservice/RoleService.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/authservice/RoleService.java
@@ -51,15 +51,8 @@ public interface RoleService {
       String roleName, String resourceId, String userId, String resourceTypeName);
 
   Collection<String> getAccessibleResourceIds(
-      CollaboratorBase hostUserInfo,
-      CollaboratorBase currentLoginUserInfo,
       ModelDBServiceResourceTypes modelDBServiceResourceTypes,
       Collection<String> requestedResourceIds);
-
-  List<Resources> getAllowedResources(
-      ModelDBServiceResourceTypes modelDBServiceResourceTypes,
-      ModelDBServiceActions modelDBServiceActions,
-      CollaboratorBase collaboratorBase);
 
   List<Resources> getSelfAllowedResources(
       ModelDBServiceResourceTypes modelDBServiceResourceTypes,

--- a/backend/server/src/main/java/ai/verta/modeldb/authservice/PublicMDBRoleServiceUtils.java
+++ b/backend/server/src/main/java/ai/verta/modeldb/authservice/PublicMDBRoleServiceUtils.java
@@ -105,22 +105,12 @@ public class PublicMDBRoleServiceUtils implements MDBRoleService {
   }
 
   @Override
-  public List<Resources> getAllowedResources(
-      ModelDBServiceResourceTypes modelDBServiceResourceTypes,
-      ModelDBServiceActions modelDBServiceActions,
-      CollaboratorBase collaboratorBase) {
-    return Collections.emptyList();
-  }
-
-  @Override
   public GeneratedMessageV3 getOrgById(String orgId) {
     return null;
   }
 
   @Override
   public Collection<String> getAccessibleResourceIds(
-      CollaboratorBase hostUserInfo,
-      CollaboratorBase currentLoginUserInfo,
       ModelDBServiceResourceTypes modelDBServiceResourceTypes,
       Collection<String> requestedResourceIds) {
     return requestedResourceIds;

--- a/backend/server/src/main/java/ai/verta/modeldb/versioning/CommitDAORdbImpl.java
+++ b/backend/server/src/main/java/ai/verta/modeldb/versioning/CommitDAORdbImpl.java
@@ -10,7 +10,6 @@ import ai.verta.modeldb.PathLocationTypeEnum.PathLocationType;
 import ai.verta.modeldb.authservice.MDBRoleService;
 import ai.verta.modeldb.common.CommonUtils;
 import ai.verta.modeldb.common.authservice.UACApisUtil;
-import ai.verta.modeldb.common.collaborator.CollaboratorUser;
 import ai.verta.modeldb.common.exceptions.InvalidArgumentException;
 import ai.verta.modeldb.common.exceptions.ModelDBException;
 import ai.verta.modeldb.common.handlers.TagsHandlerBase;
@@ -995,8 +994,6 @@ public class CommitDAORdbImpl implements CommitDAO {
     Set<String> accessibleResourceIds =
         new HashSet<>(
             mdbRoleService.getAccessibleResourceIds(
-                null,
-                new CollaboratorUser(uacApisUtil, currentLoginUserInfo),
                 modelDBServiceResourceTypes,
                 request.getRepoIdsList().stream()
                     .map(String::valueOf)

--- a/backend/server/src/main/java/ai/verta/modeldb/versioning/RepositoryDAORdbImpl.java
+++ b/backend/server/src/main/java/ai/verta/modeldb/versioning/RepositoryDAORdbImpl.java
@@ -9,7 +9,6 @@ import ai.verta.modeldb.Dataset;
 import ai.verta.modeldb.authservice.MDBRoleService;
 import ai.verta.modeldb.common.CommonUtils;
 import ai.verta.modeldb.common.authservice.UACApisUtil;
-import ai.verta.modeldb.common.collaborator.CollaboratorUser;
 import ai.verta.modeldb.common.exceptions.InternalErrorException;
 import ai.verta.modeldb.common.exceptions.ModelDBException;
 import ai.verta.modeldb.config.MDBConfig;
@@ -1094,8 +1093,6 @@ public class RepositoryDAORdbImpl implements RepositoryDAO {
         Set<String> accessibleResourceIdsWithCollaborator =
             new HashSet<>(
                 mdbRoleService.getAccessibleResourceIds(
-                    null,
-                    new CollaboratorUser(uacApisUtil, currentLoginUserInfo),
                     ModelDBServiceResourceTypes.REPOSITORY,
                     request.getRepoIdsList().stream()
                         .map(String::valueOf)


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

GetAllowedResources is not implemented in UAC, and the one possible code path in modeldb that might hit it, never used parameter values that would get to it. This removes it so we can get rid of it from the protobufs altogether.

See https://github.com/VertaAI/protos-all/pull/493

## Risks and Area of Effect

## Testing
- [x] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

## Reverting
- [ ] Contains Migration - _Do Not Revert_