### PR TITLE
test: Set mock_client fields

### DIFF
--- a/client/verta/tests/unit_tests/conftest.py
+++ b/client/verta/tests/unit_tests/conftest.py
@@ -28,10 +28,12 @@ from verta.tracking.entities import ExperimentRun
 @pytest.fixture(scope="session")
 def mock_client(mock_conn) -> Client:
     """Return a mocked object of the Client class for use in tests"""
-    # with patch.dict(os.environ, {'VERTA_EMAIL': 'test_email@verta.ai', 'VERTA_DEV_KEY':'123test1232dev1232key123'}):
-    client = Client(_connect=False)
-    client._conn = mock_conn
-    return client
+    return Client(
+        host=f"{mock_conn.scheme}://{mock_conn.socket}",
+        email=mock_conn.credentials.email,
+        dev_key=mock_conn.credentials.dev_key,
+        _connect=False,
+    )
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

`unit_tests/client/test_get_kafka_topics.py` was failing during setup because the `mock_client` fixture required `host`/`os.environ["VERTA_HOST"]`.

## Risks and Area of Effect
- [ ] Is this a breaking change?

—

## Testing
- [x] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

```
% pytest unit_tests/client/test_get_kafka_topics.py
==================================================== test session starts ====================================================
platform darwin -- Python 3.7.10, pytest-7.4.2, pluggy-1.2.0
rootdir: /Users/miliu/Documents/modeldb/client/verta/tests
configfile: pytest.ini
plugins: xdist-3.3.1, hypothesis-6.79.4
collected 1 item                                                                                                            

unit_tests/client/test_get_kafka_topics.py .                                                                          [100%]

===================================================== 1 passed in 1.95s =====================================================
```

## Reverting
- [ ] Contains Migration - _Do Not Revert_