### PR TITLE
fix: Sort package distributions for unit test assertion

### DIFF
--- a/client/verta/tests/unit_tests/registry/test_model_dependencies.py
+++ b/client/verta/tests/unit_tests/registry/test_model_dependencies.py
@@ -159,7 +159,7 @@ def test_package_names(dependency_testing_model) -> None:
     skipped.
     """
     expected_packages = {
-        "google": ["protobuf", "googleapis-common-protos"],
+        "google": ["googleapis-common-protos", "protobuf"],
         "yaml": ["PyYAML"],
     }
     extracted_packages: Dict[str, List[str]] = md.package_names({"google", "yaml"})

--- a/client/verta/verta/_internal_utils/model_dependencies.py
+++ b/client/verta/verta/_internal_utils/model_dependencies.py
@@ -86,5 +86,5 @@ def package_names(module_names: Set[str]) -> Dict[str, List[str]]:
     locally installed package_distributions.
     """
     pkg_dist = packages_distributions()
-    return {m: pkg_dist.get(m) for m in module_names if pkg_dist.get(m)}
+    return {m: sorted(pkg_dist.get(m)) for m in module_names if pkg_dist.get(m)}
     # TODO: handle cases where 3rd-party module is not found in pkg_dist


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

<img width="806" alt="Screenshot 2023-11-29 at 10 27 04 AM" src="https://github.com/VertaAI/modeldb/assets/96442646/83cc3f6c-0513-4135-96de-105591365176">

## Risks and Area of Effect
- [ ] Is this a breaking change?

—

## Testing
- [x] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

See PR checks for passing tests.

## Reverting
- [ ] Contains Migration - _Do Not Revert_

Revert this PR.