### PR TITLE
feat: [VRD-1120, VRD-1130, VRD-1132] Add `finetune()`

### DIFF
--- a/client/verta/tests/finetune/test_finetune.py
+++ b/client/verta/tests/finetune/test_finetune.py
@@ -19,14 +19,13 @@ def test_finetune(client, registered_model, dataset):
         destination_registered_model=reg_model,
         train_dataset=train_dataset_version,
         name=name,
-        finetuning_config=finetune.LoraConfig(),
     )
     run = client.get_experiment_run(id=model_ver.experiment_run_id)
 
     # check entity names
     assert client.proj.name == reg_model.name + finetune._PROJECT_NAME_SUFFIX
     assert client.expt.name == finetune._EXPERIMENT_NAME_PREFIX + dataset.name
-    ## TODO: wait for fine-tuning to launch, then check ER name
+    # TODO: wait for fine-tuning to launch, then check ER name
     assert model_ver.name == name
 
     # check dataset association

--- a/client/verta/tests/finetune/test_finetune.py
+++ b/client/verta/tests/finetune/test_finetune.py
@@ -39,6 +39,9 @@ def test_finetune(client, registered_model, dataset):
 
     # check attributes
     for entity in [model_ver, run]:
-        assert entity.get_attributes() >= {
-            finetune._FINETUNE_ATTR_KEY: True,
-        }
+        assert (
+            entity.get_attributes().items()
+            >= {
+                finetune._FINETUNE_ATTR_KEY: True,
+            }.items()
+        )

--- a/client/verta/tests/finetune/test_finetune.py
+++ b/client/verta/tests/finetune/test_finetune.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+"""Test RegisteredModelVersion.finetune() and its downstream effects."""
+
+from verta.dataset import Path
+from verta import finetune
+
+
+def test_finetune(client, registered_model, dataset):
+    base_model_ver = registered_model.create_version()  # mocked base LLM RMV
+    name = "v1"
+
+    reg_model = client.create_registered_model()
+    train_dataset_version = dataset.create_version(
+        Path(__file__, enable_mdb_versioning=True),
+    )
+    model_ver = base_model_ver.finetune(
+        destination_registered_model=reg_model,
+        train_dataset=train_dataset_version,
+        name=name,
+        finetuning_config=finetune.LoraConfig(),
+    )
+    run = client.get_experiment_run(id=model_ver.experiment_run_id)
+
+    # check entity names
+    assert client.proj.name == reg_model.name + finetune._PROJECT_NAME_SUFFIX
+    assert client.expt.name == finetune._EXPERIMENT_NAME_PREFIX + dataset.name
+    ## TODO: wait for fine-tuning to launch, then check ER name
+    assert model_ver.name == name
+
+    # check dataset association
+    for entity in [model_ver, run]:
+        for key, value in [
+            (finetune._TRAIN_DATASET_NAME, train_dataset_version),
+            # TODO: eval and test, too
+        ]:
+            assert entity.get_dataset_version(key).id == value.id
+
+    # check attributes
+    for entity in [model_ver, run]:
+        assert entity.get_attributes() >= {
+            finetune._FINETUNE_ATTR_KEY: True,
+        }

--- a/client/verta/tests/finetune/test_finetune.py
+++ b/client/verta/tests/finetune/test_finetune.py
@@ -7,6 +7,7 @@ from verta import finetune
 
 
 def test_finetune(client, registered_model, dataset):
+    """Verify that happy-path ``finetune()`` works."""
     base_model_ver = registered_model.create_version()  # mocked base LLM RMV
     name = "v1"
 

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -931,7 +931,8 @@ class Client(object):
         return self._get_or_create_registered_model(
             self._conn,
             self._conf,
-            self._ctx,
+            ctx,
+            name=name,
             desc=desc,
             labels=labels,
             public_within_org=public_within_org,

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -537,6 +537,7 @@ class Client(object):
         visibility=None,
         id=None,
     ):
+        """:meth:`set_project` but static."""
         resource_name = "Project"
         param_names = "`desc`, `tags`, `attrs`, `public_within_org`, or `visibility`"
         params = (desc, tags, attrs, public_within_org, visibility)
