### PR TITLE
test: Add options for model_ver_proto strategy

### DIFF
--- a/client/verta/tests/unit_tests/conftest.py
+++ b/client/verta/tests/unit_tests/conftest.py
@@ -74,5 +74,5 @@ def mock_registered_model_version(mock_conn, mock_config):
     return MockRegisteredModelVersion(
         mock_conn,
         mock_config,
-        _RegistryService.ModelVersion(id=555, registered_model_id=123)
+        _RegistryService.ModelVersion(id=555, registered_model_id=123),
     )

--- a/client/verta/tests/unit_tests/registry/test_registered_model_version.py
+++ b/client/verta/tests/unit_tests/registry/test_registered_model_version.py
@@ -14,12 +14,12 @@ from verta._protos.public.registry import RegistryService_pb2
 from verta.registry.entities import RegisteredModelVersion
 
 from ..strategies import (
-    int64,
-    uint64,
     artifact_proto,
     attribute_proto,
     code_blob_proto,
+    int64,
     model_artifact_proto,
+    uint64,
 )
 
 


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

I was working on something else, and ended up making some self-contained changes to registry protobuf strategies.

## Risks and Area of Effect

—

## Testing
- [x] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

Tests still pass in 3.10:

```
% pytest unit_tests 
==================================================== test session starts ====================================================
platform darwin -- Python 3.10.6, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/miliu/Documents/modeldb/client/verta/tests, configfile: pytest.ini
plugins: forked-1.4.0, xdist-3.1.0, typeguard-2.13.3, hypothesis-6.67.1
collected 87 items                                                                                                          

unit_tests/test_runtime.py ..........................                                                                 [ 29%]
unit_tests/client/test_get_kafka_topics.py .                                                                          [ 31%]
unit_tests/custom_modules/test_custom_modules_util.py ....                                                            [ 35%]
unit_tests/deployment/test_build.py ....                                                                              [ 40%]
unit_tests/deployment/test_build_scan.py ...                                                                          [ 43%]
unit_tests/deployment/test_deployed_model.py .....................                                                    [ 67%]
unit_tests/deployment/test_endpoint.py .......                                                                        [ 75%]
unit_tests/environment/test_python.py .                                                                               [ 77%]
unit_tests/internal_utils/test_kafka_utils.py ...                                                                     [ 80%]
unit_tests/registry/test_check_model_dependencies.py ...                                                              [ 83%]
unit_tests/registry/test_model_dependencies.py ............                                                           [ 97%]
unit_tests/registry/test_registered_model_version.py ..                                                               [100%]

========================================= 87 passed, 1 warning in 128.76s (0:02:08) =========================================

```

## Reverting
- [ ] Contains Migration - _Do Not Revert_

Revert this PR.