### PR TITLE
fix: make sure reconcilers and jetstream threads shut down cleanly

### DIFF
--- a/backend/common/src/main/java/ai/verta/modeldb/common/nats/JetstreamConnector.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/nats/JetstreamConnector.java
@@ -11,9 +11,10 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.DisposableBean;
 
 @Log4j2
-public class JetstreamConnector {
+public class JetstreamConnector implements DisposableBean {
   private static final Duration RECONNECT_WAIT_INTERVAL = Duration.ofSeconds(2L);
   private static final int MEGABYTE = 1024 * 1024;
   private static final int MAX_STREAM_BYTES = 100 * MEGABYTE;
@@ -203,6 +204,7 @@ public class JetstreamConnector {
   }
 
   public Dispatcher createDispatcher() {
+    checkNatsConnection();
     return natsConnection.createDispatcher();
   }
 
@@ -256,6 +258,12 @@ public class JetstreamConnector {
     } catch (IOException | JetStreamApiException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  @Override
+  public void destroy() throws Exception {
+    log.warn("Destroying jetstream connector...closing the nats connection.");
+    close();
   }
 
   public static class StreamNotFoundException extends Exception {}

--- a/backend/common/src/main/java/ai/verta/modeldb/common/reconcilers/Reconciler.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/reconcilers/Reconciler.java
@@ -10,6 +10,7 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.internal.DaemonThreadFactory;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Set;
@@ -20,8 +21,6 @@ import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
-
-import io.opentelemetry.sdk.internal.DaemonThreadFactory;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

Since our reconciler threads were not marked as daemon threads, a crashing spring container might leave them running, keeping the JVM from exiting. 

Also, make the JetstreamConnector shut down the NATS connection if it gets a signal from the spring container.

## Risks and Area of Effect
- [ ] Is this a breaking change?

## Testing
- [ ] Unit test
- [ ] Deployed to dev env
- [x] Other (explain) - Incorporated these changes locally into the registry, reproduced a hung-JVM after container crashed, and verified this change allowed the JVM to exit cleanly.

## Reverting
- [ ] Contains Migration - _Do Not Revert_