@@ -550,12 +551,7 @@ class Client(object):
             ctx.proj = Project._get_or_create_by_name(
                 conn,
                 name,
-                lambda name: Project._get_by_name(
-                    conn,
-                    conf,
-                    name,
-                    ctx.workspace_name,
-                ),
+                lambda name: Project._get_by_name(conn, conf, name, ctx.workspace_name),
                 lambda name: Project._create(
                     conn,
                     conf,
@@ -568,10 +564,7 @@ class Client(object):
                     visibility=visibility,
                 ),
                 lambda: check_unnecessary_params_warning(
-                    resource_name,
-                    "name {}".format(name),
-                    param_names,
-                    params,
+                    resource_name, "name {}".format(name), param_names, params
                 ),
             )
 
@@ -906,24 +899,54 @@ class Client(object):
         ctx = _Context(self._conn, self._conf)
         ctx.workspace_name = workspace
 
+        return self._get_or_create_registered_model(
+            self._conn,
+            self._conf,
+            self._ctx,
+            desc=desc,
+            labels=labels,
+            public_within_org=public_within_org,
+            visibility=visibility,
+            id=id,
+            task_type=task_type,
+            data_type=data_type,
+            pii=pii,
+        )
+
+    @staticmethod
+    def _get_or_create_registered_model(
+        conn,
+        conf,
+        ctx,
+        name=None,
+        desc=None,
+        labels=None,
+        public_within_org=None,
+        visibility=None,
+        id=None,
+        task_type=None,
+        data_type=None,
+        pii=False,
+    ):
+        """:meth:`get_or_create_registered_model` but static."""
         resource_name = "Registered Model"
         param_names = "`desc`, `labels`, `public_within_org`, or `visibility`"
         params = (desc, labels, public_within_org, visibility)
         if id is not None:
