### PR TITLE
feat: Enable setting org ID/name through env var

### DIFF
--- a/client/verta/tests/unit_tests/client/test_arguments.py
+++ b/client/verta/tests/unit_tests/client/test_arguments.py
@@ -8,31 +8,46 @@ import pytest
 import responses
 
 
-@hypothesis.given(org_id=st.uuids(), org_name=st.text(string.printable, min_size=1))
-def test_organization_id_and_name_error(make_mock_client, org_id, org_name):
+class TestOrganizationIdAndNameError:
     """Verify setting both org id and name raises an exception."""
-    org_id = str(org_id)
-    error = ValueError("cannot provide both `organization_id` and `organization_name`")
-    raises_expected_error = pytest.raises(type(error), match=str(error))
 
-    with raises_expected_error:
-        make_mock_client(organization_id=org_id, organization_name=org_name)
+    _error = ValueError("cannot provide both `organization_id` and `organization_name`")
+    raises_expected_error = pytest.raises(type(_error), match=str(_error))
 
-    with pytest.MonkeyPatch.context() as monkeypatch:
-        monkeypatch.setenv("VERTA_ORG_ID", org_id)
-        monkeypatch.setenv("VERTA_ORG_NAME", org_name)
-        with raises_expected_error:
-            make_mock_client()
+    @hypothesis.given(org_id=st.uuids(), org_name=st.text(string.printable, min_size=1))
+    def test_args(self, make_mock_client, org_id, org_name):
+        org_id = str(org_id)
 
-    with pytest.MonkeyPatch.context() as monkeypatch:
-        monkeypatch.setenv("VERTA_ORG_ID", org_id)
-        with raises_expected_error:
-            make_mock_client(organization_name=org_name)
+        with self.raises_expected_error:
+            make_mock_client(organization_id=org_id, organization_name=org_name)
 
-    with pytest.MonkeyPatch.context() as monkeypatch:
-        monkeypatch.setenv("VERTA_ORG_NAME", org_name)
-        with raises_expected_error:
-            make_mock_client(organization_id=org_id)
+    @hypothesis.given(org_id=st.uuids(), org_name=st.text(string.printable, min_size=1))
+    def test_env_vars(self, make_mock_client, org_id, org_name):
+        org_id = str(org_id)
+
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            monkeypatch.setenv("VERTA_ORG_ID", org_id)
+            monkeypatch.setenv("VERTA_ORG_NAME", org_name)
+            with self.raises_expected_error:
+                make_mock_client()
+
+    @hypothesis.given(org_id=st.uuids(), org_name=st.text(string.printable, min_size=1))
+    def test_id_env_var_name_arg(self, make_mock_client, org_id, org_name):
+        org_id = str(org_id)
+
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            monkeypatch.setenv("VERTA_ORG_ID", org_id)
+            with self.raises_expected_error:
+                make_mock_client(organization_name=org_name)
+
+    @hypothesis.given(org_id=st.uuids(), org_name=st.text(string.printable, min_size=1))
+    def test_name_env_var_id_arg(self, make_mock_client, org_id, org_name):
+        org_id = str(org_id)
+
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            monkeypatch.setenv("VERTA_ORG_NAME", org_name)
+            with self.raises_expected_error:
+                make_mock_client(organization_id=org_id)
 
 
 class TestOrganizationId:

--- a/client/verta/tests/unit_tests/client/test_arguments.py
+++ b/client/verta/tests/unit_tests/client/test_arguments.py
@@ -1,0 +1,34 @@
+"""Test :class:`verta.Client`'s argument handling."""
+
+import string
+
+import hypothesis
+import hypothesis.strategies as st
+import pytest
+
+
+@hypothesis.given(org_id=st.uuids(), org_name=st.text(string.printable, min_size=1))
+def test_organization_id_and_name_error(make_mock_client, org_id, org_name):
+    """Verify setting both org id and name raises an exception."""
+    org_id = str(org_id)
+    error = ValueError("cannot provide both `organization_id` and `organization_name`")
+    raises_expected_error = pytest.raises(type(error), match=str(error))
+
+    with raises_expected_error:
+        make_mock_client(organization_id=org_id, organization_name=org_name)
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setenv("VERTA_ORG_ID", org_id)
+        monkeypatch.setenv("VERTA_ORG_NAME", org_name)
+        with raises_expected_error:
+            make_mock_client()
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setenv("VERTA_ORG_ID", org_id)
+        with raises_expected_error:
+            make_mock_client(organization_name=org_name)
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setenv("VERTA_ORG_NAME", org_name)
+        with raises_expected_error:
+            make_mock_client(organization_id=org_id)

