### PR TITLE
feat: add new future empty convience method in Future class

### DIFF
--- a/backend/common/src/main/java/ai/verta/modeldb/common/futures/Future.java
+++ b/backend/common/src/main/java/ai/verta/modeldb/common/futures/Future.java
@@ -1,5 +1,6 @@
 package ai.verta.modeldb.common.futures;
 
+import ai.verta.common.Empty;
 import ai.verta.modeldb.common.exceptions.ModelDBException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -487,5 +488,9 @@ public class Future<T> {
 
   public static void disableCallSiteStackCapture() {
     captureStacksAtCreation = false;
+  }
+
+  public static Future<Empty> empty() {
+    return Future.of(Empty.getDefaultInstance());
   }
 }


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context
Small convenience method so that we can do this when composing futures:
```java
.thenSupply(Future::empty)
```


## Risks and Area of Effect
- [ ] Is this a breaking change?

## Testing
- [ ] Unit test
- [ ] Deployed to dev env
- [ ] Other (explain) 

## Reverting
- [ ] Contains Migration - _Do Not Revert_