-            registered_model = RegisteredModel._get_by_id(self._conn, self._conf, id)
+            registered_model = RegisteredModel._get_by_id(conn, conf, id)
             check_unnecessary_params_warning(
                 resource_name, "id {}".format(id), param_names, params
             )
         else:
             registered_model = RegisteredModel._get_or_create_by_name(
-                self._conn,
+                conn,
                 name,
                 lambda name: RegisteredModel._get_by_name(
-                    self._conn, self._conf, name, ctx.workspace_name
+                    conn, conf, name, ctx.workspace_name
                 ),
                 lambda name: RegisteredModel._create(
-                    self._conn,
-                    self._conf,
+                    conn,
+                    conf,
                     ctx,
                     name=name,
                     desc=desc,

--- a/client/verta/verta/finetune/__init__.py
+++ b/client/verta/verta/finetune/__init__.py
@@ -8,8 +8,8 @@ from ._finetuning_config import _FinetuningConfig
 from ._lora_config import LoraConfig
 
 
-_TRACKING_NAME_SUFFIX = " Fine-Tuning"  # append to RM and RMV names for project and run
-_EXPERIMENT_NAME = "Fine-Tuning"
+_PROJECT_NAME_SUFFIX = " Fine-Tuning"  # append to RM name for projname
+_EXPERIMENT_NAME_PREFIX = "On Dataset: "  # prepend to train dataset name for expt name
 _TRAIN_DATASET_NAME = "train"
 _EVAL_DATASET_NAME = "eval"
 _TEST_DATASET_NAME = "test"

--- a/client/verta/verta/finetune/__init__.py
+++ b/client/verta/verta/finetune/__init__.py
@@ -2,9 +2,19 @@
 """Utilities for model fine-tuning."""
 
 from verta._internal_utils import documentation
+from verta.tracking.entities._deployable_entity import _RESERVED_ATTR_PREFIX
 
 from ._finetuning_config import _FinetuningConfig
 from ._lora_config import LoraConfig
+
+
+_PROJECT_NAME_SUFFIX = " Fine-Tuning"  # append to registered model name
+_EXPERIMENT_NAME = "Fine-Tuning"
+_TRAIN_DATASET_NAME = "train"
+_EVAL_DATASET_NAME = "eval"
+_TEST_DATASET_NAME = "test"
+_FINETUNE_BASE_RMV_ATTR_KEY = f"{_RESERVED_ATTR_PREFIX}FINETUNE_BASE"
+_FINETUNE_ATTR_KEY = f"{_RESERVED_ATTR_PREFIX}FINETUNE"
 
 
 documentation.reassign_module(

--- a/client/verta/verta/finetune/__init__.py
+++ b/client/verta/verta/finetune/__init__.py
@@ -8,7 +8,7 @@ from ._finetuning_config import _FinetuningConfig
 from ._lora_config import LoraConfig
 
 
-_PROJECT_NAME_SUFFIX = " Fine-Tuning"  # append to registered model name
+_TRACKING_NAME_SUFFIX = " Fine-Tuning"  # append to RM and RMV names for project and run
 _EXPERIMENT_NAME = "Fine-Tuning"
 _TRAIN_DATASET_NAME = "train"
 _EVAL_DATASET_NAME = "eval"

--- a/client/verta/verta/registry/_constants.py
+++ b/client/verta/verta/registry/_constants.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 
 from verta._protos.public.registry import ModelMetadata_pb2
+from verta.tracking.entities._deployable_entity import _RESERVED_ATTR_PREFIX
 
 
-MODEL_LANGUAGE_ATTR_KEY = "__verta_reserved__model_language"
-MODEL_TYPE_ATTR_KEY = "__verta_reserved__model_type"
+MODEL_LANGUAGE_ATTR_KEY = f"{_RESERVED_ATTR_PREFIX}model_language"
+MODEL_TYPE_ATTR_KEY = f"{_RESERVED_ATTR_PREFIX}model_type"
 
 
 class ModelLanguage(object):

--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -1839,7 +1839,7 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
             self._conf,
             ctx,
             name=destination_registered_model.name
-            + verta.finetune._PROJECT_NAME_SUFFIX,
+            + verta.finetune._TRACKING_NAME_SUFFIX,
         )
         ctx.expt = Client._get_or_create_experiment(
             self._conn,
@@ -1851,6 +1851,8 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
             self._conn,
             self._conf,
             ctx,
+            # TODO: make this match the RMV when `name` is None
+            name=name + verta.finetune._TRACKING_NAME_SUFFIX if name else None,
             attrs={verta.finetune._FINETUNE_ATTR_KEY: True},
         )
 

--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -1822,11 +1822,17 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
             Registered model (or simply its name) in which to create the new fine-tuned
             model version.
         train_dataset : :class:`~verta.dataset.entities.DatasetVersion`
-            Dataset to use for training.
+            Dataset version to use for training. The `content` passed to
+            :meth:`Dataset.create_version() <verta.dataset.entities.Dataset.create_version>`
+            must have ``enable_mdb_versioning=True``.
         eval_dataset : :class:`~verta.dataset.entities.DatasetVersion`, optional
-            Dataset to use for evaluation.
+            Dataset version to use for evaluation. The `content` passed to
+            :meth:`Dataset.create_version() <verta.dataset.entities.Dataset.create_version>`
+            must have ``enable_mdb_versioning=True``.
         test_dataset : :class:`~verta.dataset.entities.DatasetVersion`, optional
-            Dataset to use for final testing at the end of fine-tuning.
+            Dataset version to use for final testing at the end of fine-tuning. The
+            `content` passed to :meth:`Dataset.create_version() <verta.dataset.entities.Dataset.create_version>`
+            must have ``enable_mdb_versioning=True``.
         name : str, optional
             Name for the new fine-tuned model version. If no name is provided, one will
             be generated.

--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -1814,7 +1814,7 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
         name: Optional[str] = None,
         finetuning_config: Optional[verta.finetune._FinetuningConfig] = None,
     ) -> "RegisteredModelVersion":
-        """Fine-tune this model version using provided datasets.
+        """Fine-tune this model version using the provided dataset(s).
 
         Parameters
         ----------

--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -1808,7 +1808,6 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
             str,
             "verta.registry.entities.RegisteredModel",
         ],
