### PR TITLE
chore: Sort predecessors in _to_graph_spec()

### DIFF
--- a/client/verta/tests/unit_tests/pipeline/test_pipeline_step.py
+++ b/client/verta/tests/unit_tests/pipeline/test_pipeline_step.py
@@ -138,7 +138,7 @@ def test_to_graph_spec(
         )
     assert step._to_graph_spec() == {
         "name": "test_name",
-        "predecessors": [s.name for s in predecessors],
+        "predecessors": sorted(s.name for s in predecessors),
     }
 
 

--- a/client/verta/verta/pipeline/_pipeline_step.py
+++ b/client/verta/verta/pipeline/_pipeline_step.py
@@ -271,7 +271,7 @@ class PipelineStep:
         """
         return {
             "name": self.name,
-            "predecessors": [s.name for s in self.predecessors],
+            "predecessors": sorted(s.name for s in self.predecessors),
         }
 
     def _to_step_spec(self) -> Dict[str, Any]:


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

This has been breaking a unit test because of the arbitrary ordering.

## Risks and Area of Effect
- [ ] Is this a breaking change?

—

## Testing
- [x] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

```
% pytest unit_tests/pipeline/test_pipeline_step.py::test_to_graph_spec
==================================================== test session starts ====================================================
platform darwin -- Python 3.7.10, pytest-7.4.2, pluggy-1.2.0
rootdir: /Users/miliu/Documents/modeldb/client/verta/tests
configfile: pytest.ini
plugins: xdist-3.3.1, hypothesis-6.79.4
collected 1 item                                                                                                            

unit_tests/pipeline/test_pipeline_step.py .                                                                           [100%]

===================================================== 1 passed in 0.04s =====================================================
```

## Reverting
- [ ] Contains Migration - _Do Not Revert_

Revert this PR.