### PR TITLE
fix: Be sure to always try to initialize a stream if the lookup is missing the required stream (#4090)

### DIFF
--- a/backend/common/src/main/java/ai/verta/modeldb/common/nats/JetstreamConnector.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/nats/JetstreamConnector.java
@@ -34,7 +34,7 @@ public class JetstreamConnector {
   public JetStream getJetStream(String streamName) {
     log.info("Getting JetStream for stream {}", streamName);
     checkNatsConnection();
-    return jetStreamMap.get(streamName);
+    return jetStreamMap.computeIfAbsent(streamName, this::ensureStreamExists);
   }
 
   public void checkNatsConnection() {
@@ -44,7 +44,6 @@ public class JetstreamConnector {
       natsConnection = getConnection();
       verifyStreams();
     }
-    log.info("Ensuring stream exists");
   }
 
   private Connection getConnection() {

--- a/backend/common/src/test/java/ai/verta/modeldb/common/nats/JetstreamConnectorTest.java
+++ b/backend/common/src/test/java/ai/verta/modeldb/common/nats/JetstreamConnectorTest.java
@@ -123,6 +123,15 @@ class JetstreamConnectorTest {
   }
 
   @Test
+  void nonPreconfiguredStream() {
+    // verify the pre-configured streams
+    connector.verifyStreams();
+    // ask for a new one, non-preconfigured...
+    JetStream stream = connector.getJetStream("fish");
+    assertThat(stream).isNotNull();
+  }
+
+  @Test
   void existingConsumer_changeFromPullToPush() throws Exception {
     JetstreamConfig config =
         new JetstreamConfig(


### PR DESCRIPTION
(cherry picked from commit 62b5f9c06bb52bbf7e984d18fa16d06e046f3251)

<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

## Risks and Area of Effect
- [ ] Is this a breaking change?

## Testing
- [x] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

## Reverting
- [ ] Contains Migration - _Do Not Revert_