### PR TITLE
Feature: Implement experiment run name update functionality

### DIFF
--- a/backend/server/src/main/java/ai/verta/modeldb/experimentRun/FutureExperimentRunDAO.java
+++ b/backend/server/src/main/java/ai/verta/modeldb/experimentRun/FutureExperimentRunDAO.java
@@ -366,8 +366,6 @@ public class FutureExperimentRunDAO {
         .thenSupply(() -> tagsHandler.getTags(runId).toInternalFuture(), executor);
   }
 
-  // TODO: refactor all usages to use updateVersionNumberV2
-  @Deprecated
   private InternalFuture<Void> updateModifiedTimestamp(String runId, Long now) {
     return jdbi.useHandle(
         handle -> {

--- a/backend/server/src/main/java/ai/verta/modeldb/experimentRun/FutureExperimentRunDAO.java
+++ b/backend/server/src/main/java/ai/verta/modeldb/experimentRun/FutureExperimentRunDAO.java
@@ -1,67 +1,15 @@
 package ai.verta.modeldb.experimentRun;
 
-import ai.verta.common.Artifact;
-import ai.verta.common.CodeVersion;
-import ai.verta.common.KeyValue;
-import ai.verta.common.KeyValueQuery;
+import ai.verta.common.*;
 import ai.verta.common.ModelDBResourceEnum.ModelDBServiceResourceTypes;
-import ai.verta.common.OperatorEnum;
-import ai.verta.common.Pagination;
-import ai.verta.common.ValueTypeEnum;
-import ai.verta.modeldb.AddExperimentRunTags;
-import ai.verta.modeldb.CloneExperimentRun;
-import ai.verta.modeldb.CommitArtifactPart;
-import ai.verta.modeldb.CommitMultipartArtifact;
-import ai.verta.modeldb.CreateExperimentRun;
-import ai.verta.modeldb.DeleteArtifact;
-import ai.verta.modeldb.DeleteExperimentRunAttributes;
-import ai.verta.modeldb.DeleteExperimentRunTags;
-import ai.verta.modeldb.DeleteExperimentRuns;
-import ai.verta.modeldb.DeleteHyperparameters;
-import ai.verta.modeldb.DeleteMetrics;
-import ai.verta.modeldb.DeleteObservations;
-import ai.verta.modeldb.ExperimentRun;
+import ai.verta.modeldb.*;
 import ai.verta.modeldb.ExperimentRun.Builder;
-import ai.verta.modeldb.Feature;
-import ai.verta.modeldb.FindExperimentRuns;
-import ai.verta.modeldb.GetArtifacts;
-import ai.verta.modeldb.GetAttributes;
-import ai.verta.modeldb.GetCommittedArtifactParts;
-import ai.verta.modeldb.GetDatasets;
-import ai.verta.modeldb.GetExperimentRunCodeVersion;
-import ai.verta.modeldb.GetExperimentRunsByDatasetVersionId;
-import ai.verta.modeldb.GetExperimentRunsInExperiment;
-import ai.verta.modeldb.GetHyperparameters;
-import ai.verta.modeldb.GetMetrics;
-import ai.verta.modeldb.GetObservations;
-import ai.verta.modeldb.GetTags;
-import ai.verta.modeldb.GetUrlForArtifact;
-import ai.verta.modeldb.GetVersionedInput;
-import ai.verta.modeldb.LogArtifacts;
-import ai.verta.modeldb.LogAttributes;
-import ai.verta.modeldb.LogDatasets;
-import ai.verta.modeldb.LogEnvironment;
-import ai.verta.modeldb.LogExperimentRunCodeVersion;
-import ai.verta.modeldb.LogHyperparameters;
-import ai.verta.modeldb.LogMetrics;
-import ai.verta.modeldb.LogObservations;
-import ai.verta.modeldb.LogVersionedInput;
-import ai.verta.modeldb.ModelDBConstants;
-import ai.verta.modeldb.ModelDBMessages;
-import ai.verta.modeldb.Observation;
-import ai.verta.modeldb.UpdateExperimentRunDescription;
-import ai.verta.modeldb.VersioningEntry;
 import ai.verta.modeldb.common.CommonUtils;
 import ai.verta.modeldb.common.artifactStore.ArtifactStoreDAO;
 import ai.verta.modeldb.common.authservice.RoleServiceUtils;
 import ai.verta.modeldb.common.authservice.UACApisUtil;
 import ai.verta.modeldb.common.connections.UAC;
-import ai.verta.modeldb.common.exceptions.AlreadyExistsException;
-import ai.verta.modeldb.common.exceptions.InternalErrorException;
-import ai.verta.modeldb.common.exceptions.InvalidArgumentException;
-import ai.verta.modeldb.common.exceptions.ModelDBException;
-import ai.verta.modeldb.common.exceptions.NotFoundException;
-import ai.verta.modeldb.common.exceptions.PermissionDeniedException;
+import ai.verta.modeldb.common.exceptions.*;
 import ai.verta.modeldb.common.futures.FutureExecutor;
 import ai.verta.modeldb.common.futures.FutureJdbi;
 import ai.verta.modeldb.common.futures.FutureUtil;
@@ -71,50 +19,16 @@ import ai.verta.modeldb.common.query.QueryFilterContext;
 import ai.verta.modeldb.common.subtypes.MapSubtypes;
 import ai.verta.modeldb.config.MDBConfig;
 import ai.verta.modeldb.entities.ExperimentRunEntity;
-import ai.verta.modeldb.experimentRun.subtypes.ArtifactHandler;
-import ai.verta.modeldb.experimentRun.subtypes.AttributeHandler;
-import ai.verta.modeldb.experimentRun.subtypes.CodeVersionFromBlobHandler;
-import ai.verta.modeldb.experimentRun.subtypes.CodeVersionHandler;
-import ai.verta.modeldb.experimentRun.subtypes.CreateExperimentRunHandler;
-import ai.verta.modeldb.experimentRun.subtypes.DatasetHandler;
-import ai.verta.modeldb.experimentRun.subtypes.EnvironmentHandler;
-import ai.verta.modeldb.experimentRun.subtypes.FeatureHandler;
-import ai.verta.modeldb.experimentRun.subtypes.FilterPrivilegedDatasetsHandler;
-import ai.verta.modeldb.experimentRun.subtypes.FilterPrivilegedVersionedInputsHandler;
-import ai.verta.modeldb.experimentRun.subtypes.HyperparametersFromConfigHandler;
-import ai.verta.modeldb.experimentRun.subtypes.KeyValueBaseHandler;
-import ai.verta.modeldb.experimentRun.subtypes.ObservationHandler;
-import ai.verta.modeldb.experimentRun.subtypes.PredicatesHandler;
-import ai.verta.modeldb.experimentRun.subtypes.SortingHandler;
-import ai.verta.modeldb.experimentRun.subtypes.TagsHandler;
-import ai.verta.modeldb.experimentRun.subtypes.VersionInputHandler;
+import ai.verta.modeldb.experimentRun.subtypes.*;
 import ai.verta.modeldb.utils.RdbmsUtils;
 import ai.verta.modeldb.versioning.BlobDAO;
 import ai.verta.modeldb.versioning.CommitDAO;
 import ai.verta.modeldb.versioning.EnvironmentBlob;
 import ai.verta.modeldb.versioning.RepositoryDAO;
-import ai.verta.uac.Action;
+import ai.verta.uac.*;
 import ai.verta.uac.Empty;
-import ai.verta.uac.IsSelfAllowed;
-import ai.verta.uac.ModelDBActionEnum;
-import ai.verta.uac.ResourceType;
-import ai.verta.uac.Resources;
-import ai.verta.uac.ServiceEnum;
 import com.google.protobuf.Value;
-import com.google.rpc.Code;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -1519,8 +1433,7 @@ public class FutureExperimentRunDAO {
             () -> {
               // Validate request parameter
               if (request.getDatasetVersionId().isEmpty()) {
-                throw new ModelDBException(
-                    "DatasetVersion Id should not be empty", Code.INVALID_ARGUMENT);
+                throw new InvalidArgumentException("DatasetVersion Id should not be empty");
               }
             },
             executor);
@@ -1875,5 +1788,29 @@ public class FutureExperimentRunDAO {
     query.setParameter("repoIds", repoIds);
     query.executeUpdate();
     LOGGER.debug("ExperimentRun versioning deleted successfully");
+  }
+
+  public InternalFuture<Empty> updateExperimentRunName(UpdateExperimentRunName request) {
+    final var runId = request.getId();
+    final var name = request.getName();
+    final var now = Calendar.getInstance().getTimeInMillis();
+
+    return checkPermission(
+            Collections.singletonList(runId), ModelDBActionEnum.ModelDBServiceActions.UPDATE)
+        .thenCompose(
+            unused ->
+                jdbi.withHandle(
+                    handle -> {
+                      String updateQueryString =
+                          "UPDATE experiment_run SET name=:name, date_updated=:date_updated WHERE id=:runId";
+                      handle
+                          .createUpdate(updateQueryString)
+                          .bind("name", name)
+                          .bind("date_updated", now)
+                          .bind("runId", runId)
+                          .execute();
+                      return Empty.newBuilder().build();
+                    }),
+            executor);
   }
 }

--- a/backend/server/src/main/java/ai/verta/modeldb/experimentRun/FutureExperimentRunServiceImpl.java
+++ b/backend/server/src/main/java/ai/verta/modeldb/experimentRun/FutureExperimentRunServiceImpl.java
@@ -218,8 +218,15 @@ public class FutureExperimentRunServiceImpl extends ExperimentRunServiceImplBase
   public void updateExperimentRunName(
       UpdateExperimentRunName request,
       StreamObserver<UpdateExperimentRunName.Response> responseObserver) {
-    responseObserver.onError(
-        Status.UNIMPLEMENTED.withDescription(ModelDBMessages.UNIMPLEMENTED).asRuntimeException());
+    try {
+      final var response =
+          futureExperimentRunDAO
+              .updateExperimentRunName(request)
+              .thenApply(unused -> UpdateExperimentRunName.Response.newBuilder().build(), executor);
+      FutureGrpc.ServerResponse(responseObserver, response, executor);
+    } catch (Exception e) {
+      CommonUtils.observeError(responseObserver, e);
+    }
   }
 
   @Override

--- a/backend/server/src/main/java/ai/verta/modeldb/experimentRun/FutureExperimentRunServiceImpl.java
+++ b/backend/server/src/main/java/ai/verta/modeldb/experimentRun/FutureExperimentRunServiceImpl.java
@@ -1,5 +1,7 @@
 package ai.verta.modeldb.experimentRun;
 
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
 import ai.verta.common.CodeVersion;
 import ai.verta.common.KeyValueQuery;
 import ai.verta.common.OperatorEnum;
@@ -220,6 +222,12 @@ public class FutureExperimentRunServiceImpl extends ExperimentRunServiceImplBase
       UpdateExperimentRunName request,
       StreamObserver<UpdateExperimentRunName.Response> responseObserver) {
     try {
+
+      if (isBlank(request.getName())) {
+        var errorMessage = "Name is not present";
+        throw new InvalidArgumentException(errorMessage);
+      }
+
       final var response =
           futureExperimentRunDAO
               .updateExperimentRunName(request)

--- a/backend/server/src/main/java/ai/verta/modeldb/experimentRun/FutureExperimentRunServiceImpl.java
+++ b/backend/server/src/main/java/ai/verta/modeldb/experimentRun/FutureExperimentRunServiceImpl.java
@@ -10,6 +10,7 @@ import ai.verta.modeldb.common.CommonUtils;
 import ai.verta.modeldb.common.exceptions.InternalErrorException;
 import ai.verta.modeldb.common.exceptions.InvalidArgumentException;
 import ai.verta.modeldb.common.exceptions.NotFoundException;
+import ai.verta.modeldb.common.futures.Future;
 import ai.verta.modeldb.common.futures.FutureExecutor;
 import ai.verta.modeldb.common.futures.FutureGrpc;
 import ai.verta.modeldb.common.futures.InternalFuture;
@@ -222,8 +223,9 @@ public class FutureExperimentRunServiceImpl extends ExperimentRunServiceImplBase
       final var response =
           futureExperimentRunDAO
               .updateExperimentRunName(request)
-              .thenApply(unused -> UpdateExperimentRunName.Response.newBuilder().build(), executor);
-      FutureGrpc.ServerResponse(responseObserver, response, executor);
+              .thenSupply(() -> Future.of(UpdateExperimentRunName.Response.getDefaultInstance()));
+
+      FutureGrpc.serverResponse(responseObserver, response);
     } catch (Exception e) {
       CommonUtils.observeError(responseObserver, e);
     }

--- a/backend/server/src/test/java/ai/verta/modeldb/ExperimentRunTest.java
+++ b/backend/server/src/test/java/ai/verta/modeldb/ExperimentRunTest.java
@@ -7085,6 +7085,12 @@ public class ExperimentRunTest extends ModeldbTestSetup {
   void shouldUpdateExperimentRunNameSuccessfully() {
     var newName = "Run 007";
 
+    var previousExperimentRun =
+        experimentRunServiceStub
+            .getExperimentRunById(
+                GetExperimentRunById.newBuilder().setId(experimentRun.getId()).build())
+            .getExperimentRun();
+
     assertDoesNotThrow(
         () ->
             experimentRunServiceStub.updateExperimentRunName(
@@ -7101,6 +7107,8 @@ public class ExperimentRunTest extends ModeldbTestSetup {
 
     assertThat(foundExperimentRun).isNotNull();
     assertThat(foundExperimentRun.getName()).isEqualTo(newName);
+    assertThat(foundExperimentRun.getVersionNumber())
+        .isEqualTo(previousExperimentRun.getVersionNumber() + 1);
   }
 
   @Test

--- a/backend/server/src/test/java/ai/verta/modeldb/ExperimentRunTest.java
+++ b/backend/server/src/test/java/ai/verta/modeldb/ExperimentRunTest.java
@@ -7080,4 +7080,38 @@ public class ExperimentRunTest extends ModeldbTestSetup {
 
     LOGGER.info("logEnvironment test stop................................");
   }
+
+  @Test
+  void shouldUpdateExperimentRunNameSuccessfully() {
+    var newName = "Run 007";
+
+    assertDoesNotThrow(
+        () ->
+            experimentRunServiceStub.updateExperimentRunName(
+                UpdateExperimentRunName.newBuilder()
+                    .setId(experimentRun.getId())
+                    .setName(newName)
+                    .build()));
+
+    var foundExperimentRun =
+        experimentRunServiceStub
+            .getExperimentRunById(
+                GetExperimentRunById.newBuilder().setId(experimentRun.getId()).build())
+            .getExperimentRun();
+
+    assertThat(foundExperimentRun).isNotNull();
+    assertThat(foundExperimentRun.getName()).isEqualTo(newName);
+  }
+
+  @Test
+  void shouldThrowExceptionWhenUpdateExperimentRunWithoutNameArgument() {
+    var exception =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                experimentRunServiceStub.updateExperimentRunName(
+                    UpdateExperimentRunName.newBuilder().setId(experimentRun.getId()).build()));
+
+    assertThat(exception.getStatus().getDescription()).isEqualTo("Name is not present");
+  }
 }


### PR DESCRIPTION
Added functionality to update the name of an experiment run by modifying the methods in FutureExperimentRunServiceImpl and FutureExperimentRunDAO classes. The changes permit the updating of the experiment run name in the database. This functionality was implemented in response to the need for modification of experiment run details after their creation. Also, optimized the import statements in FutureExperimentRunDAO class for better readability and maintenance.

<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

## Risks and Area of Effect
- [ ] Is this a breaking change?

## Testing
- [x] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

## Reverting
- [ ] Contains Migration - _Do Not Revert_