### PR TITLE
feat: Add RegisteredModelVersion.experiment_run_id property

### DIFF
--- a/client/verta/tests/registry/model_version/test_from_run.py
+++ b/client/verta/tests/registry/model_version/test_from_run.py
@@ -37,6 +37,16 @@ class TestFromRun:
             )
             assert np.array_equal(model_version.get_artifact("some-artifact"), artifact)
 
+    def test_experiment_run_id_property(self, experiment_run, registered_model):
+        """Verify ``ModelVersion.experiment_run_id`` value."""
+        model_version = registered_model.create_version()
+        assert model_version.experiment_run_id is None
+
+        model_version_from_run = registered_model.create_version_from_run(
+            experiment_run,
+        )
+        assert model_version_from_run.experiment_run_id == experiment_run.id
+
     def test_from_run_diff_workspaces(
         self, client, experiment_run, workspace, created_entities
     ):

--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -3,13 +3,12 @@
 from __future__ import print_function
 
 import ast
-import json
 import logging
 import os
 import pathlib
 import pickle
 import tempfile
-from typing import List
+from typing import List, Optional
 import warnings
 
 from google.protobuf.struct_pb2 import Value
@@ -69,6 +68,10 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
         Whether there is a model associated with this model version.
     registered_model_id : int
         ID of this version's registered model.
+    experiment_run_id : str or None
+        ID of this version's source experiment run, if it was created via
+        :meth:`RegisteredModel.create_version_from_run()
+        <verta.registry.entities.RegisteredModel.create_version_from_run>`.
     stage : str
         Model version stage.
     url : str
@@ -191,6 +194,11 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
             )
         else:
             return self._conn._OSS_DEFAULT_WORKSPACE
+
+    @property
+    def experiment_run_id(self) -> Optional[str]:
+        self._refresh_cache()
+        return self._msg.experiment_run_id or None
 
     def get_artifact_keys(self):
         """


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

Expose `experiment_run_id` as public property.

## Risks and Area of Effect

—

## Testing
- [x] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

```sh
% pytest registry/model_version/test_from_run.py::TestFromRun::test_experiment_run_id_property unit_tests/registry/test_registered_model_version.py::test_experiment_run_id_property                                              
==================================================== test session starts ====================================================
platform darwin -- Python 3.10.6, pytest-7.2.1, pluggy-1.0.0                                                                 
rootdir: /Users/miliu/Documents/modeldb/client/verta/tests, configfile: pytest.ini                                           
plugins: forked-1.4.0, xdist-3.1.0, typeguard-2.13.3, hypothesis-6.67.1                                                      
collected 2 items                                                                                                            
                                                                                                                             
registry/model_version/test_from_run.py .                                                                             [ 50%] 
unit_tests/registry/test_registered_model_version.py .                                                                [100%] 
                                                                                                                             
==================================================== 2 passed in 19.34s =====================================================
```

## Reverting
- [ ] Contains Migration - _Do Not Revert_

Revert this PR.