### PR TITLE
Revert "fix: be sure to close S3Objects after converting them to resources

### DIFF
--- a/backend/common/src/main/java/ai/verta/modeldb/common/artifactStore/storageservice/s3/S3Client.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/artifactStore/storageservice/s3/S3Client.java
@@ -9,6 +9,7 @@ import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.logging.log4j.LogManager;
@@ -34,7 +35,7 @@ public class S3Client {
   private volatile AtomicInteger referenceCounter;
   private volatile AWSCredentials awsCredentials;
 
-  public S3Client(S3Config s3Config) throws ModelDBException {
+  public S3Client(S3Config s3Config) throws IOException, ModelDBException {
     String cloudAccessKey = s3Config.getCloudAccessKey();
     String cloudSecretKey = s3Config.getCloudSecretKey();
     String minioEndpoint = s3Config.getMinioEndpoint();

--- a/backend/common/src/main/java/ai/verta/modeldb/common/artifactStore/storageservice/s3/S3Service.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/artifactStore/storageservice/s3/S3Service.java
@@ -40,9 +40,9 @@ public class S3Service implements ArtifactStoreService {
   private final String bucketName;
   private final ArtifactStoreConfig artifactStoreConfig;
 
-  public S3Service(ArtifactStoreConfig artifactStoreConfig) throws ModelDBException {
+  public S3Service(ArtifactStoreConfig artifactStoreConfig) throws ModelDBException, IOException {
     this.artifactStoreConfig = artifactStoreConfig;
-    this.s3Client = new S3Client(artifactStoreConfig.getS3());
+    s3Client = new S3Client(artifactStoreConfig.getS3());
     this.bucketName = artifactStoreConfig.getS3().getCloudBucketName();
   }
 
@@ -249,21 +249,19 @@ public class S3Service implements ArtifactStoreService {
       if (doesObjectExist(bucketName, artifactPath)) {
         LOGGER.trace("S3Service - loadFileAsResource - resource exists");
         LOGGER.trace("S3Service - loadFileAsResource returned");
-        try (S3Object resource = client.getClient().getObject(bucketName, artifactPath)) {
-          var responseHeaders = new HttpHeaders();
-          for (Map.Entry<String, Object> header :
-              resource.getObjectMetadata().getRawMetadata().entrySet()) {
-            responseHeaders.add(header.getKey(), String.valueOf(header.getValue()));
-          }
-          responseHeaders.add("FileName", fileName);
-          LOGGER.debug("getArtifact returned");
-          return ResponseEntity.ok()
-              .cacheControl(CacheControl.noCache())
-              .headers(responseHeaders)
-              .body(new InputStreamResource(resource.getObjectContent()));
-        } catch (IOException e) {
-          throw new UncheckedIOException(e);
+        S3Object resource = client.getClient().getObject(bucketName, artifactPath);
+
+        var responseHeaders = new HttpHeaders();
+        for (Map.Entry<String, Object> header :
+            resource.getObjectMetadata().getRawMetadata().entrySet()) {
+          responseHeaders.add(header.getKey(), String.valueOf(header.getValue()));
         }
+        responseHeaders.add("FileName", fileName);
+        LOGGER.debug("getArtifact returned");
+        return ResponseEntity.ok()
+            .cacheControl(CacheControl.noCache())
+            .headers(responseHeaders)
+            .body(new InputStreamResource(resource.getObjectContent()));
       } else {
         String errorMessage = "File not found " + artifactPath;
         LOGGER.info(errorMessage);


### PR DESCRIPTION
 (#4123)

This reverts commit 61ad9e0cce47ecd121773a0f550c7876c253c456.

<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

It turns out this closes the stream before it can be read, so breaks artifact download. 

I tested this with apache http connection pool logging enabled, and the http connection does get closed properly without this change (probably the input stream gets closed implicitly by spring after the client is done pulling the data). so, this needs to be reverted.

## Risks and Area of Effect
- [ ] Is this a breaking change?

## Testing
- [ ] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

## Reverting
- [ ] Contains Migration - _Do Not Revert_