### PR TITLE
test: Limit size of model_ver_proto strategy

### DIFF
--- a/client/verta/tests/unit_tests/registry/test_registered_model_version.py
+++ b/client/verta/tests/unit_tests/registry/test_registered_model_version.py
@@ -67,20 +67,34 @@ def model_ver_proto(
         hide_output_label=draw(st.booleans()),
         # artifacts
         datasets=draw(
-            st.lists(artifact_proto(), unique_by=lambda artifact: artifact.key),
+            st.lists(
+                artifact_proto(),
+                max_size=3,
+                unique_by=lambda artifact: artifact.key,
+            ),
         ),
-        code_blob_map=draw(st.dictionaries(st.text(ascii_letters), code_blob_proto())),
+        code_blob_map=draw(
+            st.dictionaries(st.text(ascii_letters), code_blob_proto(), max_size=3)
+        ),
     )
     if allow_attributes:
         msg.attributes.extend(
             draw(
-                st.lists(attribute_proto(), unique_by=lambda attribute: attribute.key),
+                st.lists(
+                    attribute_proto(),
+                    max_size=3,
+                    unique_by=lambda attribute: attribute.key,
+                ),
             )
         )
     if allow_artifacts:
         msg.artifacts.extend(
             draw(
-                st.lists(artifact_proto(), unique_by=lambda artifact: artifact.key),
+                st.lists(
+                    artifact_proto(),
+                    max_size=3,
+                    unique_by=lambda artifact: artifact.key,
+                ),
             ),
         )
     if with_model or (with_model is None and draw(st.booleans())):
@@ -146,10 +160,6 @@ def test_repr(mock_conn, mock_config, model_ver_proto, workspace):
         assert f"code version keys: {sorted(msg.code_blob_map.keys())}" in repr_lines
 
 
-@settings(
-    # this test generates *two* model versions!
-    suppress_health_check=[HealthCheck.data_too_large, HealthCheck.too_slow],
-)
 @given(
     model_ver_proto=model_ver_proto(with_experiment_run_id=False),
     model_ver_from_run_proto=model_ver_proto(with_experiment_run_id=True),
@@ -180,10 +190,6 @@ def test_experiment_run_id_property(
         )
 
 
-@settings(
-    # this test generates *two* model versions!
-    suppress_health_check=[HealthCheck.data_too_large, HealthCheck.too_slow],
-)
 @given(
     model_ver_proto=model_ver_proto(with_experiment_run_id=False),
     model_ver_from_run_proto=model_ver_proto(with_experiment_run_id=True),


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

This composite strategy is huuuuuge occasionally resulting in

```
E   hypothesis.errors.FailedHealthCheck: Examples routinely exceeded the max allowable size. (20 examples overran while generating 4 valid ones). Generating examples this large will usually lead to bad results. You could try setting max_size parameters on your collections and turning max_leaves down on recursive() calls.
E   See https://hypothesis.readthedocs.io/en/latest/healthchecks.html for more information about this. If you want to disable just this health check, add HealthCheck.data_too_large to the suppress_health_check settings for this test.
```

This PR reduces the number of decisions Hypothesis has to make when drawing from `model_ver_proto` (https://hypothesis.readthedocs.io/en/latest/settings.html#hypothesis.HealthCheck.data_too_large).

## Risks and Area of Effect
- [ ] Is this a breaking change?

—

## Testing
- [x] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

```
% pytest unit_tests/registry/test_registered_model_version.py
==================================================== test session starts ====================================================
platform darwin -- Python 3.7.10, pytest-7.4.2, pluggy-1.2.0
rootdir: /Users/miliu/Documents/modeldb/client/verta/tests
configfile: pytest.ini
plugins: xdist-3.3.1, hypothesis-6.79.4
collected 3 items                                                                                                           

unit_tests/registry/test_registered_model_version.py ...                                                              [100%]

=============================================== 3 passed in 64.29s (0:01:04) ================================================
```

## Reverting
- [ ] Contains Migration - _Do Not Revert_

Revert this PR.