### PR TITLE
feat: introduce jitter in the reconciler resync loop

### DIFF
--- a/.run/PullRequestSuite.run.xml
+++ b/.run/PullRequestSuite.run.xml
@@ -1,0 +1,29 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="PullRequestSuite" type="JUnit" factoryName="JUnit" nameIsGenerated="true">
+    <module name="modeldb" />
+    <extension name="coverage">
+      <pattern>
+        <option name="PATTERN" value="ai.verta.modeldb.*" />
+        <option name="ENABLED" value="true" />
+      </pattern>
+    </extension>
+    <extension name="net.ashald.envfile">
+      <option name="IS_ENABLED" value="true" />
+      <option name="IS_SUBST" value="false" />
+      <option name="IS_PATH_MACRO_SUPPORTED" value="false" />
+      <option name="IS_IGNORE_MISSING_FILES" value="false" />
+      <option name="IS_ENABLE_EXPERIMENTAL_INTEGRATIONS" value="false" />
+      <ENTRIES>
+        <ENTRY IS_ENABLED="true" PARSER="runconfig" IS_EXECUTABLE="false" />
+        <ENTRY IS_ENABLED="true" PARSER="yaml" IS_EXECUTABLE="false" PATH="backend/server/itconfig/test-env-h2.json" />
+      </ENTRIES>
+    </extension>
+    <option name="PACKAGE_NAME" value="ai.verta.modeldb" />
+    <option name="MAIN_CLASS_NAME" value="ai.verta.modeldb.PullRequestSuite" />
+    <option name="METHOD_NAME" value="" />
+    <option name="TEST_OBJECT" value="class" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/backend/common/src/main/java/ai/verta/modeldb/common/reconcilers/Reconciler.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/reconcilers/Reconciler.java
@@ -1,6 +1,7 @@
 package ai.verta.modeldb.common.reconcilers;
 
 import static io.opentelemetry.api.common.AttributeKey.longKey;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 import ai.verta.modeldb.common.futures.FutureExecutor;
 import ai.verta.modeldb.common.futures.FutureJdbi;
@@ -13,10 +14,10 @@ import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.internal.DaemonThreadFactory;
 import java.util.HashSet;
 import java.util.LinkedList;
+import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -28,6 +29,7 @@ public abstract class Reconciler<T> {
   private static final AttributeKey<String> RECONCILER_NAME_ATTRIBUTE_KEY =
       AttributeKey.stringKey("reconciler");
   private static final AttributeKey<Long> NUMBER_OF_ITEMS_ATTRIBUTE_KEY = longKey("numberOfItems");
+  private static final Random random = new Random();
   protected final Logger logger;
   protected final HashSet<T> elements = new HashSet<>();
   protected final LinkedList<T> order = new LinkedList<>();
@@ -41,16 +43,6 @@ public abstract class Reconciler<T> {
   protected final FutureJdbi futureJdbi;
   protected final FutureExecutor executor;
   private final Tracer tracer;
-
-  @Deprecated(forRemoval = true)
-  protected Reconciler(
-      ReconcilerConfig config,
-      Logger logger,
-      FutureJdbi futureJdbi,
-      FutureExecutor executor,
-      boolean deduplicate) {
-    this(config, futureJdbi, executor, OpenTelemetry.noop(), deduplicate);
-  }
 
   protected Reconciler(
       ReconcilerConfig config,
@@ -72,7 +64,7 @@ public abstract class Reconciler<T> {
   }
 
   private void startResync() {
-    Runnable runnable =
+    Runnable resyncJob =
         () -> {
           Span span =
               tracer
@@ -91,13 +83,41 @@ public abstract class Reconciler<T> {
         };
 
     var executorService =
-        Executors.newSingleThreadScheduledExecutor(
+        Executors.newSingleThreadExecutor(
             new DaemonThreadFactory(getClass().getSimpleName() + "-resyncer"));
-    executorService.scheduleAtFixedRate(
-        runnable,
-        30L /*as per last parameter timeunit*/,
-        config.getResyncPeriodSeconds(),
-        TimeUnit.SECONDS);
+
+    long initialDelayMilliseconds = SECONDS.toMillis(30);
+    long resyncPeriodMillis = SECONDS.toMillis(config.getResyncPeriodSeconds());
+    executorService.submit(
+        () -> {
+          if (!sleepWithJitter(initialDelayMilliseconds)) {
+            return;
+          }
+
+          while (true) {
+            try {
+              resyncJob.run();
+            } catch (Exception e) {
+              logger.error("Resync job failed", e);
+            }
+            if (!sleepWithJitter(resyncPeriodMillis)) {
+              return;
+            }
+          }
+        });
+  }
+
+  private boolean sleepWithJitter(long milliseconds) {
+    try {
+      float plusOrMinus20Percent = (random.nextFloat() * 0.4f) - 0.2f;
+      long millisWithJitter = (long) (milliseconds * (1f + plusOrMinus20Percent));
+      logger.debug("sleeping {} milliseconds", millisWithJitter);
+      Thread.sleep(millisWithJitter);
+      return true;
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return false;
+    }
   }
 
   private void startWorkers() {
@@ -150,7 +170,7 @@ public abstract class Reconciler<T> {
     }
   }
 
-  private ReconcileResult traceReconcile(Set<T> idsToProcess) throws Exception {
+  private void traceReconcile(Set<T> idsToProcess) throws Exception {
     Span span =
         tracer
             .spanBuilder(getClass().getSimpleName() + " reconcile")
@@ -158,7 +178,7 @@ public abstract class Reconciler<T> {
             .setAttribute(NUMBER_OF_ITEMS_ATTRIBUTE_KEY, (long) idsToProcess.size())
             .startSpan();
     try (Scope ignored = span.makeCurrent()) {
-      return reconcile(idsToProcess);
+      reconcile(idsToProcess);
     } catch (Exception e) {
       span.recordException(e);
       span.setStatus(StatusCode.ERROR, e.getMessage());
@@ -185,7 +205,9 @@ public abstract class Reconciler<T> {
     Set<T> ret = new HashSet<>();
     lock.lock();
     try {
-      while (elements.isEmpty()) notEmpty.await();
+      while (elements.isEmpty()) {
+        notEmpty.await();
+      }
 
       while (!elements.isEmpty() && ret.size() < config.getBatchSize()) {
         T obj = order.pop();

--- a/backend/common/src/main/java/ai/verta/modeldb/common/reconcilers/Reconciler.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/reconcilers/Reconciler.java
@@ -111,7 +111,7 @@ public abstract class Reconciler<T> {
     try {
       float plusOrMinus20Percent = (random.nextFloat() * 0.4f) - 0.2f;
       long millisWithJitter = (long) (milliseconds * (1f + plusOrMinus20Percent));
-      logger.debug("sleeping {} milliseconds", millisWithJitter);
+      logger.trace("sleeping {} milliseconds", millisWithJitter);
       Thread.sleep(millisWithJitter);
       return true;
     } catch (InterruptedException e) {


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

This will help spread out our reconcilers, so they don't run in lockstep

## Risks and Area of Effect
- [ ] Is this a breaking change?

## Testing
- [ ] Unit test
- [ ] Deployed to dev env
- [x] Other (explain) - updated registry to use this branch and observed the resulting jitter in the run intervals

## Reverting
- [ ] Contains Migration - _Do Not Revert_