### PR TITLE
chore: Only run Java build on PRs with backend changes

### DIFF
--- a/.github/workflows/java-build-push-test.yaml
+++ b/.github/workflows/java-build-push-test.yaml
@@ -3,14 +3,19 @@ name: Java Build, Push, Test
 on:
   pull_request:
     types: [opened, reopened, synchronize]
+    paths:
+      - .run
+      - backend
+      - protos
+      - pom.xml
   push:
     branches:
       - main
-      - 'release/*'
+      - "release/*"
 
 permissions:
   id-token: write # This is required for requesting the JWT
-  contents: write  # Read is required for actions/checkout, write is required to comment on commits
+  contents: write # Read is required for actions/checkout, write is required to comment on commits
   pull-requests: write # This is needed for the coverage plugin to write comments to the PR
   packages: write
   statuses: write
@@ -69,9 +74,9 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
-          distribution: 'zulu'
-          java-version: '11'
-          cache: 'maven'
+          distribution: "zulu"
+          java-version: "11"
+          cache: "maven"
           server-id: github-verta # Value of the distributionManagement/repository/id field of the pom.xml
 
       - name: Check formatting
@@ -152,7 +157,7 @@ jobs:
         run: JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8 ./test_backend.sh
 
       - name: Upload Report
-        uses: 'actions/upload-artifact@v3'
+        uses: "actions/upload-artifact@v3"
         with:
           name: jacoco-reports
           path: |

--- a/.github/workflows/java-build-push-test.yaml
+++ b/.github/workflows/java-build-push-test.yaml
@@ -4,7 +4,6 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
     paths:
-      - .run
       - backend
       - protos
       - pom.xml

--- a/.github/workflows/java-build-push-test.yaml
+++ b/.github/workflows/java-build-push-test.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
     paths:
+      - .github/workflows/java-build-push-test.yaml
       - backend
       - protos
       - pom.xml

--- a/.github/workflows/java-build-push-test.yaml
+++ b/.github/workflows/java-build-push-test.yaml
@@ -7,6 +7,7 @@ on:
       - backend
       - protos
       - pom.xml
+      - build_and_publish_backend.sh
   push:
     branches:
       - main

--- a/.github/workflows/java-build-push-test.yaml
+++ b/.github/workflows/java-build-push-test.yaml
@@ -11,11 +11,11 @@ on:
   push:
     branches:
       - main
-      - "release/*"
+      - 'release/*'
 
 permissions:
   id-token: write # This is required for requesting the JWT
-  contents: write # Read is required for actions/checkout, write is required to comment on commits
+  contents: write  # Read is required for actions/checkout, write is required to comment on commits
   pull-requests: write # This is needed for the coverage plugin to write comments to the PR
   packages: write
   statuses: write
@@ -74,9 +74,9 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
-          distribution: "zulu"
-          java-version: "11"
-          cache: "maven"
+          distribution: 'zulu'
+          java-version: '11'
+          cache: 'maven'
           server-id: github-verta # Value of the distributionManagement/repository/id field of the pom.xml
 
       - name: Check formatting
@@ -157,7 +157,7 @@ jobs:
         run: JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8 ./test_backend.sh
 
       - name: Upload Report
-        uses: "actions/upload-artifact@v3"
+        uses: 'actions/upload-artifact@v3'
         with:
           name: jacoco-reports
           path: |


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

So I don't have to wait for this check on client PRs.

## Risks and Area of Effect
- [ ] Is this a breaking change?

I chose these paths by checking which files and directories at [the repo root](https://github.com/VertaAI/modeldb) were changed in the last few months. Hopefully I captured everything relevant to not break the check for Java PRs.

## Testing
- [ ] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

—

## Reverting
- [ ] Contains Migration - _Do Not Revert_

Revert this PR.