### PR TITLE
refactor: remove internal future rest server response method in FutureRest class

### DIFF
--- a/backend/common/src/main/java/ai/verta/modeldb/common/futures/FutureRest.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/futures/FutureRest.java
@@ -4,28 +4,6 @@ import ai.verta.modeldb.common.CommonUtils;
 import java.util.concurrent.CompletableFuture;
 
 public class FutureRest {
-  private FutureRest() {}
-
-  // Injects the result of the future into the grpc StreamObserver as the return of the server
-  public static <T> CompletableFuture<T> serverResponse(
-      InternalFuture<T> future, FutureExecutor ex) {
-    CompletableFuture<T> promise = new CompletableFuture<>();
-    future.whenComplete(
-        (v, t) -> {
-          if (t == null) {
-            try {
-              promise.complete(v);
-            } catch (Throwable e) {
-              CommonUtils.observeError(promise, t);
-            }
-          } else {
-            CommonUtils.observeError(promise, t);
-          }
-        },
-        ex);
-    return promise;
-  }
-
   public static <T> CompletableFuture<T> serverResponse(Future<T> future) {
     CompletableFuture<T> promise = new CompletableFuture<>();
     future.whenComplete(


### PR DESCRIPTION
The recent update involves cleaning up FutureRest class by removing an unnecessary server response method. This removal simplifies the handling of server responses, reducing the associated complexity in the server and increasing code maintainability. The function was redundant since there was another method with similar functionalities.

<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

## Risks and Area of Effect
- [ ] Is this a breaking change?

## Testing
- [ ] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

## Reverting
- [ ] Contains Migration - _Do Not Revert_