### PR TITLE
chore: update the OTel tracing configuration to use the OTLP exporter

### DIFF
--- a/backend/common/pom.xml
+++ b/backend/common/pom.xml
@@ -80,7 +80,7 @@
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-exporter-jaeger</artifactId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry.semconv</groupId>

--- a/backend/common/src/main/java/ai/verta/modeldb/common/configuration/OpenTelemetryConfig.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/configuration/OpenTelemetryConfig.java
@@ -13,7 +13,7 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.contrib.metrics.prometheus.clientbridge.PrometheusCollector;
-import io.opentelemetry.exporter.jaeger.JaegerGrpcSpanExporter;
+import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
 import io.opentelemetry.extension.trace.propagation.JaegerPropagator;
 import io.opentelemetry.instrumentation.grpc.v1_6.GrpcTelemetry;
 import io.opentelemetry.instrumentation.resources.ContainerResource;
@@ -63,8 +63,8 @@ public class OpenTelemetryConfig {
       tracerProvider = SdkTracerProvider.builder().build();
     } else {
       SpanExporter spanExporter =
-          JaegerGrpcSpanExporter.builder()
-              .setEndpoint(System.getenv("OTEL_EXPORTER_JAEGER_ENDPOINT"))
+          OtlpHttpSpanExporter.builder()
+              .setEndpoint(System.getenv("OTEL_EXPORTER_OTLP_ENDPOINT"))
               .build();
       tracerProvider =
           SdkTracerProvider.builder()
@@ -156,9 +156,9 @@ public class OpenTelemetryConfig {
     public void onStart(Context parentContext, ReadWriteSpan span) {
       String dbName = span.getAttribute(SemanticAttributes.DB_NAME);
       if (dbName != null) {
-        String netPeerName = span.getAttribute(SemanticAttributes.NET_PEER_NAME);
-        if (netPeerName != null) {
-          span.setAttribute(SemanticAttributes.PEER_SERVICE, dbName + "[" + netPeerName + "]");
+        String serverAddress = span.getAttribute(SemanticAttributes.SERVER_ADDRESS);
+        if (serverAddress != null) {
+          span.setAttribute(SemanticAttributes.PEER_SERVICE, dbName + "[" + serverAddress + "]");
         }
       }
     }


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

Now that jaeger has been updated, we can stop using the deprecated (and soon to be deleted) jaeger span exporter.

## Risks and Area of Effect
- [ ] Is this a breaking change?

## Testing
- [ ] Unit test
- [x] Deployed to dev env
- [ ] Other (explain) 

## Reverting
- [ ] Contains Migration - _Do Not Revert_