### PR TITLE
feat: Add Python.python_version property

### DIFF
--- a/client/verta/tests/unit_tests/environment/test_python.py
+++ b/client/verta/tests/unit_tests/environment/test_python.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+
+import sys
+
+from verta.environment import Python
+
+
+class TestPython:
+    def test_python_version(self):
+        """Verify ``python_version`` property matches ``sys.version_info``."""
+        python_version = Python([]).python_version
+
+        # tuple values match
+        assert tuple(python_version) == tuple(sys.version_info[:3])
+
+        # namedtuple fields match
+        for field in ["major", "minor", "micro"]:
+            assert getattr(python_version, field) == getattr(sys.version_info, field)

--- a/client/verta/verta/environment/_python.py
+++ b/client/verta/verta/environment/_python.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 
+import collections
 import copy
 import logging
 import os
 import sys
+from typing import Optional
 
 from .._vendored import six
 
@@ -53,6 +55,12 @@ class Python(_environment._Environment):
         Apt packages to be installed alongside a Python environment.
     env_vars : dict of str to str, or None
         Environment variables.
+    python_version : 3-tuple of int, or None
+        Python version. This tuple contains three compoennts of the version number:
+        *major*, *minor*, and *micro*. Similar to :obj:`sys.version_info`, the
+        components can be accessed by index or by name, so
+        ``env.python_version[0]`` is equivalent to
+        ``env.python_version.major`` and so on.
 
     Examples
     --------
@@ -173,6 +181,21 @@ class Python(_environment._Environment):
         else:
             # raw requirements
             return self._msg.python.raw_requirements.splitlines()
+
+    @property
+    def python_version(self) -> Optional[collections.namedtuple]:
+        if not self._msg.python.version.major:
+            return None
+
+        python_version = collections.namedtuple(
+            "python_version",
+            ["major", "minor", "micro"],
+        )
+        return python_version(
+            major=self._msg.python.version.major,
+            minor=self._msg.python.version.minor,
+            micro=self._msg.python.version.patch,
+        )
 
     @classmethod
     def _from_proto(cls, blob_msg):

--- a/client/verta/verta/environment/_python.py
+++ b/client/verta/verta/environment/_python.py
@@ -60,7 +60,8 @@ class Python(_environment._Environment):
         *major*, *minor*, and *micro*. Similar to :obj:`sys.version_info`, the
         components can be accessed by index or by name, so
         ``env.python_version[0]`` is equivalent to
-        ``env.python_version.major`` and so on.
+        ``env.python_version.major`` and so on. Returns ``None`` if no Python
+        version was captured.
 
     Examples
     --------


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

Expose `Python` version number as public property.

## Risks and Area of Effect

—

## Testing
- [x] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

Added unit test, passes in Python `3.10.6`.

## Reverting
- [ ] Contains Migration - _Do Not Revert_

Revert this PR.