### PR TITLE
feat: [VRD-1135] Add `model_ver.get_experiment_run()`

### DIFF
--- a/client/verta/tests/registry/model_version/test_from_run.py
+++ b/client/verta/tests/registry/model_version/test_from_run.py
@@ -38,7 +38,7 @@ class TestFromRun:
             assert np.array_equal(model_version.get_artifact("some-artifact"), artifact)
 
     def test_experiment_run_id_property(self, experiment_run, registered_model):
-        """Verify ``ModelVersion.experiment_run_id`` value."""
+        """Verify ``ModelVersion.experiment_run_id`` has the expected value."""
         model_version = registered_model.create_version()
         assert model_version.experiment_run_id is None
 
@@ -46,6 +46,16 @@ class TestFromRun:
             experiment_run,
         )
         assert model_version_from_run.experiment_run_id == experiment_run.id
+
+    def test_get_experiment_run(self, experiment_run, registered_model):
+        """Verify ``ModelVersion.get_experiment_run`` returns the expected run."""
+        model_version = registered_model.create_version()
+        assert model_version.get_experiment_run() is None
+
+        model_version_from_run = registered_model.create_version_from_run(
+            experiment_run,
+        )
+        assert model_version_from_run.get_experiment_run().id == experiment_run.id
 
     def test_from_run_diff_workspaces(
         self, client, experiment_run, workspace, created_entities

--- a/client/verta/tests/unit_tests/registry/test_registered_model_version.py
+++ b/client/verta/tests/unit_tests/registry/test_registered_model_version.py
@@ -6,7 +6,7 @@ from string import ascii_letters
 from typing import List, Optional
 from unittest.mock import patch
 
-import hypothesis
+from hypothesis import given, settings, HealthCheck
 import hypothesis.strategies as st
 
 from verta._internal_utils._utils import timestamp_to_str
@@ -90,7 +90,7 @@ def model_ver_proto(
 
 
 @patch.object(RegisteredModelVersion, "_refresh_cache", return_value=None)
-@hypothesis.given(
+@given(
     model_ver_proto=model_ver_proto(),
     workspace=st.text(ascii_letters, min_size=1),
 )
@@ -145,7 +145,11 @@ def test_repr(mock_conn, mock_config, model_ver_proto, workspace):
 
 
 @patch.object(RegisteredModelVersion, "_refresh_cache", return_value=None)
-@hypothesis.given(
+@settings(
+    # this test generates *two* model versions!
+    suppress_health_check=[HealthCheck.data_too_large, HealthCheck.too_slow],
+)
+@given(
     model_ver_proto=model_ver_proto(with_experiment_run_id=False),
     model_ver_from_run_proto=model_ver_proto(with_experiment_run_id=True),
 )

--- a/client/verta/tests/unit_tests/registry/test_registered_model_version.py
+++ b/client/verta/tests/unit_tests/registry/test_registered_model_version.py
@@ -8,6 +8,8 @@ from unittest.mock import patch
 
 from hypothesis import given, settings, HealthCheck
 import hypothesis.strategies as st
+import responses
+from responses.matchers import query_param_matcher
 
 from verta._internal_utils._utils import timestamp_to_str
 from verta._protos.public.registry import RegistryService_pb2
@@ -89,7 +91,6 @@ def model_ver_proto(
     return msg
 
 
-@patch.object(RegisteredModelVersion, "_refresh_cache", return_value=None)
 @given(
     model_ver_proto=model_ver_proto(),
     workspace=st.text(ascii_letters, min_size=1),
@@ -101,50 +102,50 @@ def test_repr(mock_conn, mock_config, model_ver_proto, workspace):
     This test does not yet cover all available fields, but exists in its current form to cover newly-added model catalog fields.
 
     """
-    model_ver = RegisteredModelVersion(
-        conn=mock_conn,
-        conf=mock_config,
-        msg=model_ver_proto,
-    )
-    with patch.object(RegisteredModelVersion, "workspace", new=workspace):
-        repr_lines: List[str] = repr(model_ver).split("\n")
-    msg: RegistryService_pb2.ModelVersion = model_ver._msg
-
-    assert f"version: {msg.version}" in repr_lines
-    assert (
-        "url: {}://{}/{}/registry/{}/versions/{}".format(
-            mock_conn.scheme,
-            mock_conn.socket,
-            workspace,
-            msg.registered_model_id,
-            msg.id,
+    with patch.object(RegisteredModelVersion, "_refresh_cache", return_value=None):
+        model_ver = RegisteredModelVersion(
+            conn=mock_conn,
+            conf=mock_config,
+            msg=model_ver_proto,
         )
-        in repr_lines
-    )
-    assert f"time created: {timestamp_to_str(msg.time_created)}" in repr_lines
-    assert f"time updated: {timestamp_to_str(msg.time_updated)}" in repr_lines
-    assert f"labels: {msg.labels}" in repr_lines
+        with patch.object(RegisteredModelVersion, "workspace", new=workspace):
+            repr_lines: List[str] = repr(model_ver).split("\n")
+        msg: RegistryService_pb2.ModelVersion = model_ver._msg
 
-    assert f"input description: {msg.input_description}" in repr_lines
-    assert f"output description: {msg.output_description}" in repr_lines
-    assert f"hide input label: {msg.hide_input_label}" in repr_lines
-    assert f"hide output label: {msg.hide_output_label}" in repr_lines
+        assert f"version: {msg.version}" in repr_lines
+        assert (
+            "url: {}://{}/{}/registry/{}/versions/{}".format(
+                mock_conn.scheme,
+                mock_conn.socket,
+                workspace,
+                msg.registered_model_id,
+                msg.id,
+            )
+            in repr_lines
+        )
+        assert f"time created: {timestamp_to_str(msg.time_created)}" in repr_lines
+        assert f"time updated: {timestamp_to_str(msg.time_updated)}" in repr_lines
+        assert f"labels: {msg.labels}" in repr_lines
 
-    assert f"id: {msg.id}" in repr_lines
-    assert f"registered model id: {msg.registered_model_id}" in repr_lines
+        assert f"input description: {msg.input_description}" in repr_lines
+        assert f"output description: {msg.output_description}" in repr_lines
+        assert f"hide input label: {msg.hide_input_label}" in repr_lines
+        assert f"hide output label: {msg.hide_output_label}" in repr_lines
 
-    expected_artifact_keys: List[str] = [artifact.key for artifact in msg.artifacts]
-    if msg.model.key:
-        expected_artifact_keys.append(model_ver._MODEL_KEY)
-    assert f"artifact keys: {sorted(expected_artifact_keys)}" in repr_lines
-    assert (
-        f"dataset version keys: {sorted(dataset.key for dataset in msg.datasets)}"
-        in repr_lines
-    )
-    assert f"code version keys: {sorted(msg.code_blob_map.keys())}" in repr_lines
+        assert f"id: {msg.id}" in repr_lines
+        assert f"registered model id: {msg.registered_model_id}" in repr_lines
+
+        expected_artifact_keys: List[str] = [artifact.key for artifact in msg.artifacts]
+        if msg.model.key:
+            expected_artifact_keys.append(model_ver._MODEL_KEY)
+        assert f"artifact keys: {sorted(expected_artifact_keys)}" in repr_lines
+        assert (
+            f"dataset version keys: {sorted(dataset.key for dataset in msg.datasets)}"
+            in repr_lines
+        )
+        assert f"code version keys: {sorted(msg.code_blob_map.keys())}" in repr_lines
 
 
-@patch.object(RegisteredModelVersion, "_refresh_cache", return_value=None)
 @settings(
     # this test generates *two* model versions!
     suppress_health_check=[HealthCheck.data_too_large, HealthCheck.too_slow],
@@ -159,20 +160,71 @@ def test_experiment_run_id_property(
     model_ver_proto,
     model_ver_from_run_proto,
 ):
-    """Verify ``ModelVersion.experiment_run_id`` value."""
-    model_ver = RegisteredModelVersion(
-        conn=mock_conn,
-        conf=mock_config,
-        msg=model_ver_proto,
-    )
-    assert model_ver.experiment_run_id is None
+    """Verify ``ModelVersion.experiment_run_id`` has the expected value."""
+    with patch.object(RegisteredModelVersion, "_refresh_cache", return_value=None):
+        model_ver = RegisteredModelVersion(
+            conn=mock_conn,
+            conf=mock_config,
+            msg=model_ver_proto,
+        )
+        assert model_ver.experiment_run_id is None
 
-    model_ver_from_run = RegisteredModelVersion(
-        conn=mock_conn,
-        conf=mock_config,
-        msg=model_ver_from_run_proto,
-    )
-    assert (
-        model_ver_from_run.experiment_run_id
-        == model_ver_from_run_proto.experiment_run_id
-    )
+        model_ver_from_run = RegisteredModelVersion(
+            conn=mock_conn,
+            conf=mock_config,
+            msg=model_ver_from_run_proto,
+        )
+        assert (
+            model_ver_from_run.experiment_run_id
+            == model_ver_from_run_proto.experiment_run_id
+        )
+
+
+@settings(
+    # this test generates *two* model versions!
+    suppress_health_check=[HealthCheck.data_too_large, HealthCheck.too_slow],
+)
+@given(
+    model_ver_proto=model_ver_proto(with_experiment_run_id=False),
+    model_ver_from_run_proto=model_ver_proto(with_experiment_run_id=True),
+)
+def test_get_experiment_run(
+    mock_conn,
+    mock_config,
+    model_ver_proto,
+    model_ver_from_run_proto,
+):
+    """Verify ``ModelVersion.get_experiment_run`` makes the expected backend call."""
+    with patch.object(RegisteredModelVersion, "_refresh_cache", return_value=None):
+        model_ver = RegisteredModelVersion(
+            conn=mock_conn,
+            conf=mock_config,
+            msg=model_ver_proto,
+        )
+        assert model_ver.get_experiment_run() is None
+
+        model_ver_from_run = RegisteredModelVersion(
+            conn=mock_conn,
+            conf=mock_config,
+            msg=model_ver_from_run_proto,
+        )
+        with responses.RequestsMock() as rsps:
+            rsps.get(
+                f"{mock_conn.scheme}://{mock_conn.socket}/api/v1/modeldb/experiment-run/getExperimentRunById",
+                match=[
+                    query_param_matcher(
+                        {"id": model_ver_from_run_proto.experiment_run_id},
+                    ),
+                ],
+                status=200,
+                json={
+                    "experiment_run": {
+                        "id": model_ver_from_run_proto.experiment_run_id,
+                    },
+                },
+            )
+
+            assert (
+                model_ver_from_run.get_experiment_run().id
+                == model_ver_from_run_proto.experiment_run_id
+            )

--- a/client/verta/verta/registry/entities/_modelversion.py
+++ b/client/verta/verta/registry/entities/_modelversion.py
@@ -205,6 +205,22 @@ class RegisteredModelVersion(_deployable_entity._DeployableEntity):
         self._refresh_cache()
         return self._msg.experiment_run_id or None
 
+    def get_experiment_run(self) -> Optional["verta.tracking.entities.ExperimentRun"]:
+        """Get this model's source experiment run, if it was created via :meth:`RegisteredModel.create_version_from_run() <verta.registry.entities.RegisteredModel.create_version_from_run>`.
+
+        Returns
+        -------
+        :class:`~verta.tracking.entities.ExperimentRun` or None
+
+        """
+        # import here to circumvent circular imports
+        from verta.tracking.entities import ExperimentRun
+
+        if self.experiment_run_id is None:
+            return None
+
+        return ExperimentRun._get_by_id(self._conn, self._conf, self.experiment_run_id)
+
     def get_artifact_keys(self):
         """
         Gets the artifact keys of this model version.


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

Instead of having to jump through the `model_ver.experiment_run_id` hoop, a user can now just get the ER directly.

## Risks and Area of Effect
- [ ] Is this a breaking change?

New method. There's a slight refactor of existing unit tests, but I made sure they still pass (see **Testing**).

## Testing
- [ ] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

```
% pytest registry/model_version/test_from_run.py::TestFromRun::test_get_experiment_run unit_tests/registry/test_registered_model_version.py            
==================================================== test session starts ====================================================
platform darwin -- Python 3.7.10, pytest-7.4.2, pluggy-1.2.0                                                                 
rootdir: /Users/miliu/Documents/modeldb/client/verta/tests                                                                   
configfile: pytest.ini                                                                                                       
plugins: xdist-3.3.1, hypothesis-6.79.4                                                                                      
collected 4 items                                                                                                            
                                                                                                                             
registry/model_version/test_from_run.py .                                                                             [ 25%] 
unit_tests/registry/test_registered_model_version.py ...                                                              [100%] 
                                                                                                                             
=============================================== 4 passed in 197.81s (0:03:17) ===============================================
```

## Reverting
- [ ] Contains Migration - _Do Not Revert_

Revert this PR.