--- a/client/verta/tests/unit_tests/client/test_arguments.py
+++ b/client/verta/tests/unit_tests/client/test_arguments.py
@@ -51,6 +51,8 @@ class TestOrganizationIdAndNameError:
 
 
 class TestOrganizationId:
+    """Verify org ID can be set by argument and by environment variable."""
+
     @hypothesis.given(org_id=st.uuids())
     def test_arg(self, make_mock_client, org_id):
         org_id = str(org_id)
@@ -78,6 +80,13 @@ class TestOrganizationId:
 
 
 class TestOrganizationName:
+    """Verify org name can be set by argument and by environment variable.
+
+    When given an org name, :meth:`verta.Client.__init__` calls UAC to get that
+    org's ID; so these tests mock that call to return an expected org ID.
+
+    """
+
     @hypothesis.given(org_id=st.uuids(), org_name=st.text(string.printable, min_size=1))
     def test_arg(self, mock_conn, make_mock_client, org_id, org_name):
         org_id = str(org_id)

--- a/client/verta/tests/unit_tests/client/test_arguments.py
+++ b/client/verta/tests/unit_tests/client/test_arguments.py
@@ -32,3 +32,30 @@ def test_organization_id_and_name_error(make_mock_client, org_id, org_name):
         monkeypatch.setenv("VERTA_ORG_NAME", org_name)
         with raises_expected_error:
             make_mock_client(organization_id=org_id)
+
+
+class TestOrganizationId:
+    @hypothesis.given(org_id=st.uuids())
+    def test_arg(self, make_mock_client, org_id):
+        org_id = str(org_id)
+
+        client = make_mock_client(organization_id=org_id)
+        assert client._conn._credentials.organization_id == org_id
+
+    @hypothesis.given(org_id=st.uuids())
+    def test_env_var(self, make_mock_client, org_id):
+        org_id = str(org_id)
+
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            monkeypatch.setenv("VERTA_ORG_ID", org_id)
+            client = make_mock_client()
+        assert client._conn._credentials.organization_id == org_id
+
+    @hypothesis.given(org_ids=st.lists(st.uuids(), min_size=2, max_size=2))
+    def test_arg_overrides_env_var(self, make_mock_client, org_ids):
+        org_id1, org_id2 = map(str, org_ids)
+
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            monkeypatch.setenv("VERTA_ORG_ID", org_id1)
+            client = make_mock_client(organization_id=org_id2)
+        assert client._conn._credentials.organization_id == org_id2

--- a/client/verta/verta/client.py
+++ b/client/verta/verta/client.py
@@ -153,10 +153,6 @@ class Client(object):
         organization_name=None,
         _connect=True,
     ):
-        if organization_id is not None and organization_name is not None:
-            raise ValueError(
-                "cannot provide both `organization_id` and `organization_name`"
-            )
         self._load_config()
 
         host = self._get_with_fallback(host, env_var="VERTA_HOST", config_var="host")
@@ -177,6 +173,19 @@ class Client(object):
             env_var=JWTCredentials.JWT_TOKEN_SIG_ENV,
             config_var="jwt_token_sig",
         )
+
+        organization_id = self._get_with_fallback(
+            organization_id,
+            env_var="VERTA_ORG_ID",
+        )
+        organization_name = self._get_with_fallback(
+            organization_name,
+            env_var="VERTA_ORG_NAME",
+        )
+        if organization_id is not None and organization_name is not None:
+            raise ValueError(
+                "cannot provide both `organization_id` and `organization_name`"
+            )
 
         self.auth_credentials = credentials._build(
             email=email,


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

For ✨advanced✨ situations where a sys admin needs to set their organization, but can't modify code to add `Client()` arguments.

## Risks and Area of Effect
- [ ] Is this a breaking change?

There's the slimmest chance I could be introducing a bug because scientists still can't completely explain how `Client()` handles arguments vs environment variables, but I'm adding ample unit test coverage to dispel doubt. Also `organization_id` and `organization_name` are marked as _(alpha)_ in the docstring.

## Testing
- [x] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

See PR checks.

## Reverting
- [ ] Contains Migration - _Do Not Revert_

Revert this PR.