### PR TITLE
test: Don't require `pydantic` for client unit test suite

### DIFF
--- a/client/verta/tests/registry/test_standard_model.py
+++ b/client/verta/tests/registry/test_standard_model.py
@@ -7,15 +7,14 @@ import re
 import warnings
 
 import hypothesis
-import hypothesis.strategies as st
 import pytest
 
 from verta._internal_utils import _artifact_utils, model_validator
 from verta.environment import Python
 from verta.registry import _constants, verify_io
 
-from ..models import standard_models
-from ..strategies import json_strategy
+from tests.models import standard_models
+from tests.unit_tests.strategies import json_strategy
 
 
 verta_models = standard_models.verta_models()

--- a/client/verta/tests/strategies.py
+++ b/client/verta/tests/strategies.py
@@ -2,13 +2,11 @@
 
 from datetime import timedelta
 import os
-import re
 import string
 import warnings
 
 import hypothesis
 import hypothesis.strategies as st
-from hypothesis import given
 
 from tests.registry.pydantic_models import AnInnerClass, InputClass, OutputClass
 from verta._internal_utils.time_utils import duration_millis
@@ -23,15 +21,6 @@ def duration_millis_ignore_warn(delta):
 millis_timedelta_strategy = st.timedeltas(min_value=timedelta(milliseconds=1))
 
 millis_uint64_strategy = millis_timedelta_strategy.map(duration_millis_ignore_warn)
-
-
-# from https://hypothesis.readthedocs.io/en/latest/data.html#recursive-data
-json_strategy = st.recursive(
-    st.none() | st.booleans() | st.floats() | st.text(string.printable),
-    lambda children: st.lists(children)
-    | st.dictionaries(st.text(string.printable), children),
-    max_leaves=500,
-)
 
 
 @st.composite

--- a/client/verta/tests/unit_tests/pipeline/test_step_handler.py
+++ b/client/verta/tests/unit_tests/pipeline/test_step_handler.py
@@ -8,7 +8,7 @@ import hypothesis.strategies as st
 from verta._pipeline_orchestrator._step_handler import ModelObjectStepHandler
 
 from tests.models.standard_models import VertaModelDecorated
-from tests.strategies import json_strategy
+from tests.unit_tests.strategies import json_strategy
 
 
 class TestModelObjectStepHandler:

--- a/client/verta/tests/unit_tests/strategies.py
+++ b/client/verta/tests/unit_tests/strategies.py
@@ -1,17 +1,24 @@
 # -*- coding: utf-8 -*-
 
 """Hypothesis composite strategies for use in client unit tests."""
-from string import ascii_letters, ascii_lowercase, hexdigits
+from string import ascii_letters, ascii_lowercase, hexdigits, printable
 from typing import Any, Dict, Optional
 
 import hypothesis.strategies as st
 
-from tests.strategies import json_strategy
 from verta._internal_utils._utils import _VALID_FLAT_KEY_CHARS, python_to_val_proto
 from verta._protos.public.common import CommonService_pb2
 from verta._protos.public.modeldb.versioning import Code_pb2, Dataset_pb2
 from verta.endpoint import build, KafkaSettings
 from verta.endpoint.resources import NvidiaGPU, NvidiaGPUModel, Resources
+
+
+# from https://hypothesis.readthedocs.io/en/latest/data.html#recursive-data
+json_strategy = st.recursive(
+    st.none() | st.booleans() | st.floats() | st.text(printable),
+    lambda children: st.lists(children) | st.dictionaries(st.text(printable), children),
+    max_leaves=500,
+)
 
 
 @st.composite


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

Because of how we were importing our composite Hypothesis strategy, we were making our unit test suite dependent on `pydantic` which causes the suite to error out because it's not in [requirements-unit-tests.txt](https://github.com/VertaAI/modeldb/blob/main/client/verta/requirements-unit-tests.txt).

This PR rearranges things to remove that dependency.

## Risks and Area of Effect
- [ ] Is this a breaking change?

—

## Testing
- [x] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

### Before

```
% pytest unit_tests/deployment/test_build.py
==================================================== test session starts ====================================================
platform darwin -- Python 3.7.10, pytest-7.4.2, pluggy-1.2.0
rootdir: /Users/miliu/Documents/modeldb/client/verta/tests
configfile: pytest.ini
plugins: xdist-3.3.1, hypothesis-6.79.4
collected 0 items / 1 error                                                                                                 

========================================================== ERRORS ===========================================================
___________________________________ ERROR collecting unit_tests/deployment/test_build.py ____________________________________
ImportError while importing test module '/Users/miliu/Documents/modeldb/client/verta/tests/unit_tests/deployment/test_build.p
y'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/Users/miliu/.pyenv/versions/3.7.10/lib/python3.7/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
unit_tests/deployment/test_build.py:11: in <module>
    from tests.unit_tests.strategies import build_dict, mock_workspace
unit_tests/strategies.py:9: in <module>
    from tests.strategies import json_strategy
strategies.py:13: in <module>
    from tests.registry.pydantic_models import AnInnerClass, InputClass, OutputClass
registry/pydantic_models.py:3: in <module>
    from pydantic import BaseModel
E   ModuleNotFoundError: No module named 'pydantic'
================================================== short test summary info ==================================================
ERROR unit_tests/deployment/test_build.py
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
===================================================== 1 error in 0.19s ======================================================
```

### After

```
% pytest unit_tests/deployment/test_build.py
==================================================== test session starts ====================================================
platform darwin -- Python 3.7.10, pytest-7.4.2, pluggy-1.2.0
rootdir: /Users/miliu/Documents/modeldb/client/verta/tests
configfile: pytest.ini
plugins: xdist-3.3.1, hypothesis-6.79.4
collected 4 items                                                                                                           

unit_tests/deployment/test_build.py ....                                                                              [100%]

===================================================== 4 passed in 7.37s =====================================================
```

## Reverting
- [ ] Contains Migration - _Do Not Revert_

Revert this PR.