### PR TITLE
Feature: Add OpenTelemetry AutoConfigured SDK initialisation to TracingExtension

### DIFF
--- a/backend/common-testing/pom.xml
+++ b/backend/common-testing/pom.xml
@@ -58,6 +58,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.opentelemetry.instrumentation</groupId>
             <artifactId>opentelemetry-spring-webmvc-5.3</artifactId>
             <version>${otel.instrumentation.version}</version>

--- a/backend/common-testing/src/main/java/ai/verta/common/testing/utils/TracingExtension.java
+++ b/backend/common-testing/src/main/java/ai/verta/common/testing/utils/TracingExtension.java
@@ -193,8 +193,8 @@ public class TracingExtension
 
   /**
    * This method initiates an OpenTelemetrySdk instance using AutoConfiguredOpenTelemetrySdk
-   * builder. It also configures various properties including
-   * tracing exporter, propagators, and disabled resource providers.
+   * builder. It also configures various properties including tracing exporter, propagators, and
+   * disabled resource providers.
    *
    * <p>For tracing in tests, consider the following steps:
    *

--- a/backend/common-testing/src/main/java/ai/verta/common/testing/utils/TracingExtension.java
+++ b/backend/common-testing/src/main/java/ai/verta/common/testing/utils/TracingExtension.java
@@ -236,6 +236,7 @@ public class TracingExtension
                 })
             .build();
     var openTelemetrySdk = autoConfiguredOpenTelemetrySdk.getOpenTelemetrySdk();
+    TracingExtension.setOpenTelemetry(openTelemetrySdk);
     log.debug("openTelemetrySdk initialized = " + openTelemetrySdk);
     return openTelemetrySdk;
   }

--- a/backend/common-testing/src/main/java/ai/verta/common/testing/utils/TracingExtension.java
+++ b/backend/common-testing/src/main/java/ai/verta/common/testing/utils/TracingExtension.java
@@ -5,7 +5,10 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 import java.lang.reflect.Method;
+import java.util.Map;
 import java.util.Optional;
 import lombok.extern.log4j.Log4j2;
 import org.junit.jupiter.api.extension.*;
@@ -183,5 +186,55 @@ public class TracingExtension
   @Override
   public void postProcessTestInstance(Object o, ExtensionContext extensionContext) {
     maybeStartRootSpan(extensionContext);
+  }
+
+  /**
+   * This method initiates an OpenTelemetrySdk instance using AutoConfiguredOpenTelemetrySdk
+   * builder. It sets the global OpenTelemetry SDK, and configures various properties including
+   * tracing exporter, propagators, and disabled resource providers.
+   *
+   * <p>For tracing in tests, consider the following steps:
+   *
+   * <ul>
+   *   <li>Run Jaeger locally using: {@code docker run --rm --name jaeger -p 16686:16686 -p
+   *       4317:4317 jaegertracing/all-in-one:1.48}
+   *   <li>Set the OTEL_TRACES_EXPORTER environment variable to "otlp" when running the tests.
+   *   <li>Extend your test with the TracingExtension: {@code @ExtendWith(TracingExtension.class)}
+   * </ul>
+   *
+   * Note: This method sets the 'otel.traces.exporter' as 'none', the 'otel.propagators' as
+   * 'jaeger,tracecontext', and the 'otel.java.disabled.resource.providers' as
+   * 'io.opentelemetry.instrumentation.resources.ProcessResourceProvider'.
+   *
+   * @return OpenTelemetrySdk instance with the provided configurations
+   */
+  public static OpenTelemetrySdk initializeOpenTelemetrySdk() {
+    log.info("initializing otel");
+    var autoConfiguredOpenTelemetrySdk =
+        AutoConfiguredOpenTelemetrySdk.builder()
+            .setResultAsGlobal()
+            .addPropertiesSupplier(
+                () ->
+                    Map.of(
+                        "otel.traces.exporter",
+                        "none",
+                        "otel.propagators",
+                        "jaeger,tracecontext",
+                        "otel.java.disabled.resource.providers",
+                        "io.opentelemetry.instrumentation.resources.ProcessResourceProvider"))
+            .addPropertiesCustomizer(
+                configProperties -> {
+                  return Map.of(
+                      "otel.metrics.exporter",
+                      "none",
+                      "otel.logs.exporter",
+                      "none",
+                      "otel.service.name",
+                      "registry-local-its");
+                })
+            .build();
+    var openTelemetrySdk = autoConfiguredOpenTelemetrySdk.getOpenTelemetrySdk();
+    log.debug("openTelemetrySdk initialized = " + openTelemetrySdk);
+    return openTelemetrySdk;
   }
 }


### PR DESCRIPTION
The TracingExtension.java class was extended by introducing a new method to initialize an OpenTelemetrySdk instance using
AutoConfiguredOpenTelemetrySdk builder. This instance sets the global OpenTelemetry SDK, and configures various properties including tracing exporter, propagators, and disabled resource providers.

The purpose of this change is to streamline the handling of tracing in testing environment. Developers can now easily initialise the Open Telemetry SDK, which may be useful for enhanced tracking of testing processes.

Also, the pom.xml file in the common-testing directory was updated to include a dependency on 'opentelemetry-sdk-extension-autoconfigure' for enabling the AutoConfiguredOpenTelemetrySdk usage.

<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

## Risks and Area of Effect

## Testing
- [ ] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

## Reverting
- [ ] Contains Migration - _Do Not Revert_