-        # TODO: how to specify/determine project [name]?
         train_dataset: _dataset_version.DatasetVersion,
         eval_dataset: Optional[_dataset_version.DatasetVersion] = None,
         test_dataset: Optional[_dataset_version.DatasetVersion] = None,

--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -39,7 +39,13 @@ from verta import utils
 from verta import _blob, code, data_types, environment
 from verta.endpoint.build import Build
 import verta.finetune
+<<<<<<< Updated upstream
 from verta.tracking import _Context
+=======
+import verta.registry.entities
+from verta.tracking import _Context
+import verta.tracking.entities
+>>>>>>> Stashed changes
 from verta.tracking.entities._entity import _MODEL_ARTIFACTS_ATTR_KEY
 from verta.tracking.entities import _deployable_entity
 from .. import lock, DockerImage
@@ -1804,7 +1810,10 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
 
     def finetune(
         self,
-        destination_registered_model: "verta.registry.entities.RegisteredModel",
+        destination_registered_model: Union[
+            str,
+            "verta.registry.entities.RegisteredModel",
+        ],
         # TODO: how to specify/determine project [name]?
         train_dataset: _dataset_version.DatasetVersion,
         eval_dataset: Optional[_dataset_version.DatasetVersion] = None,
@@ -1817,8 +1826,16 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
 
         ctx = _Context(self._conn, self._conf)
         ctx.workspace_name = self.workspace
+
         if not self.get_attributes().get(verta.finetune._FINETUNE_BASE_RMV_ATTR_KEY):
             raise ValueError("this model version is not eligible for fine-tuning")
+        if isinstance(destination_registered_model, str):
+            destination_registered_model = Client._get_or_create_registered_model(
+                self._conn,
+                self._conf,
+                ctx,
+                name=destination_registered_model,
+            )
 
         ctx.proj = Client._get_or_create_project(
             self._conn,

--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -1830,7 +1830,7 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
         name : str, optional
             Name for the new fine-tuned model version. If no name is provided, one will
             be generated.
-        finetuning_config : :mod:`verta.finetune <fine-tuning configuration>`, default :class:`~verta.finetune.LoraConfig>`
+        finetuning_config : :mod:`fine-tuning configuration <verta.finetune>`, default :class:`~verta.finetune.LoraConfig`
             Fine-tuning algorithm and configuration.
 
         Returns

--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -1819,7 +1819,10 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
         from verta.dataset.entities import Dataset
         from verta.tracking.entities import ExperimentRun
 
-        # TODO: check `enable_mdb_versioning`
+        if finetuning_config is None:
+            finetuning_config = verta.finetune.LoraConfig()
+
+        # TODO: [VRD-1131] check `enable_mdb_versioning`
 
         ctx = _Context(self._conn, self._conf)
         ctx.workspace_name = self.workspace

--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -1818,7 +1818,7 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
 
         Parameters
         ----------
-        destinantion_registered_model : str or :class:`~verta.registry.entities.RegisteredModel`
+        destination_registered_model : str or :class:`~verta.registry.entities.RegisteredModel`
             Registered model (or simply its name) in which to create the new fine-tuned
             model version.
         train_dataset : :class:`~verta.dataset.entities.DatasetVersion`

--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -39,13 +39,7 @@ from verta import utils
 from verta import _blob, code, data_types, environment
 from verta.endpoint.build import Build
 import verta.finetune
-<<<<<<< Updated upstream
 from verta.tracking import _Context
-=======
-import verta.registry.entities
-from verta.tracking import _Context
-import verta.tracking.entities
->>>>>>> Stashed changes
 from verta.tracking.entities._entity import _MODEL_ARTIFACTS_ATTR_KEY
 from verta.tracking.entities import _deployable_entity
 from .. import lock, DockerImage
@@ -1844,7 +1838,12 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
             name=destination_registered_model.name
             + verta.finetune._PROJECT_NAME_SUFFIX,
         )
-        # TODO: create experiment
+        ctx.expt = Client._get_or_create_experiment(
+            self._conn,
+            self._conf,
+            ctx,
+            name=verta.finetune._EXPERIMENT_NAME,
+        )
         # TODO: create ER
         # TODO: log attributes
         # TODO: log dataset versions

--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -1839,12 +1839,10 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
             New fine-tuned model version.
 
         """
+        # import here to circumvent circular imports
         from verta import Client
         from verta.dataset.entities import Dataset
         from verta.tracking.entities import ExperimentRun
-
-        if finetuning_config is None:
-            finetuning_config = verta.finetune.LoraConfig()
 
         # TODO: [VRD-1131] check `enable_mdb_versioning`
 
@@ -1861,6 +1859,8 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
                 ctx,
                 name=destination_registered_model,
             )
+        if finetuning_config is None:
+            finetuning_config = verta.finetune.LoraConfig()
 
         # create experiment run
         ctx.proj = Client._get_or_create_project(

--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -1814,7 +1814,31 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
         name: Optional[str] = None,
         finetuning_config: Optional[verta.finetune._FinetuningConfig] = None,
     ) -> "RegisteredModelVersion":
-        """"""
+        """Fine-tune this model version using provided datasets.
+
+        Parameters
+        ----------
+        destinantion_registered_model : str or :class:`~verta.registry.entities.RegisteredModel`
+            Registered model (or simply its name) in which to create the new fine-tuned
+            model version.
+        train_dataset : :class:`~verta.dataset.entities.DatasetVersion`
+            Dataset to use for training.
+        eval_dataset : :class:`~verta.dataset.entities.DatasetVersion`, optional
+            Dataset to use for evaluation.
+        test_dataset : :class:`~verta.dataset.entities.DatasetVersion`, optional
+            Dataset to use for final testing at the end of fine-tuning.
+        name : str, optional
+            Name for the new fine-tuned model version. If no name is provided, one will
+            be generated.
+        finetuning_config : :mod:`verta.finetune <fine-tuning configuration>`, default :class:`~verta.finetune.LoraConfig>`
+            Fine-tuning algorithm and configuration.
+
+        Returns
+        -------
+        :class:`~verta.registry.entities.RegisteredModelVersion`
+            New fine-tuned model version.
+
+        """
         from verta import Client
         from verta.dataset.entities import Dataset
         from verta.tracking.entities import ExperimentRun

--- a/client/verta/verta/tracking/entities/_deployable_entity.py
+++ b/client/verta/verta/tracking/entities/_deployable_entity.py
@@ -42,6 +42,7 @@ _CACHE_DIR = os.path.join(
 )
 
 _INTERNAL_ATTR_PREFIX = "__verta_"
+_RESERVED_ATTR_PREFIX = f"{_INTERNAL_ATTR_PREFIX}reserved__"
 
 
 @six.add_metaclass(abc.ABCMeta)


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

Creates the ER for tracking the fine-tuning job, creates the RMV for storing the fine-tuned model, logs datasets and internal attributes, and `POST`s `/finetuning-job`.

## Risks and Area of Effect
- [ ] Is this a breaking change?

There's a very touchy refactor of a handful of `Client` methods, but I covered them in **Testing**.

## Testing
- [ ] Unit test
- [ ] Deployed to dev env
- [x] Other (explain) 

Ran the new `test_finetune` integration test, along with coverage of entity CRUD methods on the client to check for regressions on the refactor

```
% pytest finetune test_entities.py registry/test_model.py
==================================================== test session starts ====================================================
platform darwin -- Python 3.7.10, pytest-7.4.2, pluggy-1.2.0                                                                 
rootdir: /Users/miliu/Documents/modeldb/client/verta/tests                                                                   
configfile: pytest.ini                                                                                                       
plugins: xdist-3.3.1, hypothesis-6.79.4                                                                                      
collected 78 items                                                                                                           
                                                                                                                             
finetune/test_finetune.py .                                                                                           [  1%] 
test_entities.py ...........................ss......s.s                                                               [ 50%]
registry/test_model.py .....F..........s.......s......s......s                                                        [100%]

==================================== 1 failed, 69 passed, 8 skipped in 433.59s (0:07:13) ====================================
```

The one failure on `registry/test_model.py::TestModel::test_find` is unrelated.

## Reverting
- [ ] Contains Migration - _Do Not Revert_

Revert this PR.