### PR TITLE
feat: [VRD-1131] Validate fine-tuning datasets are MDB-versioned

### DIFF
--- a/client/verta/tests/finetune/test_finetune.py
+++ b/client/verta/tests/finetune/test_finetune.py
@@ -2,45 +2,140 @@
 
 """Test RegisteredModelVersion.finetune() and its downstream effects."""
 
+import itertools
+
+import pytest
+
 from verta.dataset import Path
 from verta import finetune
 
 
-def test_finetune(client, registered_model, dataset):
-    """Verify that happy-path ``finetune()`` works."""
-    base_model_ver = registered_model.create_version()  # mocked base LLM RMV
-    name = "v1"
-
-    reg_model = client.create_registered_model()
-    train_dataset_version = dataset.create_version(
-        Path(__file__, enable_mdb_versioning=True),
-    )
-    model_ver = base_model_ver.finetune(
-        destination_registered_model=reg_model,
-        train_dataset=train_dataset_version,
-        name=name,
-    )
-    run = client.get_experiment_run(id=model_ver.experiment_run_id)
-
-    # check entity names
-    assert client.proj.name == reg_model.name + finetune._PROJECT_NAME_SUFFIX
-    assert client.expt.name == finetune._EXPERIMENT_NAME_PREFIX + dataset.name
-    # TODO: wait for fine-tuning to launch, then check ER name
-    assert model_ver.name == name
-
-    # check dataset association
-    for entity in [model_ver, run]:
-        for key, value in [
-            (finetune._TRAIN_DATASET_NAME, train_dataset_version),
-            # TODO: eval and test, too
-        ]:
-            assert entity.get_dataset_version(key).id == value.id
-
-    # check attributes
-    for entity in [model_ver, run]:
-        assert (
-            entity.get_attributes().items()
-            >= {
-                finetune._FINETUNE_ATTR_KEY: True,
-            }.items()
+class TestHappyPaths:
+    def test_entity_names(self, client, make_registered_model, dataset):
+        """Verify created entities' names are as expected."""
+        base_model_ver = make_registered_model().create_version()  # mocked base LLM RMV
+        name = "v1"
+        reg_model = make_registered_model()
+        train_dataset = dataset.create_version(
+            Path(__file__, enable_mdb_versioning=True),
         )
+
+        model_ver = base_model_ver.finetune(
+            destination_registered_model=reg_model,
+            train_dataset=train_dataset,
+            name=name,
+        )
+        run = client.get_experiment_run(id=model_ver.experiment_run_id)
+
+        # check entity names
+        assert client.proj.name == reg_model.name + finetune._PROJECT_NAME_SUFFIX
+        assert client.expt.name == finetune._EXPERIMENT_NAME_PREFIX + dataset.name
+        # TODO: wait for fine-tuning to launch, then check ER name
+        assert model_ver.name == name
+
+    def test_datasets(self, client, make_registered_model, dataset):
+        """Verify created entities' logged dataset versions are as expected."""
+        base_model_ver = make_registered_model().create_version()  # mocked base LLM RMV
+        destination_registered_model = make_registered_model()
+        train_dataset = dataset.create_version(
+            Path(__file__, enable_mdb_versioning=True),
+        )
+        eval_dataset = dataset.create_version(
+            Path(__file__, enable_mdb_versioning=True),
+        )
+        test_dataset = dataset.create_version(
+            Path(__file__, enable_mdb_versioning=True),
+        )
+
+        # get every relevant arrangement of dataset arguments
+        possible_datasets = itertools.product(
+            [train_dataset],
+            [eval_dataset, None],
+            [test_dataset, None],
+        )
+
+        for train_dataset, eval_dataset, test_dataset in possible_datasets:
+            model_ver = base_model_ver.finetune(
+                destination_registered_model=destination_registered_model,
+                train_dataset=train_dataset,
+                eval_dataset=eval_dataset,
+                test_dataset=test_dataset,
+            )
+            run = client.get_experiment_run(id=model_ver.experiment_run_id)
+
+            # check dataset association
+            for entity in [model_ver, run]:
+                for dataset_name, dataset_version in [
+                    (finetune._TRAIN_DATASET_NAME, train_dataset),
+                    (finetune._EVAL_DATASET_NAME, eval_dataset),
+                    (finetune._TEST_DATASET_NAME, test_dataset),
+                ]:
+                    if dataset_version is not None:
+                        assert (
+                            entity.get_dataset_version(dataset_name).id
+                            == dataset_version.id
+                        )
+
+    def test_attributes(self, client, make_registered_model, dataset):
+        """Verify created entities' attributes are as expected."""
+        base_model_ver = make_registered_model().create_version()  # mocked base LLM RMV
+        reg_model = make_registered_model()
+        train_dataset = dataset.create_version(
+            Path(__file__, enable_mdb_versioning=True),
+        )
+
+        model_ver = base_model_ver.finetune(
+            destination_registered_model=reg_model,
+            train_dataset=train_dataset,
+        )
+        run = client.get_experiment_run(id=model_ver.experiment_run_id)
+
+        # check attributes
+        for entity in [model_ver, run]:
+            assert (
+                entity.get_attributes().items()
+                >= {
+                    finetune._FINETUNE_ATTR_KEY: True,
+                }.items()
+            )
+
+
+class TestErrors:
+    def test_dataset_not_mdb_versioned_error(self, make_registered_model, dataset):
+        """Verify that non-ModelDB-versioned datasets cause exceptions."""
+        base_model_ver = make_registered_model().create_version()  # mocked base LLM RMV
+        destination_registered_model = make_registered_model()
+        unversioned_dataset = dataset.create_version(
+            Path(__file__),
+        )
+        versioned_dataset = dataset.create_version(
+            Path(__file__, enable_mdb_versioning=True),
+        )
+
+        # get every relevant arrangement of dataset arguments
+        possible_datasets = itertools.product(
+            [unversioned_dataset, versioned_dataset, None],
+            repeat=3,
+        )
+        possible_datasets = filter(  # `train_dataset` cannot be None
+            lambda datasets: datasets[0] is not None,
+            possible_datasets,
+        )
+        possible_datasets = filter(  # this test needs at least one unversioned
+            lambda datasets: any(
+                dataset is unversioned_dataset for dataset in datasets
+            ),
+            possible_datasets,
+        )
+
+        for train_dataset, eval_dataset, test_dataset in possible_datasets:
+            with pytest.raises(
+                ValueError,
+                match=" must have ``enable_mdb_versioning=True`` on creation",
+            ):
+                base_model_ver.finetune(
+                    destination_registered_model=destination_registered_model,
+                    train_dataset=train_dataset,
+                    eval_dataset=eval_dataset,
+                    test_dataset=test_dataset,
+                )

--- a/client/verta/tests/finetune/test_finetune.py
+++ b/client/verta/tests/finetune/test_finetune.py
@@ -102,7 +102,7 @@ class TestHappyPaths:
 
 class TestErrors:
     def test_dataset_not_mdb_versioned_error(self, make_registered_model, dataset):
-        """Verify that non-ModelDB-versioned datasets cause exceptions."""
+        """Verify that using non-ModelDB-versioned datasets raises an exception."""
         base_model_ver = make_registered_model().create_version()  # mocked base LLM RMV
         destination_registered_model = make_registered_model()
         unversioned_dataset = dataset.create_version(

--- a/client/verta/verta/dataset/_dataset.py
+++ b/client/verta/verta/dataset/_dataset.py
@@ -385,7 +385,7 @@ class _Dataset(_blob.Blob):
 
 class Component(object):
     """
-    A dataset component returned by ``dataset.list_components()``.
+    A dataset component returned by ``dataset_version.get_content().list_components()``.
 
     Attributes
     ----------

--- a/client/verta/verta/dataset/_dataset.py
+++ b/client/verta/verta/dataset/_dataset.py
@@ -113,15 +113,12 @@ class _Dataset(_blob.Blob):
         self._dataset_version = dataset_version
 
     @property
-    def _is_downloadable(self):
+    def _is_downloadable(self) -> bool:
         """
         Whether this has a linked dataset version to download from.
 
         """
-        if self._dataset_version:
-            return True
-        else:
-            return False
+        return bool(self._dataset_version and self._mdb_versioned)
 
     @property
     def _conn(self):

--- a/client/verta/verta/dataset/_path.py
+++ b/client/verta/verta/dataset/_path.py
@@ -103,6 +103,9 @@ class Path(_dataset._Dataset):
                 for component_msg in blob_msg.dataset.path.components
             ]
         )
+        obj._mdb_versioned = any(
+            component._internal_versioned_path for component in obj.list_components()
+        )
 
         return obj
 

--- a/client/verta/verta/dataset/_s3.py
+++ b/client/verta/verta/dataset/_s3.py
@@ -96,6 +96,9 @@ class S3(_dataset._Dataset):
                 for component_msg in blob_msg.dataset.s3.components
             ]
         )
+        obj._mdb_versioned = any(
+            component._internal_versioned_path for component in obj.list_components()
+        )
 
         return obj
 


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

The datasets must be ModelDB-versioned—that's the mechanism that uploads the data to our system so that the fine-tuning job can actually use them.

## Risks and Area of Effect
- [ ] Is this a breaking change?

This fixes a check in `dataset_version.get_content().download()` to actually verify that the data is actually ModelDB-versioned. I updated the integration test for this, and it still passes (see **Testing**).

This also makes a change to the `registered_model` and `class_registered_model` fixtures. I ran a couple of random tests to make sure they still work (trust me).

## Testing
- [ ] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain)

The new fine-tuning integration tests pass, as do the amended dataset versioning tests

```sh
% pytest finetune test_dataset_versioning/test_dataset_version.py::TestManagedVersioning
==================================================== test session starts ====================================================
platform darwin -- Python 3.7.10, pytest-7.4.2, pluggy-1.2.0
rootdir: /Users/miliu/Documents/modeldb/client/verta/tests
configfile: pytest.ini
plugins: xdist-3.3.1, hypothesis-6.79.4
collected 6 items                                                                                                           

finetune/test_finetune.py ....                                                                                        [ 66%]
test_dataset_versioning/test_dataset_version.py ..                                                                    [100%]

========================================= 6 passed, 1 warning in 174.74s (0:02:54) ==========================================
```

## Reverting
- [ ] Contains Migration - _Do Not Revert_

Revert this PR.